### PR TITLE
FIX: Remove `null: false` from dropped column

### DIFF
--- a/db/migrate/20230322142028_make_dropped_value_column_nullable.rb
+++ b/db/migrate/20230322142028_make_dropped_value_column_nullable.rb
@@ -1,16 +1,7 @@
 # frozen_string_literal: true
 class MakeDroppedValueColumnNullable < ActiveRecord::Migration[7.0]
   def up
-    column_exists = DB.exec(<<~SQL) == 1
-      SELECT 1
-      FROM INFORMATION_SCHEMA.COLUMNS
-      WHERE
-        table_schema = 'public' AND
-        table_name = 'completion_prompts' AND
-        column_name = 'value'
-    SQL
-
-    if column_exists
+    if column_exists?(:completion_prompts, :value)
       Migration::SafeMigrate.disable!
       change_column_null :completion_prompts, :value, true
       Migration::SafeMigrate.enable!

--- a/db/migrate/20230322142028_make_dropped_value_column_nullable.rb
+++ b/db/migrate/20230322142028_make_dropped_value_column_nullable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+class MakeDroppedValueColumnNullable < ActiveRecord::Migration[7.0]
+  def up
+    column_exists = DB.exec(<<~SQL) == 1
+      SELECT 1
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE
+        table_schema = 'public' AND
+        table_name = 'completion_prompts' AND
+        column_name = 'value'
+    SQL
+
+    if column_exists
+      Migration::SafeMigrate.disable!
+      change_column_null :completion_prompts, :value, true
+      Migration::SafeMigrate.enable!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
It's causing an issue when attempting to seed data in fresh installs. The column was dropped in a post-migration.