### PR TITLE
FIX: guide GPT 3.5 better

### DIFF
--- a/lib/modules/ai_bot/anthropic_bot.rb
+++ b/lib/modules/ai_bot/anthropic_bot.rb
@@ -15,6 +15,26 @@ module DiscourseAi
         7500 # https://console.anthropic.com/docs/prompt-design#what-is-a-prompt
       end
 
+      def get_delta(partial, context)
+        context[:pos] ||= 0
+
+        full = partial[:completion]
+        delta = full[context[:pos]..-1]
+
+        context[:pos] = full.length
+
+        if !context[:processed]
+          delta = ""
+          index = full.index("Assistant: ")
+          if index
+            delta = full[index + 11..-1]
+            context[:processed] = true
+          end
+        end
+
+        delta
+      end
+
       private
 
       def build_message(poster_username, content, system: false)
@@ -25,10 +45,6 @@ module DiscourseAi
 
       def model_for
         "claude-v1"
-      end
-
-      def update_with_delta(_, partial)
-        partial[:completion]
       end
 
       def get_updated_title(prompt)

--- a/lib/modules/ai_bot/commands/command.rb
+++ b/lib/modules/ai_bot/commands/command.rb
@@ -29,6 +29,10 @@ module DiscourseAi
           @args = args
         end
 
+        def bot
+          @bot ||= DiscourseAi::AiBot::Bot.as(bot_user)
+        end
+
         def standalone?
           false
         end
@@ -80,6 +84,9 @@ module DiscourseAi
           HTML
 
           raw << custom_raw if custom_raw.present?
+
+          replacement = "!#{self.class.name} #{args}"
+          raw = post.raw.sub(replacement, raw) if post.raw.include?(replacement)
 
           if chain_next_response
             post.raw = raw

--- a/lib/modules/ai_bot/commands/search_command.rb
+++ b/lib/modules/ai_bot/commands/search_command.rb
@@ -95,8 +95,12 @@ module DiscourseAi::AiBot::Commands
       results =
         Search.execute(search_string.to_s, search_type: :full_page, guardian: Guardian.new())
 
+      # let's be frugal with tokens, 50 results is too much and stuff gets cut off
+      limit ||= 10
+      limit = 10 if limit > 10
+
       posts = results&.posts || []
-      posts = posts[0..limit - 1] if limit
+      posts = posts[0..limit - 1]
 
       @last_num_results = posts.length
 

--- a/lib/modules/ai_bot/commands/search_command.rb
+++ b/lib/modules/ai_bot/commands/search_command.rb
@@ -93,7 +93,11 @@ module DiscourseAi::AiBot::Commands
 
       @last_query = search_string
       results =
-        Search.execute(search_string.to_s, search_type: :full_page, guardian: Guardian.new())
+        Search.execute(
+          search_string.to_s + " status:public",
+          search_type: :full_page,
+          guardian: Guardian.new(),
+        )
 
       # let's be frugal with tokens, 50 results is too much and stuff gets cut off
       limit ||= 10

--- a/lib/modules/ai_bot/commands/summarize_command.rb
+++ b/lib/modules/ai_bot/commands/summarize_command.rb
@@ -84,10 +84,6 @@ module DiscourseAi::AiBot::Commands
       false
     end
 
-    def bot
-      @bot ||= DiscourseAi::AiBot::Bot.as(bot_user)
-    end
-
     def summarize(data, guidance, topic)
       text = +""
       data.each do |id, post_number, raw, username|

--- a/lib/modules/ai_bot/open_ai_bot.rb
+++ b/lib/modules/ai_bot/open_ai_bot.rb
@@ -75,8 +75,8 @@ module DiscourseAi
         "gpt-3.5-turbo"
       end
 
-      def update_with_delta(current_delta, partial)
-        current_delta + partial.dig(:choices, 0, :delta, :content).to_s
+      def get_delta(partial, _context)
+        partial.dig(:choices, 0, :delta, :content).to_s
       end
 
       def get_updated_title(prompt)

--- a/spec/lib/modules/ai_bot/anthropic_bot_spec.rb
+++ b/spec/lib/modules/ai_bot/anthropic_bot_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::AiBot::AnthropicBot do
+  describe "#update_with_delta" do
+    def bot_user
+      User.find(DiscourseAi::AiBot::EntryPoint::GPT4_ID)
+    end
+
+    subject { described_class.new(bot_user) }
+
+    describe "get_delta" do
+      it "can properly remove Assistant prefix" do
+        context = {}
+        reply = +""
+
+        reply << subject.get_delta({ completion: "\n\nAssist" }, context)
+        expect(reply).to eq("")
+
+        reply << subject.get_delta({ completion: "\n\nAssistant: test" }, context)
+        expect(reply).to eq("test")
+
+        reply << subject.get_delta({ completion: "\n\nAssistant: test\nworld" }, context)
+        expect(reply).to eq("test\nworld")
+      end
+    end
+  end
+end

--- a/spec/lib/modules/ai_bot/bot_spec.rb
+++ b/spec/lib/modules/ai_bot/bot_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe DiscourseAi::AiBot::Bot do
     it "can respond to !search" do
       bot.system_prompt_style!(:simple)
 
