### PR TITLE
FEATURE: experimental read command for bot

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -100,7 +100,9 @@ en:
         summarize: "Summarize"
         image: "Generate image"
         google: "Search Google"
+        read: "Read topic"
       command_description:
+        read: "Reading: %{title}"
         time: "Time in %{timezone} is %{time}"
         summarize: "Summarized <a href='%{url}'>%{title}</a>"
         image: "%{prompt}"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -203,6 +203,7 @@ plugins:
      - image
      - search
      - summarize
+     - read
      - tags
      - time
   ai_helper_add_ai_pm_to_header:

--- a/lib/modules/ai_bot/entry_point.rb
+++ b/lib/modules/ai_bot/entry_point.rb
@@ -35,6 +35,7 @@ module DiscourseAi
         require_relative "commands/summarize_command"
         require_relative "commands/image_command"
         require_relative "commands/google_command"
+        require_relative "commands/read_command"
       end
 
       def inject_into(plugin)

--- a/lib/modules/ai_bot/open_ai_bot.rb
+++ b/lib/modules/ai_bot/open_ai_bot.rb
@@ -95,6 +95,7 @@ module DiscourseAi
             Commands::TimeCommand,
             Commands::SearchCommand,
             Commands::SummarizeCommand,
+            Commands::ReadCommand,
           ].tap do |cmds|
             cmds << Commands::TagsCommand if SiteSetting.tagging_enabled
             cmds << Commands::ImageCommand if SiteSetting.ai_stability_api_key.present?

--- a/spec/lib/modules/ai_bot/commands/read_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/read_command_spec.rb
@@ -1,0 +1,20 @@
+#frozen_string_literal: true
+
+RSpec.describe DiscourseAi::AiBot::Commands::ReadCommand do
+  fab!(:bot_user) { User.find(DiscourseAi::AiBot::EntryPoint::GPT3_5_TURBO_ID) }
+
+  describe "#process" do
+    it "can read a topic" do
+      post1 = Fabricate(:post, raw: "hello there")
+      Fabricate(:post, raw: "mister sam", topic: post1.topic)
+
+      read = described_class.new(bot_user, post1)
+
+      results = read.process(topic_id: post1.topic_id)
+
+      expect(results[:topic_id]).to eq(post1.topic_id)
+      expect(results[:content]).to include("hello")
+      expect(results[:content]).to include("sam")
+    end
+  end
+end


### PR DESCRIPTION
This command is useful for reading a topics content. It allows us to perform
critical analysis or suggest answers.

Given 8k token limit in GPT-4 I hardcoded reading to 1500 tokens, but we can
follow up and allow larger windows on models that support more tokens.

On local testing even in this limited form this can be very useful.
