### PR TITLE
FIX: ensure we only attempt embedding once every 15 minutes

### DIFF
--- a/spec/lib/modules/embeddings/semantic_related_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_related_spec.rb
@@ -16,33 +16,65 @@ describe DiscourseAi::Embeddings::SemanticRelated do
   before { SiteSetting.ai_embeddings_semantic_related_topics_enabled = true }
 
   describe "#candidates_for" do
-    before do
-      Discourse.cache.clear
-      DiscourseAi::Embeddings::Topic
-        .any_instance
-        .expects(:symmetric_semantic_search)
-        .returns(Topic.unscoped.order(id: :desc).limit(100).pluck(:id))
+    context "when embeddings do not exist" do
+      let (:topic) do
+        topic = Fabricate(:topic)
+        described_class.clear_cache_for(target)
+        topic
+      end
+
+      it "queues job only once per 15 minutes" do
+        # sadly we need to mock a DB connection to return nothing
+        DiscourseAi::Embeddings::Topic
+          .any_instance
+          .expects(:query_symmetric_embeddings)
+          .returns([])
+          .twice
+
+        results = nil
+
+        expect_enqueued_with(job: :generate_embeddings, args: { topic_id: topic.id }) do
+          results = described_class.candidates_for(topic).to_a
+        end
+
+        expect(results).to eq([])
+
+        expect_not_enqueued_with(job: :generate_embeddings, args: { topic_id: topic.id }) do
+          results = described_class.candidates_for(topic).to_a
+        end
+
+        expect(results).to eq([])
+      end
     end
+    context "when embeddings exist" do
+      before do
+        Discourse.cache.clear
+        DiscourseAi::Embeddings::Topic
+          .any_instance
+          .expects(:symmetric_semantic_search)
+          .returns(Topic.unscoped.order(id: :desc).limit(100).pluck(:id))
+      end
 
-    after { Discourse.cache.clear }
+      after { Discourse.cache.clear }
 
-    it "returns the related topics without non public topics" do
-      results = described_class.candidates_for(target).to_a
-      expect(results).to include(normal_topic_1)
-      expect(results).to include(normal_topic_2)
-      expect(results).to include(normal_topic_3)
-      expect(results).to include(closed_topic)
-      expect(results).to_not include(target)
-      expect(results).to_not include(unlisted_topic)
-      expect(results).to_not include(private_topic)
-      expect(results).to_not include(secured_category_topic)
-    end
-
-    context "when ai_embeddings_semantic_related_include_closed_topics is false" do
-      before { SiteSetting.ai_embeddings_semantic_related_include_closed_topics = false }
-      it "do not return closed topics" do
+      it "returns the related topics without non public topics" do
         results = described_class.candidates_for(target).to_a
-        expect(results).to_not include(closed_topic)
+        expect(results).to include(normal_topic_1)
+        expect(results).to include(normal_topic_2)
+        expect(results).to include(normal_topic_3)
+        expect(results).to include(closed_topic)
+        expect(results).to_not include(target)
+        expect(results).to_not include(unlisted_topic)
+        expect(results).to_not include(private_topic)
+        expect(results).to_not include(secured_category_topic)
+      end
+
+      context "when ai_embeddings_semantic_related_include_closed_topics is false" do
+        before { SiteSetting.ai_embeddings_semantic_related_include_closed_topics = false }
+        it "do not return closed topics" do
+          results = described_class.candidates_for(target).to_a
+          expect(results).to_not include(closed_topic)
+        end
       end
     end
   end


### PR DESCRIPTION
This also heavily reduced log noise and ensures our exception handling is
more surgical.
