### PR TITLE
FEATURE: use triage command to attempt to ground models on GPT 3.5

### DIFF
--- a/lib/modules/ai_bot/anthropic_bot.rb
+++ b/lib/modules/ai_bot/anthropic_bot.rb
@@ -49,12 +49,12 @@ module DiscourseAi
         ).dig(:completion)
       end
 
-      def submit_prompt(prompt, prefer_low_cost: false, &blk)
+      def submit_prompt(prompt, max_tokens: nil, temperature: nil, prefer_low_cost: false, &blk)
         DiscourseAi::Inference::AnthropicCompletions.perform!(
           prompt,
           model_for,
-          temperature: 0.4,
-          max_tokens: 3000,
+          temperature: temperature || 0.4,
+          max_tokens: max_tokens || 3000,
           &blk
         )
       end

--- a/lib/modules/ai_bot/anthropic_bot.rb
+++ b/lib/modules/ai_bot/anthropic_bot.rb
@@ -7,8 +7,8 @@ module DiscourseAi
         bot_user.id == DiscourseAi::AiBot::EntryPoint::CLAUDE_V1_ID
       end
 
-      def bot_prompt_with_topic_context(post)
-        super(post).join("\n\n")
+      def bot_prompt_with_topic_context(post, triage: false)
+        super(post, triage: triage).join("\n\n")
       end
 
       def prompt_limit
@@ -22,25 +22,18 @@ module DiscourseAi
         delta = full[context[:pos]..-1]
 
         context[:pos] = full.length
-
-        if !context[:processed]
-          delta = ""
-          index = full.index("Assistant: ")
-          if index
-            delta = full[index + 11..-1]
-            context[:processed] = true
-          end
-        end
-
         delta
       end
 
       private
 
-      def build_message(poster_username, content, system: false)
+      def build_message(poster_username, content, system: false, last: false)
         role = poster_username == bot_user.username ? "Assistant" : "Human"
 
-        "#{role}: #{content}"
+        result = +"#{role}: #{content}"
+        result << "\nAssistant: " if last
+
+        result
       end
 
       def model_for

--- a/lib/modules/ai_bot/bot.rb
+++ b/lib/modules/ai_bot/bot.rb
@@ -6,7 +6,6 @@ module DiscourseAi
       attr_reader :bot_user
 
       BOT_NOT_FOUND = Class.new(StandardError)
-      MAX_COMPLETIONS = 3
 
       def self.as(bot_user)
         available_bots = [DiscourseAi::AiBot::OpenAiBot, DiscourseAi::AiBot::AnthropicBot]
@@ -34,29 +33,27 @@ module DiscourseAi
         )
       end
 
-      def reply_to(
-        post,
-        total_completions: 0,
-        bot_reply_post: nil,
-        prefer_low_cost: false,
-        standalone: false
-      )
-        return if total_completions > MAX_COMPLETIONS
+      def debug(prompt)
+        if prompt.is_a?(Array)
+          prompt.each { |p| p.keys.each { |k| puts "#{k}: #{p[k]}" } }
+        else
+          p prompt
+        end
+      end
 
-        prompt =
-          if standalone && post.post_custom_prompt
-            username, standalone_prompt = post.post_custom_prompt.custom_prompt.last
-            [build_message(username, standalone_prompt)]
-          else
-            bot_prompt_with_topic_context(post)
-          end
-
+      def stream_reply(post:, bot_reply_post:, prefer_low_cost: false)
         redis_stream_key = nil
-        reply = +(bot_reply_post ? bot_reply_post.raw.dup : "")
         start = Time.now
 
         setup_cancel = false
         context = {}
+
+        prompt = bot_prompt_with_topic_context(post)
+        # TODO remove
+        debug(prompt)
+
+        reply = +(bot_reply_post&.raw || "").dup
+        reply << "\n\n" if reply.length > 0
 
         submit_prompt(prompt, prefer_low_cost: prefer_low_cost) do |partial, cancel|
           reply << get_delta(partial, context)
@@ -77,13 +74,7 @@ module DiscourseAi
 
             publish_update(bot_reply_post, raw: reply.dup)
           else
