### PR TITLE
DEV: Categorize plugin settings into discourse_ai

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_ai: "Discourse AI"
   js:
     discourse_ai:
       modals:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_ai:
   discourse_ai_enabled:
     default: true
     client: true


### PR DESCRIPTION
Moving the plugin settings into a more specific category
makes them easier to find in the plugin UI and removes
them from the generic "Plugins" tab.

![image](https://github.com/discourse/discourse-ai/assets/920448/bd3f52bc-d953-446f-b762-afd828d7e053)
