### PR TITLE
REFACTOR: Cohesive narrative for single-chunk summaries.

### DIFF
--- a/lib/modules/summarization/models/discourse.rb
+++ b/lib/modules/summarization/models/discourse.rb
@@ -29,9 +29,13 @@ module DiscourseAi
         def summarize_with_truncation(contents, opts)
           text_to_summarize = contents.map { |c| format_content_item(c) }.join
           truncated_content =
-            ::DiscourseAi::Tokenizer::BertTokenizer.truncate(text_to_summarize, max_tokens)
+            ::DiscourseAi::Tokenizer::BertTokenizer.truncate(text_to_summarize, available_tokens)
 
           completion(truncated_content)
+        end
+
+        def summarize_single(chunk_text, _opts)
+          completion(chunk_text)
         end
 
         private

--- a/lib/modules/summarization/models/open_ai.rb
+++ b/lib/modules/summarization/models/open_ai.rb
@@ -37,7 +37,7 @@ module DiscourseAi
           messages = [{ role: "system", content: build_base_prompt(opts) }]
 
           text_to_summarize = contents.map { |c| format_content_item(c) }.join
-          truncated_content = tokenizer.truncate(text_to_summarize, max_tokens - reserved_tokens)
+          truncated_content = tokenizer.truncate(text_to_summarize, available_tokens)
 
           messages << {
             role: "user",
@@ -47,13 +47,24 @@ module DiscourseAi
           completion(messages)
         end
 
+        def summarize_single(chunk_text, opts)
+          summarize_chunk(chunk_text, opts.merge(single_chunk: true))
+        end
+
         private
 
         def summarize_chunk(chunk_text, opts)
+          summary_instruction =
+            if opts[:single_chunk]
+              "Summarize the following forum discussion, creating a cohesive narrative:"
+            else
+              "Summarize the following in 400 words:"
+            end
+
           completion(
             [
               { role: "system", content: build_base_prompt(opts) },
-              { role: "user", content: "Summarize the following in 400 words:\n#{chunk_text}" },
+              { role: "user", content: "#{summary_instruction}\n#{chunk_text}" },
             ],
           )
         end

--- a/lib/modules/summarization/strategies/fold_content.rb
+++ b/lib/modules/summarization/strategies/fold_content.rb
@@ -18,11 +18,45 @@ module DiscourseAi
 
         def summarize(content)
           opts = content.except(:contents)
-          summaries = completion_model.summarize_in_chunks(content[:contents], opts)
 
-          return { summary: summaries.first[:summary], chunks: [] } if summaries.length == 1
+          chunks = split_into_chunks(content[:contents])
 
-          { summary: completion_model.concatenate_summaries(summaries), chunks: summaries }
+          if chunks.length == 1
+            { summary: completion_model.summarize_single(chunks.first[:summary], opts), chunks: [] }
+          else
+            summaries = completion_model.summarize_in_chunks(chunks, opts)
+
+            { summary: completion_model.concatenate_summaries(summaries), chunks: summaries }
+          end
+        end
+
+        private
+
+        def split_into_chunks(contents)
+          section = { ids: [], summary: "" }
+
+          chunks =
+            contents.reduce([]) do |sections, item|
+              new_content = completion_model.format_content_item(item)
+
+              if completion_model.can_expand_tokens?(
+                   section[:summary],
+                   new_content,
+                   completion_model.available_tokens,
+                 )
+                section[:summary] += new_content
+                section[:ids] << item[:id]
+              else
+                sections << section
+                section = { ids: [item[:id]], summary: new_content }
+              end
+
+              sections
+            end
+
+          chunks << section if section[:summary].present?
+
+          chunks
         end
       end
     end

--- a/spec/lib/modules/summarization/models/anthropic_spec.rb
+++ b/spec/lib/modules/summarization/models/anthropic_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe DiscourseAi::Summarization::Models::Anthropic do
     }
   end
 
+  def as_chunk(item)
+    { ids: [item[:id]], summary: "(#{item[:id]} #{item[:poster]} said: #{item[:text]} " }
+  end
+
   def expected_messages(contents, opts)
     base_prompt = <<~TEXT
       Human: Summarize the following forum discussion inside the given <input> tag.
@@ -43,8 +47,8 @@ RSpec.describe DiscourseAi::Summarization::Models::Anthropic do
           "<ai>This is summary 1</ai>",
         )
 
