### PR TITLE
FEATURE: support 16k and 32k variants for Azure GPT

### DIFF
--- a/assets/javascripts/discourse/connectors/composer-after-composer-editor/composer-open.js
+++ b/assets/javascripts/discourse/connectors/composer-after-composer-editor/composer-open.js
@@ -20,7 +20,10 @@ export default class extends Component {
 
   @computed("composerModel.targetRecipients")
   get isAiBotChat() {
-    if (this.composerModel.targetRecipients) {
+    if (
+      this.composerModel.targetRecipients &&
+      this.currentUser.ai_enabled_chat_bots
+    ) {
       let reciepients = this.composerModel.targetRecipients.split(",");
 
       return this.currentUser.ai_enabled_chat_bots.any((bot) =>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -31,8 +31,10 @@ en:
     ai_nsfw_flag_threshold_sexy: "Threshold for an image classified as sexy to be considered NSFW."
     ai_nsfw_models: "Models to use for NSFW inference."
 
-    ai_openai_gpt35_url: "Custom URL used for GPT 3.5 chat completions. (Azure: MUST support function calling and ideally is a GPT3.5 16K endpoint)"
+    ai_openai_gpt35_url: "Custom URL used for GPT 3.5 chat completions. (for Azuer support)"
+    ai_openai_gpt35_16k_url: "Custom URL used for GPT 3.5 16k chat completions. (for Azure support)"
     ai_openai_gpt4_url: "Custom URL used for GPT 4 chat completions. (for Azure support)"
+    ai_openai_gpt4_32k_url: "Custom URL used for GPT 4 32k chat completions. (for Azure support)"
     ai_openai_embeddings_url: "Custom URL used for the OpenAI embeddings API. (in the case of Azure it can be: https://COMPANY.openai.azure.com/openai/deployments/DEPLOYMENT/embeddings?api-version=2023-05-15)"
     ai_openai_api_key: "API key for OpenAI API"
     ai_anthropic_api_key: "API key for Anthropic API"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -89,7 +89,9 @@ plugins:
      - nsfw_detector
 
   ai_openai_gpt35_url: "https://api.openai.com/v1/chat/completions"
+  ai_openai_gpt35_16k_url: "https://api.openai.com/v1/chat/completions"
   ai_openai_gpt4_url: "https://api.openai.com/v1/chat/completions"
+  ai_openai_gpt4_32k_url: "https://api.openai.com/v1/chat/completions"
   ai_openai_embeddings_url: "https://api.openai.com/v1/embeddings"
   ai_openai_api_key:
     default: ""

--- a/lib/modules/ai_bot/open_ai_bot.rb
+++ b/lib/modules/ai_bot/open_ai_bot.rb
@@ -17,12 +17,12 @@ module DiscourseAi
         # also allow for an extra 500 or so spare tokens
         #
         # 2500 are the max reply tokens
-        # Then we have 400 or so for the full function suite
+        # Then we have 450 or so for the full function suite
         # 100 additional for growth around function calls
         if bot_user.id == DiscourseAi::AiBot::EntryPoint::GPT4_ID
-          8192 - 3000
+          8192 - 3050
         else
-          16_384 - 3000
+          16_384 - 3050
         end
       end
 
@@ -110,7 +110,7 @@ module DiscourseAi
       end
 
       def model_for(low_cost: false)
-        return "gpt-4-0613" if bot_user.id == DiscourseAi::AiBot::EntryPoint::GPT4_ID && !low_cost
+        return "gpt-4" if bot_user.id == DiscourseAi::AiBot::EntryPoint::GPT4_ID && !low_cost
         "gpt-3.5-turbo-16k"
       end
 

--- a/lib/shared/inference/openai_completions.rb
+++ b/lib/shared/inference/openai_completions.rb
@@ -62,9 +62,17 @@ module ::DiscourseAi
       )
         url =
           if model.include?("gpt-4")
-            URI(SiteSetting.ai_openai_gpt4_url)
+            if model.include?("32k")
+              URI(SiteSetting.ai_openai_gpt4_32k_url)
+            else
+              URI(SiteSetting.ai_openai_gpt4_url)
+            end
           else
-            URI(SiteSetting.ai_openai_gpt35_url)
+            if model.include?("16k")
+              URI(SiteSetting.ai_openai_gpt35_16k_url)
+            else
+              URI(SiteSetting.ai_openai_gpt35_url)
+            end
           end
         headers = { "Content-Type" => "application/json" }
 


### PR DESCRIPTION
Azure requires a single HTTP endpoint per type of completion.

The settings: `ai_openai_gpt35_16k_url` and `ai_openai_gpt4_32k_url` can be
used now to configure the extra endpoints

This amends token limit which was off a bit due to function calls and fixes
a minor JS issue where we were not testing for a property