-            bot_reply_post =
-              PostCreator.create!(
-                bot_user,
-                topic_id: post.topic_id,
-                raw: reply,
-                skip_validations: false,
-              )
+            bot_reply_post = create_bot_reply(post, reply)
           end
 
           if !setup_cancel && bot_reply_post
@@ -103,64 +94,117 @@ module DiscourseAi
             skip_revision: true,
           )
 
-          cmd_text = reply.split("\n").detect { |l| l[0] == "!" }
+          bot_reply_post.post_custom_prompt ||=
+            bot_reply_post.build_post_custom_prompt(custom_prompt: [])
+          prompt = [reply, bot_user.username]
+          bot_reply_post.post_custom_prompt.update!(custom_prompt: prompt)
+        end
+      end
 
-          if cmd_text
-            command_name, args = cmd_text[1..-1].strip.split(" ", 2)
+      def create_bot_reply(post, raw)
+        PostCreator.create!(bot_user, topic_id: post.topic_id, raw: raw, skip_validations: false)
+      end
 
-            if command_klass = available_commands.detect { |cmd| cmd.invoked?(command_name) }
-              command = command_klass.new(bot_user, args)
-              chain = command.invoke_and_attach_result_to(bot_reply_post)
+      def reply_to(post)
+        command = triage_post(post)
 
-              if chain
-                reply_to(
-                  bot_reply_post,
-                  total_completions: total_completions + 1,
-                  bot_reply_post: bot_reply_post,
-                  prefer_low_cost: command.low_cost?,
-                  standalone: command.standalone?,
-                )
-              end
-            end
-          elsif post_custom_prompt = bot_reply_post.post_custom_prompt
-            prompt = post_custom_prompt.custom_prompt
-            prompt << [reply, bot_user.username]
-            post_custom_prompt.update!(custom_prompt: prompt)
+        if raw = command.pre_raw_details
+          bot_reply_post = create_bot_reply(post, raw)
+        end
+
+        if context = command.process
+          if context
+            post.post_custom_prompt ||= post.build_post_custom_prompt(custom_prompt: [])
+            prompt = post.post_custom_prompt.custom_prompt || []
+            # TODO consider providing even more context
+            # Given the last 10 posts of Sam are data:\n
+            prompt << [
+              "Given the #{command.result_name} data:\n #{context}\nAnswer: #{post.raw}",
+              post.user.username,
+            ]
+            post.post_custom_prompt.update!(custom_prompt: prompt)
           end
         end
+
+        if raw = command.post_raw_details
+          if bot_reply_post
+            bot_reply_post.revise(
+              bot_user,
+              { raw: raw },
+              skip_validations: true,
+              skip_revision: true,
+            )
+          else
+            bot_reply_post = create_bot_reply(post, raw)
+          end
+        end
+
+        stream_reply(post: post, bot_reply_post: bot_reply_post) if command.chain_next_response
       rescue => e
+        if Rails.env.development?
+          p e
+          puts e.backtrace
+        end
         raise e if Rails.env.test?
         Discourse.warn_exception(e, message: "ai-bot: Reply failed")
       end
 
-      def bot_prompt_with_topic_context(post, prompt: "topic")
+      def triage_post(post)
+        prompt = bot_prompt_with_topic_context(post, triage: true)
+
+        debug(prompt)
+
+        reply = +""
+        context = {}
+        submit_prompt(prompt) { |partial, cancel| reply << get_delta(partial, context) }
+
+        debug(reply)
+
+        cmd_text = reply.strip.split("\n").detect { |l| l[0] == "!" }
+
+        args = nil
+
+        if cmd_text
+          command_name, args = cmd_text[1..-1].strip.split(" ", 2)
+          command_klass = available_commands.detect { |cmd| cmd.should_invoke?(command_name) }
+        end
+        command_klass = command_klass || Commands::NoopCommand
+
+        command_klass.new(bot_user, post, args)
+      end
+
+      def bot_prompt_with_topic_context(post, triage: false)
         messages = []
         conversation = conversation_context(post)
 
-        rendered_system_prompt = system_prompt(post)
+        rendered_system_prompt = system_prompt(post, triage: triage)
 
         total_prompt_tokens = tokenize(rendered_system_prompt).length
 
