### PR TITLE
FIX: missing localization

### DIFF
--- a/assets/javascripts/initializers/ai-bot-replies.js
+++ b/assets/javascripts/initializers/ai-bot-replies.js
@@ -26,7 +26,7 @@ function attachHeaderIcon(api) {
 
     api.decorateWidget("header-icons:before", (helper) => {
       return helper.attach("header-dropdown", {
-        title: "blog.start_gpt_chat",
+        title: "discourse_ai.ai_bot.shortcut_title",
         icon: "robot",
         action: "clickStartAiBotChat",
         active: false,

--- a/lib/modules/ai_bot/commands/search_command.rb
+++ b/lib/modules/ai_bot/commands/search_command.rb
@@ -13,8 +13,9 @@ module DiscourseAi::AiBot::Commands
 
       def extra_context
         <<~TEXT
-          Discourse search supports, the following special commands:
+          Discourse search supports, the following special filters:
 
+          user:USERNAME: only posts created by a specific user
           in:tagged: has at least 1 tag
           in:untagged: has no tags
           in:title: has the search term in the title
@@ -39,10 +40,14 @@ module DiscourseAi::AiBot::Commands
           -tags:TAG1+TAG2: excluding topics tagged TAG1 and TAG2
           order:latest: order by post creation desc
           order:latest_topic: order by topic creation desc
+          order:oldest : order by post creation asc
+          order:oldest_topic: order by topic creation asc
           order:views: order by topic views desc
           order:likes: order by post like count - most liked posts first
           after:YYYY-MM-DD: only topics created after a specific date
           before:YYYY-MM-DD: only topics created before a specific date
+
+          Example: !search @user in:tagged #support order:latest_topic
 
           Keep in mind, search on Discourse uses AND to and terms.
           You only have access to public topics.

--- a/lib/modules/ai_bot/commands/search_command.rb
+++ b/lib/modules/ai_bot/commands/search_command.rb
@@ -40,7 +40,7 @@ module DiscourseAi::AiBot::Commands
           -tags:TAG1+TAG2: excluding topics tagged TAG1 and TAG2
           order:latest: order by post creation desc
           order:latest_topic: order by topic creation desc
-          order:oldest : order by post creation asc
+          order:oldest: order by post creation asc
           order:oldest_topic: order by topic creation asc
           order:views: order by topic views desc
           order:likes: order by post like count - most liked posts first

--- a/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
+++ b/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe Jobs::CreateAiReply do
       before do
         bot_user = User.find(DiscourseAi::AiBot::EntryPoint::GPT3_5_TURBO_ID)
 
+        # time nees to be frozen so time in prompt does not drift
+        freeze_time
+
         OpenAiCompletionsInferenceStubs.stub_streamed_response(
           DiscourseAi::AiBot::OpenAiBot.new(bot_user).bot_prompt_with_topic_context(post),
           deltas,

--- a/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
+++ b/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Jobs::CreateAiReply do
       before do
         bot_user = User.find(DiscourseAi::AiBot::EntryPoint::GPT3_5_TURBO_ID)
 
-        # time nees to be frozen so time in prompt does not drift
+        # time needs to be frozen so time in prompt does not drift
         freeze_time
 
         OpenAiCompletionsInferenceStubs.stub_streamed_response(


### PR DESCRIPTION
blog.start_gpt_chat -> was on my blog

This also slightly tunes the search prompt to support filtering by oldest
and try a tiny bit harder to guide GPT 3.5 which is a bit of a losing battle
