### PR TITLE
FIX: chat-composer is now using glimmer

### DIFF
--- a/assets/javascripts/initializers/chat-summary.js
+++ b/assets/javascripts/initializers/chat-summary.js
@@ -19,7 +19,7 @@ function initializeChatChannelSummary(api) {
       @action
       showChannelSummary() {
         showModal("ai-summary").setProperties({
-          targetId: this.chatChannel.id,
+          targetId: this.args.channel.id,
           targetType: "chat_channel",
           allowTimeframe: true,
         });


### PR DESCRIPTION
As a result of this change the channel is now accessible through `this.args.channel` and not `this.chatChannel`.

Longer term we want a better solution here, but this should fix the issue for now.