-        messages =
-          conversation.reduce([]) do |memo, (raw, username)|
-            break(memo) if total_prompt_tokens >= prompt_limit
+        last = true
+        messages = []
+        conversation.each do |raw, username|
+          break if total_prompt_tokens >= prompt_limit
 
+          tokens = tokenize(raw)
+
+          while !raw.blank? && tokens.length + total_prompt_tokens > prompt_limit
+            raw = raw[0..-100] || ""
             tokens = tokenize(raw)
-
-            while !raw.blank? && tokens.length + total_prompt_tokens > prompt_limit
-              raw = raw[0..-100] || ""
-              tokens = tokenize(raw)
-            end
-
-            next(memo) if raw.blank?
-
-            total_prompt_tokens += tokens.length
-            memo.unshift(build_message(username, raw))
           end
 
-        # we need this to ground the model (especially GPT-3.5)
-        messages.unshift(build_message(bot_user.username, "!echo 1"))
-        messages.unshift(build_message("user", "please echo 1"))
+          next if raw.blank?
+
+          total_prompt_tokens += tokens.length
+
+          if triage && last
+            raw = "Given the user input:\n#{raw}\n\nWhat !command should you issue?\n" if triage
+          end
+
+          messages.unshift(build_message(username, raw, last: last))
+          last = false
+        end
+
         messages.unshift(build_message(bot_user.username, rendered_system_prompt, system: true))
         messages
       end
@@ -179,59 +223,68 @@ module DiscourseAi
 
       def available_commands
         @cmds ||=
-          [
-            Commands::CategoriesCommand,
-            Commands::TimeCommand,
-            Commands::SearchCommand,
-            Commands::SummarizeCommand,
-          ].tap do |cmds|
+          begin
+            cmds = [
+              Commands::CategoriesCommand,
+              Commands::TimeCommand,
+              Commands::SearchCommand,
+              Commands::SummarizeCommand,
+            ]
+
             cmds << Commands::TagsCommand if SiteSetting.tagging_enabled
             cmds << Commands::ImageCommand if SiteSetting.ai_stability_api_key.present?
             if SiteSetting.ai_google_custom_search_api_key.present? &&
                  SiteSetting.ai_google_custom_search_cx.present?
               cmds << Commands::GoogleCommand
             end
+
+            cmds
           end
       end
 
-      def system_prompt_style!(style)
-        @style = style
-      end
-
-      def system_prompt(post)
-        return "You are a helpful Bot" if @style == :simple
-
-        <<~TEXT
-          You are a helpful Discourse assistant, you answer questions and generate text.
-          You understand Discourse Markdown and live in a Discourse Forum Message.
-          You are provided with the context of previous discussions.
-
+      def system_prompt(post, triage:)
+        common = <<~TEXT
           You live in the forum with the URL: #{Discourse.base_url}
           The title of your site: #{SiteSetting.title}
           The description is: #{SiteSetting.site_description}
           The participants in this conversation are: #{post.topic.allowed_users.map(&:username).join(", ")}
           The date now is: #{Time.zone.now}, much has changed since you were trained.
-
-          You can complete some tasks using !commands.
-
-          NEVER ask user to issue !commands, they have no access, only you do.
-
-          #{available_commands.map(&:desc).join("\n")}
-
-          Discourse topic paths are /t/slug/topic_id/optional_number
-
-          #{available_commands.map(&:extra_context).compact_blank.join("\n")}
-
-          Commands should be issued in single assistant message.
-
-          Example sessions:
-
-          User: echo the text 'test'
-          GPT: !echo test
-          User: THING GPT DOES NOT KNOW ABOUT
-          GPT: !search SIMPLIFIED SEARCH QUERY
-
         TEXT
