### PR TITLE
FIX: results will be nil for invalid queries

### DIFF
--- a/lib/modules/ai_bot/commands/search_command.rb
+++ b/lib/modules/ai_bot/commands/search_command.rb
@@ -95,10 +95,10 @@ module DiscourseAi::AiBot::Commands
       results =
         Search.execute(search_string.to_s, search_type: :full_page, guardian: Guardian.new())
 
-      posts = results.posts
+      posts = results&.posts || []
       posts = posts[0..limit - 1] if limit
 
-      @last_num_results = results.posts.length
+      @last_num_results = posts.length
 
       if posts.blank?
         "No results found"

--- a/spec/lib/modules/ai_bot/commands/search_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/search_command_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe DiscourseAi::AiBot::Commands::SearchCommand do
   after { SearchIndexer.disable }
 
   describe "#process" do
+    it "can handle no results" do
+      post1 = Fabricate(:post)
+      search = described_class.new(bot_user, post1)
+
+      results = search.process("order:fake")
+      expect(results).to eq("No results found")
+    end
+
     it "can handle limits" do
       post1 = Fabricate(:post)
       _post2 = Fabricate(:post, user: post1.user)


### PR DESCRIPTION
Previous to this change invalid searches would break the command.
