### PR TITLE
FEATURE: attempt to include related topics above suggested

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-above-suggested/related-topics.js
+++ b/assets/javascripts/discourse/connectors/topic-above-suggested/related-topics.js
@@ -1,0 +1,15 @@
+export default {
+  shouldRender(args) {
+    return (args.model.related_topics?.length || 0) > 0;
+  },
+  setupComponent(args, component) {
+    if (component.model.related_topics) {
+      component.set(
+        "relatedTopics",
+        component.model.related_topics.map((topic) =>
+          this.store.createRecord("topic", topic)
+        )
+      );
+    }
+  },
+};

--- a/assets/javascripts/discourse/templates/connectors/topic-above-suggested/related-topics.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-suggested/related-topics.hbs
@@ -2,6 +2,5 @@
   <h3 id="related-topics-title" class="related-topics-title">
     {{i18n "discourse_ai.related_topics.title"}}
   </h3>
-
   <BasicTopicList @topics={{this.relatedTopics}} />
 </div>

--- a/assets/javascripts/discourse/templates/connectors/topic-above-suggested/related-topics.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-suggested/related-topics.hbs
@@ -1,0 +1,7 @@
+<div>
+  <h3 id="related-topics-title" class="related-topics-title">
+    {{i18n "discourse_ai.related_topics.title"}}
+  </h3>
+
+  <BasicTopicList @topics={{this.relatedTopics}} />
+</div>

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -25,3 +25,7 @@
     margin-bottom: 20px;
   }
 }