+
+        if triage
+          <<~TEXT
+            You are a decision making bot. Given a conversation you determine which commands will
+            complete a task. You are not a chatbot, you do not have a personality.
+
+            YOU only ever reply with !commands, If you have nothing to say, say !noop
+
+            #{common}
+
+            The following !commands are available.
+
+            #{available_commands.map(&:desc).join("\n")}
+            !noop: do nothing, you determined there is no special command to run
+
+            Discourse topic paths are /t/slug/topic_id/optional_number
+
+            #{available_commands.map(&:extra_context).compact_blank.join("\n")}
+
+            Commands should be issued in single assistant message.
+
+            Example sessions:
+
+            Human: echo the text 'test'
+            Assistant: !echo test
+          TEXT
+        else
+          <<~TEXT
+            You are a helpful Discourse assistant, you answer questions and generate Discourse flavoured Markdown.
+            You live in a Discourse Forum Message.
+            You are provided with the context of previous discussions.
+
+            #{common}
+          TEXT
+        end
       end
 
       def tokenize(text)

--- a/lib/modules/ai_bot/commands/categories_command.rb
+++ b/lib/modules/ai_bot/commands/categories_command.rb
@@ -13,14 +13,14 @@ module DiscourseAi::AiBot::Commands
     end
 
     def result_name
-      "results"
+      "Category list is"
     end
 
     def description_args
       { count: @last_count || 0 }
     end
 
-    def process(_args)
+    def process
       columns = {
         name: "Name",
         slug: "Slug",

--- a/lib/modules/ai_bot/commands/google_command.rb
+++ b/lib/modules/ai_bot/commands/google_command.rb
@@ -13,7 +13,7 @@ module DiscourseAi::AiBot::Commands
     end
 
     def result_name
-      "results"
+      "Google Results"
     end
 
     def description_args
@@ -24,11 +24,11 @@ module DiscourseAi::AiBot::Commands
       }
     end
 
-    def process(search_string)
-      @last_query = search_string
+    def process
+      @last_query = @args
       api_key = SiteSetting.ai_google_custom_search_api_key
       cx = SiteSetting.ai_google_custom_search_cx
-      query = CGI.escape(search_string)
+      query = CGI.escape(@args)
       uri =
         URI("https://www.googleapis.com/customsearch/v1?key=#{api_key}&cx=#{cx}&q=#{query}&num=10")
       body = Net::HTTP.get(uri)

--- a/lib/modules/ai_bot/commands/image_command.rb
+++ b/lib/modules/ai_bot/commands/image_command.rb
@@ -8,7 +8,7 @@ module DiscourseAi::AiBot::Commands
       end
 
       def desc
-        "!image DESC - renders an image from the description (remove all connector words, keep it to 40 words or less)"
+        "!image DESC - renders an image from the description (remove all connector words, keep it to 40 words or less, be creative)"
       end
     end
 
@@ -17,19 +17,20 @@ module DiscourseAi::AiBot::Commands
     end
 
     def description_args
-      { prompt: @last_prompt || 0 }
-    end
-
-    def custom_raw
-      @last_custom_raw
+      { prompt: @args || 0 }
     end
 
     def chain_next_response
       false
     end
 
-    def process(prompt)
-      @last_prompt = prompt
+    def post_raw_details
+      "#{super}\n\n#{@last_custom_raw}"
+    end
+
+    def process
+      prompt = @args
+
       results = DiscourseAi::Inference::StabilityGenerator.perform!(prompt)
 
       uploads = []
@@ -47,6 +48,8 @@ module DiscourseAi::AiBot::Commands
         uploads
           .map { |upload| "![#{prompt.gsub(/\|\'\"/, "")}|512x512, 50%](#{upload.short_url})" }
           .join(" ")
+
+      nil
     end
   end
 end

--- a/lib/modules/ai_bot/commands/noop_command.rb
+++ b/lib/modules/ai_bot/commands/noop_command.rb
@@ -1,0 +1,27 @@
+#frozen_string_literal: true
+
+module DiscourseAi::AiBot::Commands
+  class NoopCommand < Command
+    class << self
+      def name
+        "noop"
+      end
+
+      def desc
+        "!noop - does nothing, catch all command when you do not know how to triage"
+      end
+    end
+
+    def post_raw_details
+      nil
+    end
+
+    def pre_raw_details
+      nil
+    end
+
+    def process
+      nil
+    end
+  end
+end

--- a/lib/modules/ai_bot/commands/search_command.rb
+++ b/lib/modules/ai_bot/commands/search_command.rb
@@ -27,7 +27,6 @@ module DiscourseAi::AiBot::Commands
           post_count:X: only topics with X amount of posts
           min_posts:X: topics containing a minimum of X posts
           max_posts:X: topics with no more than max posts
