### PR TITLE
DEV: Fix Zeitwerk reloading error

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,4 @@ DiscourseAi::Engine.routes.draw do
   end
 end
 
-Discourse::Application.routes.append { mount ::DiscourseAi::Engine, at: "discourse-ai" }
+Discourse::Application.routes.draw { mount ::DiscourseAi::Engine, at: "discourse-ai" }


### PR DESCRIPTION
Using `.append` can lead to a 'two routes with the same name' error