-        summarized_chunks =
-          model.summarize_in_chunks(content[:contents], opts).map { |c| c[:summary] }
+        chunks = content[:contents].map { |c| as_chunk(c) }
+        summarized_chunks = model.summarize_in_chunks(chunks, opts).map { |c| c[:summary] }
 
         expect(summarized_chunks).to contain_exactly("This is summary 1")
       end
@@ -66,8 +70,8 @@ RSpec.describe DiscourseAi::Summarization::Models::Anthropic do
           )
         end
 
-        summarized_chunks =
-          model.summarize_in_chunks(content[:contents], opts).map { |c| c[:summary] }
+        chunks = content[:contents].map { |c| as_chunk(c) }
+        summarized_chunks = model.summarize_in_chunks(chunks, opts).map { |c| c[:summary] }
 
         expect(summarized_chunks).to contain_exactly("This is summary 1", "This is summary 2")
       end

--- a/spec/lib/modules/summarization/models/discourse_spec.rb
+++ b/spec/lib/modules/summarization/models/discourse_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe DiscourseAi::Summarization::Models::Discourse do
     end
   end
 
+  def as_chunk(item)
+    { ids: [item[:id]], summary: "(#{item[:id]} #{item[:poster]} said: #{item[:text]} " }
+  end
+
   describe "#summarize_in_chunks" do
     context "when the content fits in a single chunk" do
       it "performs a request to summarize" do
@@ -39,8 +43,8 @@ RSpec.describe DiscourseAi::Summarization::Models::Discourse do
 
         stub_request(expected_messages(content[:contents], opts), "This is summary 1")
 
-        summarized_chunks =
-          model.summarize_in_chunks(content[:contents], opts).map { |c| c[:summary] }
+        chunks = content[:contents].map { |c| as_chunk(c) }
+        summarized_chunks = model.summarize_in_chunks(chunks, opts).map { |c| c[:summary] }
 
         expect(summarized_chunks).to contain_exactly("This is summary 1")
       end
@@ -59,8 +63,8 @@ RSpec.describe DiscourseAi::Summarization::Models::Discourse do
           stub_request(expected_messages([item], opts), "This is summary #{idx + 1}")
         end
 
-        summarized_chunks =
-          model.summarize_in_chunks(content[:contents], opts).map { |c| c[:summary] }
+        chunks = content[:contents].map { |c| as_chunk(c) }
+        summarized_chunks = model.summarize_in_chunks(chunks, opts).map { |c| c[:summary] }
 
         expect(summarized_chunks).to contain_exactly("This is summary 1", "This is summary 2")
       end

--- a/spec/lib/modules/summarization/models/open_ai_spec.rb
+++ b/spec/lib/modules/summarization/models/open_ai_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe DiscourseAi::Summarization::Models::OpenAi do
     }
   end
 
+  def as_chunk(item)
+    { ids: [item[:id]], summary: "(#{item[:id]} #{item[:poster]} said: #{item[:text]} " }
+  end
+
   def expected_messages(contents, opts)
     base_prompt = <<~TEXT
       You are a summarization bot.
@@ -46,8 +50,8 @@ RSpec.describe DiscourseAi::Summarization::Models::OpenAi do
           "This is summary 1",
         )
 
-        summarized_chunks =
-          model.summarize_in_chunks(content[:contents], opts).map { |c| c[:summary] }
+        chunks = content[:contents].map { |c| as_chunk(c) }
+        summarized_chunks = model.summarize_in_chunks(chunks, opts).map { |c| c[:summary] }
 
         expect(summarized_chunks).to contain_exactly("This is summary 1")
       end
@@ -69,8 +73,8 @@ RSpec.describe DiscourseAi::Summarization::Models::OpenAi do
           )
         end
 
-        summarized_chunks =
-          model.summarize_in_chunks(content[:contents], opts).map { |c| c[:summary] }
+        chunks = content[:contents].map { |c| as_chunk(c) }
+        summarized_chunks = model.summarize_in_chunks(chunks, opts).map { |c| c[:summary] }
 
         expect(summarized_chunks).to contain_exactly("This is summary 1", "This is summary 2")
       end


### PR DESCRIPTION
Single and multi-chunk summaries end up using different prompts for the last summary. This change detects when the summarized content fits in a single chunk and uses a slightly different prompt, which leads to more consistent summary formats.

This PR also moves the chunk-splitting step to the `FoldContent` strategy as preparation for implementing streamed summaries.