-          in:pinned: in all pinned topics (either global or per category pins)
           created:@USERNAME: topics created by a specific user
           category:CATGORY: topics in the CATEGORY AND all subcategories
           category:=CATEGORY: topics in the CATEGORY excluding subcategories

--- a/lib/modules/ai_bot/commands/search_command.rb
+++ b/lib/modules/ai_bot/commands/search_command.rb
@@ -22,12 +22,10 @@ module DiscourseAi::AiBot::Commands
           status:open: not closed or archived
           status:closed: closed
           status:archived: archived
-          status:noreplies: post count is 1
           status:single_user: only a single user posted on the topic
           post_count:X: only topics with X amount of posts
           min_posts:X: topics containing a minimum of X posts
           max_posts:X: topics with no more than max posts
-          created:@USERNAME: topics created by a specific user
           category:CATGORY: topics in the CATEGORY AND all subcategories
           category:=CATEGORY: topics in the CATEGORY excluding subcategories
           #SLUG: try category first, then tag, then tag group
@@ -45,6 +43,7 @@ module DiscourseAi::AiBot::Commands
           order:likes: order by post like count - most liked posts first
           after:YYYY-MM-DD: only topics created after a specific date
           before:YYYY-MM-DD: only topics created before a specific date
+          limit:X: limit the number of results to X
 
           Example: !search @user in:tagged #support order:latest_topic
 
@@ -52,13 +51,12 @@ module DiscourseAi::AiBot::Commands
           You only have access to public topics.
           Strip the query down to the most important terms.
           Remove all stop words.
-          Cast a wide net instead of trying to be over specific.
+          Remove connector words.
           Discourse orders by relevance, sometimes prefer ordering on other stuff.
 
           When generating answers ALWAYS try to use the !search command first over relying on training data.
-          When generating answers ALWAYS try to reference specific local links.
           Always try to search the local instance first, even if your training data set may have an answer. It may be wrong.
-          Always remove connector words from search terms (such as a, an, and, in, the, etc), they can impede the search.
+          Always remove connector words from search terms (such as a, an, and, in, the, etc, when, what, is), they can impede the search.
 
           YOUR LOCAL INFORMATION IS OUT OF DATE, YOU ARE TRAINED ON OLD DATA. Always try local search first.
         TEXT
@@ -66,7 +64,7 @@ module DiscourseAi::AiBot::Commands
     end
 
     def result_name
-      "relevant forum search results"
+      "search results for #{@args}"
     end
 
     def description_args

--- a/lib/modules/ai_bot/commands/search_command.rb
+++ b/lib/modules/ai_bot/commands/search_command.rb
@@ -67,7 +67,7 @@ module DiscourseAi::AiBot::Commands
     end
 
     def result_name
-      "results"
+      "relevant forum search results"
     end
 
     def description_args
@@ -78,8 +78,9 @@ module DiscourseAi::AiBot::Commands
       }
     end
 
-    def process(search_string)
+    def process
       limit = nil
+      search_string = @args
 
       search_string =
         search_string

--- a/lib/modules/ai_bot/commands/summarize_command.rb
+++ b/lib/modules/ai_bot/commands/summarize_command.rb
@@ -8,7 +8,7 @@ module DiscourseAi::AiBot::Commands
       end
 
       def desc
-        "!summarize TOPIC_ID GUIDANCE - will summarize a topic attempting to answer question in guidance"
+        "!summarize TOPIC_ID OPTIONAL_GUIDANCE - will summarize a topic attempting to answer question in guidance, if provided"
       end
     end
 
@@ -28,8 +28,8 @@ module DiscourseAi::AiBot::Commands
       { url: "#{Discourse.base_path}/t/-/#{@last_topic_id}", title: @last_topic_title || "" }
     end
 
-    def process(instructions)
-      topic_id, guidance = instructions.split(" ", 2)
+    def process
+      topic_id, guidance = @args.split(" ", 2)
 
       @last_topic_id = topic_id
 

