### PR TITLE
FIX: Use base 10 when gettings allowed group IDs from settings.

### DIFF
--- a/assets/javascripts/initializers/ai-bot-replies.js
+++ b/assets/javascripts/initializers/ai-bot-replies.js
@@ -149,7 +149,7 @@ export default {
 
     const aiBotsAllowedGroups = settings.ai_bot_allowed_groups
       .split("|")
-      .map(parseInt);
+      .map((id) => parseInt(id, 10));
     const canInteractWithAIBots = user?.groups.some((g) =>
       aiBotsAllowedGroups.includes(g.id)
     );

--- a/assets/javascripts/initializers/composer-ai-helper.js
+++ b/assets/javascripts/initializers/composer-ai-helper.js
@@ -60,7 +60,7 @@ export default {
 
     const allowedGroups = settings.ai_helper_allowed_groups
       .split("|")
-      .map(parseInt);
+      .map((id) => parseInt(id, 10));
     const canUseAssistant = user?.groups.some((g) =>
       allowedGroups.includes(g.id)
     );


### PR DESCRIPTION
A missing parameter on the `parseInt` function was causing unexpected UI behavior for the AI helper since it turned an allowed group ID into NaN. We should always use base10 when parsing these IDs.