### PR TITLE
FIX: avoid storing corrupt prompts

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -100,7 +100,7 @@ en:
       command_description:
         time: "Time in %{timezone} is %{time}"
         summarize: "Summarized <a href='%{url}'>%{title}</a>"
-        image: "Prompt: %{prompt}"
+        image: "%{prompt}"
         categories:
           one: "Found %{count} category"
           other: "Found %{count} categories"
@@ -115,6 +115,6 @@ en:
           other: "Found %{count} <a href='%{url}'>results</a> for '%{query}'"
 
     summarization:
-      configuration_hint: 
+      configuration_hint:
         one: "Configure the `%{setting}` setting first."
         other: "Configure these settings first: %{settings}"

--- a/lib/modules/ai_bot/commands/image_command.rb
+++ b/lib/modules/ai_bot/commands/image_command.rb
@@ -36,7 +36,7 @@ module DiscourseAi::AiBot::Commands
     end
 
     def description_args
-      { prompt: @last_prompt || 0 }
+      { prompt: @last_prompt }
     end
 
     def chain_next_response

--- a/lib/modules/ai_bot/commands/search_command.rb
+++ b/lib/modules/ai_bot/commands/search_command.rb
@@ -20,7 +20,8 @@ module DiscourseAi::AiBot::Commands
           ),
           Parameter.new(
             name: "user",
-            description: "Filter search results to this username",
+            description:
+              "Filter search results to this username (only include if user explicitly asks to filter by user)",
             type: "string",
           ),
           Parameter.new(
@@ -31,7 +32,8 @@ module DiscourseAi::AiBot::Commands
           ),
           Parameter.new(
             name: "limit",
-            description: "limit number of results returned",
+            description:
+              "limit number of results returned (generally prefer to just keep to default)",
             type: "integer",
           ),
           Parameter.new(

--- a/spec/lib/modules/ai_bot/bot_spec.rb
+++ b/spec/lib/modules/ai_bot/bot_spec.rb
@@ -80,7 +80,9 @@ RSpec.describe DiscourseAi::AiBot::Bot do
       expect(last.raw).not_to include("translation missing")
       expect(last.raw).to include("I found nothing")
 
-      expect(last.post_custom_prompt.custom_prompt.to_s).to include("I found nothing")
+      expect(last.post_custom_prompt.custom_prompt).to eq(
+        [["[]", "search", "function"], ["I found nothing, sorry", bot_user.username]],
+      )
     end
   end
 

--- a/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
+++ b/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
@@ -4,6 +4,11 @@ require_relative "../../../../../support/openai_completions_inference_stubs"
 require_relative "../../../../../support/anthropic_completion_stubs"
 
 RSpec.describe Jobs::CreateAiReply do
+  before do
+    # got to do this cause we include times in system message
+    freeze_time
+  end
+
   describe "#execute" do
     fab!(:topic) { Fabricate(:topic) }
     fab!(:post) { Fabricate(:post, topic: topic) }

--- a/spec/lib/modules/ai_bot/open_ai_bot_spec.rb
+++ b/spec/lib/modules/ai_bot/open_ai_bot_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe DiscourseAi::AiBot::OpenAiBot do
 
     subject { described_class.new(bot_user) }
 
+    context "when cleaning usernames" do
+      it "can properly clean usernames so OpenAI allows it" do
+        subject.clean_username("test test").should eq("test_test")
+        subject.clean_username("test.test").should eq("test_test")
+        subject.clean_username("test😀test").should eq("test_test")
+      end
+    end
+
     context "when the topic has one post" do
       fab!(:post_1) { Fabricate(:post, topic: topic, raw: post_body(1), post_number: 1) }
 
@@ -23,7 +31,8 @@ RSpec.describe DiscourseAi::AiBot::OpenAiBot do
         post_1_message = prompt_messages[-1]
 
         expect(post_1_message[:role]).to eq("user")
-        expect(post_1_message[:content]).to eq("#{post_1.user.username}: #{post_body(1)}")
+        expect(post_1_message[:content]).to eq(post_body(1))
+        expect(post_1_message[:name]).to eq(post_1.user.username)
       end
     end
 
@@ -51,13 +60,15 @@ RSpec.describe DiscourseAi::AiBot::OpenAiBot do
 
         # negative cause we may have grounding prompts
         expect(prompt_messages[-3][:role]).to eq("user")
-        expect(prompt_messages[-3][:content]).to eq("#{post_1.username}: #{post_body(1)}")
+        expect(prompt_messages[-3][:content]).to eq(post_body(1))
+        expect(prompt_messages[-3][:name]).to eq(post_1.username)
 
         expect(prompt_messages[-2][:role]).to eq("assistant")
         expect(prompt_messages[-2][:content]).to eq(post_body(2))
 
         expect(prompt_messages[-1][:role]).to eq("user")
-        expect(prompt_messages[-1][:content]).to eq("#{post_3.username}: #{post_body(3)}")
+        expect(prompt_messages[-1][:content]).to eq(post_body(3))
+        expect(prompt_messages[-1][:name]).to eq(post_3.username)
       end
     end
   end


### PR DESCRIPTION
```
prompt << build_message(bot_user.username, reply)
```

Would store a "cooked" prompt which is invalid, instead just store the raw
values which are later passed to build_message

Additionally:

1. Disable summary command which needs honing
2. Stop storing decorations (searched for X) in prompt which leads to straying
3. Ship username directly to model, avoiding "user: content" in prompts. This
 was causing GPT to stray