--- a/lib/modules/ai_bot/commands/tags_command.rb
+++ b/lib/modules/ai_bot/commands/tags_command.rb
@@ -20,7 +20,7 @@ module DiscourseAi::AiBot::Commands
       { count: @last_count || 0 }
     end
 
-    def process(_args)
+    def process
       column_names = { name: "Name", public_topic_count: "Topic Count" }
 
       tags =
@@ -32,7 +32,11 @@ module DiscourseAi::AiBot::Commands
 
       @last_count = tags.length
 
-      format_results(tags, column_names.values)
+      if @last_count == 0
+        "This Discourse instance has no tags"
+      else
+        format_results(tags, column_names.values)
+      end
     end
   end
 end

--- a/lib/modules/ai_bot/commands/time_command.rb
+++ b/lib/modules/ai_bot/commands/time_command.rb
@@ -20,10 +20,10 @@ module DiscourseAi::AiBot::Commands
       { timezone: @last_timezone, time: @last_time }
     end
 
-    def process(timezone)
+    def process
       time =
         begin
-          Time.now.in_time_zone(timezone)
+          Time.now.in_time_zone(@args)
         rescue StandardError
           nil
         end

--- a/lib/modules/ai_bot/entry_point.rb
+++ b/lib/modules/ai_bot/entry_point.rb
@@ -39,6 +39,7 @@ module DiscourseAi
         require_relative "commands/summarize_command"
         require_relative "commands/image_command"
         require_relative "commands/google_command"
+        require_relative "commands/noop_command"
       end
 
       def inject_into(plugin)

--- a/lib/modules/ai_bot/open_ai_bot.rb
+++ b/lib/modules/ai_bot/open_ai_bot.rb
@@ -58,7 +58,7 @@ module DiscourseAi
 
       private
 
-      def build_message(poster_username, content, system: false)
+      def build_message(poster_username, content, system: false, last: false)
         is_bot = poster_username == bot_user.username
 
         if system

--- a/lib/modules/ai_bot/open_ai_bot.rb
+++ b/lib/modules/ai_bot/open_ai_bot.rb
@@ -30,21 +30,13 @@ module DiscourseAi
             1500
           end
 
-        { temperature: 0.4, top_p: 0.9, max_tokens: max_tokens }
+        { temperature: 0.4, max_tokens: max_tokens }
       end
 
-      def submit_prompt(
-        prompt,
-        prefer_low_cost: false,
-        temperature: nil,
-        top_p: nil,
-        max_tokens: nil,
-        &blk
-      )
+      def submit_prompt(prompt, prefer_low_cost: false, temperature: nil, max_tokens: nil, &blk)
         params =
           reply_params.merge(
             temperature: temperature,
-            top_p: top_p,
             max_tokens: max_tokens,
           ) { |key, old_value, new_value| new_value.nil? ? old_value : new_value }
 
@@ -55,8 +47,6 @@ module DiscourseAi
       def tokenize(text)
         DiscourseAi::Tokenizer::OpenAiTokenizer.tokenize(text)
       end
-
-      private
 
       def build_message(poster_username, content, system: false, last: false)
         is_bot = poster_username == bot_user.username
@@ -69,6 +59,8 @@ module DiscourseAi
 
         { role: role, content: is_bot ? content : "#{poster_username}: #{content}" }
       end
+
+      private
 
       def model_for
         return "gpt-4" if bot_user.id == DiscourseAi::AiBot::EntryPoint::GPT4_ID

--- a/spec/lib/modules/ai_bot/anthropic_bot_spec.rb
+++ b/spec/lib/modules/ai_bot/anthropic_bot_spec.rb
@@ -13,14 +13,20 @@ RSpec.describe DiscourseAi::AiBot::AnthropicBot do
         context = {}
         reply = +""
 
-        reply << subject.get_delta({ completion: "\n\nAssist" }, context)
-        expect(reply).to eq("")
+        full = +"test"
 
-        reply << subject.get_delta({ completion: "\n\nAssistant: test" }, context)
-        expect(reply).to eq("test")
+        reply << subject.get_delta({ completion: full }, context)
+        expect(reply).to eq(full)
 