-      expected_response = "!search test search"
+      expected_response = "ok, searching...\n!search test search"
 
       prompt = bot.bot_prompt_with_topic_context(second_post)
 
@@ -65,12 +65,14 @@ RSpec.describe DiscourseAi::AiBot::Bot do
       bot.reply_to(second_post)
 
       last = second_post.topic.posts.order("id desc").first
-      expect(last.post_custom_prompt.custom_prompt.to_s).to include("We are done now")
 
       expect(last.raw).to include("<details>")
       expect(last.raw).to include("<summary>Search</summary>")
       expect(last.raw).not_to include("translation missing")
+      expect(last.raw).to include("ok, searching...")
       expect(last.raw).to include("We are done now")
+
+      expect(last.post_custom_prompt.custom_prompt.to_s).to include("We are done now")
     end
   end
 

--- a/spec/lib/modules/ai_bot/commands/search_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/search_command_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DiscourseAi::AiBot::Commands::SearchCommand do
       post1 = Fabricate(:post)
       search = described_class.new(bot_user, post1)
 
-      results = search.process("order:fake")
+      results = search.process("order:fake ABDDCDCEDGDG")
       expect(results).to eq("No results found")
     end
 
@@ -29,6 +29,10 @@ RSpec.describe DiscourseAi::AiBot::Commands::SearchCommand do
 
       # title + 2 rows
       expect(results.split("\n").length).to eq(3)
+
+      # just searching for everything
+      results = search.process("order:latest_topic")
+      expect(results.split("\n").length).to be > 1
     end
   end
 end

--- a/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
+++ b/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
@@ -63,7 +63,8 @@ RSpec.describe Jobs::CreateAiReply do
     end
 
     context "when chatting with Claude from Anthropic" do
-      let(:deltas) { expected_response.split(" ").map { |w| "#{w} " } }
+      let(:claude_response) { "Assistant: #{expected_response}" }
+      let(:deltas) { claude_response.split(" ").map { |w| "#{w} " } }
 
       before do
         bot_user = User.find(DiscourseAi::AiBot::EntryPoint::CLAUDE_V1_ID)

--- a/spec/lib/modules/ai_bot/open_ai_bot_spec.rb
+++ b/spec/lib/modules/ai_bot/open_ai_bot_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DiscourseAi::AiBot::OpenAiBot do
       it "includes it in the prompt" do
         prompt_messages = subject.bot_prompt_with_topic_context(post_1)
 
-        post_1_message = prompt_messages[1]
+        post_1_message = prompt_messages[-1]
 
         expect(post_1_message[:role]).to eq("user")
         expect(post_1_message[:content]).to eq("#{post_1.user.username}: #{post_body(1)}")
@@ -33,11 +33,11 @@ RSpec.describe DiscourseAi::AiBot::OpenAiBot do
       it "trims the prompt" do
         prompt_messages = subject.bot_prompt_with_topic_context(post_1)
 
-        expect(prompt_messages[0][:role]).to eq("system")
-        expect(prompt_messages[1][:role]).to eq("user")
+        expect(prompt_messages[-2][:role]).to eq("assistant")
+        expect(prompt_messages[-1][:role]).to eq("user")
         # trimming is tricky... it needs to account for system message as
         # well... just make sure we trim for now
-        expect(prompt_messages[1][:content].length).to be < post_1.raw.length
+        expect(prompt_messages[-1][:content].length).to be < post_1.raw.length
       end
     end
 
@@ -51,14 +51,15 @@ RSpec.describe DiscourseAi::AiBot::OpenAiBot do
       it "includes them in the prompt respecting the post number order" do
         prompt_messages = subject.bot_prompt_with_topic_context(post_3)
 
-        expect(prompt_messages[1][:role]).to eq("user")
-        expect(prompt_messages[1][:content]).to eq("#{post_1.username}: #{post_body(1)}")
+        # negative cause we may have grounding prompts
+        expect(prompt_messages[-3][:role]).to eq("user")
+        expect(prompt_messages[-3][:content]).to eq("#{post_1.username}: #{post_body(1)}")
 
-        expect(prompt_messages[2][:role]).to eq("assistant")
-        expect(prompt_messages[2][:content]).to eq(post_body(2))
+        expect(prompt_messages[-2][:role]).to eq("assistant")
+        expect(prompt_messages[-2][:content]).to eq(post_body(2))
 
-        expect(prompt_messages[3][:role]).to eq("user")
-        expect(prompt_messages[3][:content]).to eq("#{post_3.username}: #{post_body(3)}")
+        expect(prompt_messages[-1][:role]).to eq("user")
+        expect(prompt_messages[-1][:content]).to eq("#{post_3.username}: #{post_body(3)}")
       end
     end
   end


### PR DESCRIPTION
This limits search results to 10 cause we were blowing the whole token
budget on search results, additionally it includes a quick exchange at
the start of a session to try and guide GPT 3.5 to follow instructions

Sadly GPT 3.5 drifts off very quickly but this does improve stuff a bit.

It also attempts to correct some issues with anthropic, though it still is
surprisingly hard to ground