+
+.topic-above-suggested-outlet.related-topics {
+  margin: 4.5em 0 1em;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,6 +1,8 @@
 en:
   js:
     discourse_ai:
+      related_topics:
+        title: "Related Topics"
       ai_helper:
         title: "Suggest changes using AI"
         description: "Choose one of the options below, and the AI will suggest you a new version of the text."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -43,7 +43,7 @@ en:
     ai_embeddings_models: "Discourse will generate embeddings for each of the models enabled here"
     ai_embeddings_semantic_suggested_model: "Model to use for suggested topics."
     ai_embeddings_generate_for_pms: "Generate embeddings for personal messages."
-    ai_embeddings_semantic_suggested_topics_anons_enabled: "Use Semantic Search for suggested topics for anonymous users."
+    ai_embeddings_semantic_suggested_topics_enabled: "Use Semantic Search for related topics."
     ai_embeddings_pg_connection_string: "PostgreSQL connection string for the embeddings module. Needs pgvector extension enabled and a series of tables created. See docs for more info."
 
   reviewables:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -128,5 +128,5 @@ plugins:
       - multi-qa-mpnet-base-dot-v1
       - paraphrase-multilingual-mpnet-base-v2
   ai_embeddings_generate_for_pms: false
-  ai_embeddings_semantic_suggested_topics_anons_enabled: false
+  ai_embeddings_semantic_suggested_topics_enabled: false
   ai_embeddings_pg_connection_string: ""

--- a/lib/modules/embeddings/entry_point.rb
+++ b/lib/modules/embeddings/entry_point.rb
@@ -12,7 +12,8 @@ module DiscourseAi
 
       def inject_into(plugin)
         plugin.add_to_class(:topic_view, :related_topics) do
-          if topic.private_message? || !SiteSetting.ai_embeddings_semantic_suggested_topics_enabled
+          if !@guardian&.user || topic.private_message? ||
+               !SiteSetting.ai_embeddings_semantic_suggested_topics_enabled
             return nil
           end
 

--- a/lib/modules/embeddings/entry_point.rb
+++ b/lib/modules/embeddings/entry_point.rb
@@ -11,6 +11,16 @@ module DiscourseAi
       end
 
       def inject_into(plugin)
+        plugin.add_to_serializer(:topic_view, :related_topics) do
+          if !object.topic.private_message? && scope.authenticated?
+            TopicList.new(
+              :suggested,
+              nil,
+              DiscourseAi::Embeddings::SemanticSuggested.candidates_for(object.topic),
+            ).topics
+          end
+        end
+
         callback =
           Proc.new do |topic|
             if SiteSetting.ai_embeddings_enabled

--- a/lib/modules/embeddings/entry_point.rb
+++ b/lib/modules/embeddings/entry_point.rb
@@ -12,7 +12,9 @@ module DiscourseAi
 
       def inject_into(plugin)
         plugin.add_to_class(:topic_view, :related_topics) do
-          return nil if topic.private_message?
+          if topic.private_message? || !SiteSetting.ai_embeddings_semantic_suggested_topics_enabled
+            return nil
+          end
 
           @related_topics ||=
             TopicList.new(

--- a/lib/modules/embeddings/semantic_suggested.rb
+++ b/lib/modules/embeddings/semantic_suggested.rb
@@ -8,6 +8,10 @@ module DiscourseAi
         return if topic_query.user
         return if topic.private_message?
 
+        { result: candidates_for(topic), params: {} }
+      end
+
+      def self.candidates_for(topic)
         cache_for =
           case topic.created_at
           when 6.hour.ago..Time.now
@@ -28,19 +32,16 @@ module DiscourseAi
         rescue StandardError => e
           Rails.logger.error("SemanticSuggested: #{e}")
           Jobs.enqueue(:generate_embeddings, topic_id: topic.id)
-          return { result: [], params: {} }
+          return ::Topic.none
         end
 
         # array_position forces the order of the topics to be preserved
-        candidates =
-          ::Topic
-            .visible
-            .listable_topics
-            .secured
-            .where(id: candidate_ids)
-            .order("array_position(ARRAY#{candidate_ids}, id)")
-
-        { result: candidates, params: {} }
+        ::Topic
+          .visible
+          .listable_topics
+          .secured
+          .where(id: candidate_ids)
+          .order("array_position(ARRAY#{candidate_ids}, id)")
       end
 
       def self.search_suggestions(topic)

--- a/lib/modules/embeddings/semantic_suggested.rb
+++ b/lib/modules/embeddings/semantic_suggested.rb
@@ -4,7 +4,7 @@ module DiscourseAi
   module Embeddings
     class SemanticSuggested
       def self.build_suggested_topics(topic, pm_params, topic_query)
-        return unless SiteSetting.ai_embeddings_semantic_suggested_topics_anons_enabled
+        return unless SiteSetting.ai_embeddings_semantic_suggested_topics_enabled
         return if topic_query.user
         return if topic.private_message?
 

--- a/spec/lib/modules/embeddings/semantic_suggested_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_suggested_spec.rb
@@ -12,7 +12,7 @@ describe DiscourseAi::Embeddings::SemanticSuggested do
   fab!(:secured_category) { Fabricate(:category, read_restricted: true) }
   fab!(:secured_category_topic) { Fabricate(:topic, category: secured_category) }
 
-  before { SiteSetting.ai_embeddings_semantic_suggested_topics_anons_enabled = true }
+  before { SiteSetting.ai_embeddings_semantic_suggested_topics_enabled = true }
 
   describe "#build_suggested_topics" do
     before do

--- a/spec/requests/topic_spec.rb
+++ b/spec/requests/topic_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ::TopicsController do
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:topic1) { Fabricate(:topic) }
+  fab!(:topic2) { Fabricate(:topic) }
+  fab!(:user) { Fabricate(:admin) }
+
+  before do
+    Discourse.cache.clear
+    SiteSetting.ai_embeddings_semantic_suggested_topics_enabled = true
+  end
+
+  after { Discourse.cache.clear }
+
+  context "when a user is logged on" do
+    it "includes related topics in payload when configured" do
+      DiscourseAi::Embeddings::SemanticSuggested.stubs(:search_suggestions).returns([topic2.id])
+      sign_in(user)
+
+      get("#{topic.relative_url}.json")
+      json = response.parsed_body
+
+      expect(json["suggested_topics"].length).to eq(0)
+      expect(json["related_topics"].length).to be > 0
+    end
+  end
+end


### PR DESCRIPTION
This is an attempt at including related above suggested for logged on users

TODO

 - tests
 - ensure this is zero work if feature is not enabled
 - perhaps get rid of ai_embeddings_semantic_suggested_topics_anon_enabled and use a diff setting for both
 - have this disable random suggested, so we don't double up when logged in