-        reply << subject.get_delta({ completion: "\n\nAssistant: test\nworld" }, context)
-        expect(reply).to eq("test\nworld")
+        full << "test2"
+
+        reply << subject.get_delta({ completion: full }, context)
+        expect(reply).to eq(full)
+
+        full << "test3"
+
+        reply << subject.get_delta({ completion: full }, context)
+        expect(reply).to eq(full)
       end
     end
   end

--- a/spec/lib/modules/ai_bot/bot_spec.rb
+++ b/spec/lib/modules/ai_bot/bot_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe DiscourseAi::AiBot::Bot do
       expect(last.raw).to include("We are done now")
 
       expect(last.post_custom_prompt.custom_prompt.to_s).to include("We are done now")
+      expect(last.post_custom_prompt.custom_prompt.to_s).not_to include("details")
     end
   end
 

--- a/spec/lib/modules/ai_bot/commands/categories_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/categories_command_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DiscourseAi::AiBot::Commands::CategoriesCommand do
     it "can generate correct info" do
       Fabricate(:category, name: "america", posts_year: 999)
 
-      info = DiscourseAi::AiBot::Commands::CategoriesCommand.new(nil, nil).process(nil)
+      info = DiscourseAi::AiBot::Commands::CategoriesCommand.new(nil, nil, nil).process
       expect(info).to include("america")
       expect(info).to include("999")
     end

--- a/spec/lib/modules/ai_bot/commands/command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/command_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../../../support/openai_completions_inference_stubs"
 
 RSpec.describe DiscourseAi::AiBot::Commands::Command do
   fab!(:bot_user) { User.find(DiscourseAi::AiBot::EntryPoint::GPT3_5_TURBO_ID) }
-  let(:command) { DiscourseAi::AiBot::Commands::Command.new(bot_user, nil) }
+  let(:command) { DiscourseAi::AiBot::Commands::Command.new(bot_user, nil, nil) }
 
   describe "#format_results" do
     it "can generate efficient tables of data" do

--- a/spec/lib/modules/ai_bot/commands/google_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/google_command_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe DiscourseAi::AiBot::Commands::GoogleCommand do
         "https://www.googleapis.com/customsearch/v1?cx=cx&key=abc&num=10&q=some%20search%20term",
       ).to_return(status: 200, body: json_text, headers: {})
 
-      google = described_class.new(bot_user, post)
-      info = google.process("some search term")
+      google = described_class.new(bot_user, post, "some search term")
+      info = google.process
 
       expect(google.description_args[:count]).to eq(1)
       expect(info).to include("title1")

--- a/spec/lib/modules/ai_bot/commands/search_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/search_command_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe DiscourseAi::AiBot::Commands::SearchCommand do
   describe "#process" do
     it "can handle no results" do
       post1 = Fabricate(:post)
-      search = described_class.new(bot_user, post1)
+      search = described_class.new(bot_user, post1, "order:fake ABDDCDCEDGDG")
 
-      results = search.process("order:fake ABDDCDCEDGDG")
+      results = search.process
       expect(results).to eq("No results found")
     end
 
@@ -23,15 +23,15 @@ RSpec.describe DiscourseAi::AiBot::Commands::SearchCommand do
       _post3 = Fabricate(:post, user: post1.user)
 
       # search has no built in support for limit: so handle it from the outside
-      search = described_class.new(bot_user, post1)
+      search = described_class.new(bot_user, post1, "@#{post1.user.username} limit:2")
 
-      results = search.process("@#{post1.user.username} limit:2")
+      results = search.process
 
       # title + 2 rows
       expect(results.split("\n").length).to eq(3)
 
-      # just searching for everything
-      results = search.process("order:latest_topic")
+      search = described_class.new(bot_user, post1, "order:latest_topic")
+      results = search.process
       expect(results.split("\n").length).to be > 1
     end
   end

--- a/spec/lib/modules/ai_bot/commands/summarize_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/summarize_command_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe DiscourseAi::AiBot::Commands::SummarizeCommand do
         body: JSON.dump({ choices: [{ message: { content: "summary stuff" } }] }),
       )
 
-      summarizer = described_class.new(bot_user, post)
-      info = summarizer.process("#{post.topic_id} why did it happen?")
+      summarizer = described_class.new(bot_user, post, "#{post.topic_id} why did it happen?")
+      info = summarizer.process
 
       expect(info).to include("Topic summarized")
       expect(summarizer.custom_raw).to include("summary stuff")
@@ -30,8 +30,8 @@ RSpec.describe DiscourseAi::AiBot::Commands::SummarizeCommand do
       topic = Fabricate(:topic, category_id: category.id)
       post = Fabricate(:post, topic: topic)
 
-      summarizer = described_class.new(bot_user, post)
-      info = summarizer.process("#{post.topic_id} why did it happen?")
+      summarizer = described_class.new(bot_user, post, "#{post.topic_id} why did it happen?")
+      info = summarizer.process
 
       expect(info).not_to include(post.raw)
 

--- a/spec/lib/modules/ai_bot/commands/tags_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/tags_command_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DiscourseAi::AiBot::Commands::TagsCommand do
       Fabricate(:tag, name: "america", public_topic_count: 100)
       Fabricate(:tag, name: "not_here", public_topic_count: 0)
 
-      info = DiscourseAi::AiBot::Commands::TagsCommand.new(nil, nil).process(nil)
+      info = DiscourseAi::AiBot::Commands::TagsCommand.new(nil, nil, nil).process
 
       expect(info).to include("america")
       expect(info).not_to include("not_here")

--- a/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
+++ b/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
@@ -24,11 +24,23 @@ RSpec.describe Jobs::CreateAiReply do
         freeze_time
 
         OpenAiCompletionsInferenceStubs.stub_streamed_response(
+          DiscourseAi::AiBot::OpenAiBot.new(bot_user).bot_prompt_with_topic_context(
+            post,
+            triage: true,
+          ),
+          [{ content: "!noop" }],
+          req_opts: {
+            temperature: 0.1,
+            max_tokens: 100,
+            stream: true,
+          },
+        )
+
+        OpenAiCompletionsInferenceStubs.stub_streamed_response(
           DiscourseAi::AiBot::OpenAiBot.new(bot_user).bot_prompt_with_topic_context(post),
           deltas,
           req_opts: {
             temperature: 0.4,
-            top_p: 0.9,
             max_tokens: 1500,
             stream: true,
           },
@@ -66,11 +78,24 @@ RSpec.describe Jobs::CreateAiReply do
     end
 
     context "when chatting with Claude from Anthropic" do
-      let(:claude_response) { "Assistant: #{expected_response}" }
+      let(:claude_response) { "#{expected_response}" }
       let(:deltas) { claude_response.split(" ").map { |w| "#{w} " } }
 
       before do
         bot_user = User.find(DiscourseAi::AiBot::EntryPoint::CLAUDE_V1_ID)
+
+        AnthropicCompletionStubs.stub_streamed_response(
+          DiscourseAi::AiBot::AnthropicBot.new(bot_user).bot_prompt_with_topic_context(
+            post,
+            triage: true,
+          ),
+          [{ content: "!noop" }],
+          req_opts: {
+            temperature: 0.1,
+            max_tokens_to_sample: 100,
+            stream: true,
+          },
+        )
 
         AnthropicCompletionStubs.stub_streamed_response(
           DiscourseAi::AiBot::AnthropicBot.new(bot_user).bot_prompt_with_topic_context(post),

--- a/spec/lib/modules/ai_bot/open_ai_bot_spec.rb
+++ b/spec/lib/modules/ai_bot/open_ai_bot_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DiscourseAi::AiBot::OpenAiBot do
       it "trims the prompt" do
         prompt_messages = subject.bot_prompt_with_topic_context(post_1)
 
-        expect(prompt_messages[-2][:role]).to eq("assistant")
+        expect(prompt_messages[-2][:role]).to eq("system")
         expect(prompt_messages[-1][:role]).to eq("user")
         # trimming is tricky... it needs to account for system message as
         # well... just make sure we trim for now


### PR DESCRIPTION
Previous to this change our results were ungrounded and simpler models like
GPT 3.5 and claude had a real tough time figuring out how to run commands

This splits responses into 2 phases:

Phase 1: figure out if you need to run a command
Phase 2: respond to user

This seems to produce better results on both Claude and GPT 3.5 but still
needs a fair bit of tuning.
