### PR TITLE
FIX: Display related topics when scrolling to the bottom of a topic.

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-more-content/related-topics.hbs
+++ b/assets/javascripts/discourse/connectors/topic-more-content/related-topics.hbs
@@ -3,8 +3,8 @@
   class="more-topics__list {{if this.hidden 'hidden'}}"
   role="complementary"
   aria-labelledby="related-topics-title"
-  data-mobile-title={{i18n "discourse_ai.related_topics.pill"}}
-  data-list-id={{this.listId}}
+  {{did-insert this.registerList}}
+  {{will-destroy this.removeList}}
 >
   <h3 id="related-topics-title" class="more-topics__list-title">
     {{i18n "discourse_ai.related_topics.title"}}

--- a/assets/javascripts/discourse/connectors/topic-more-content/related-topics.js
+++ b/assets/javascripts/discourse/connectors/topic-more-content/related-topics.js
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
-import { computed } from "@ember/object";
+import { action, computed } from "@ember/object";
+import I18n from "I18n";
 
 export default class extends Component {
   static shouldRender(args) {
@@ -13,14 +14,28 @@ export default class extends Component {
 
   listId = "related-topics";
 
-  @computed("moreTopicsPreferenceTracking.preference")
+  @computed("moreTopicsPreferenceTracking.selectedTab")
   get hidden() {
-    return this.moreTopicsPreferenceTracking.preference !== this.listId;
+    return this.moreTopicsPreferenceTracking.selectedTab !== this.listId;
   }
 
   get relatedTopics() {
     return this.args.outletArgs.model.related_topics.map((topic) =>
       this.store.createRecord("topic", topic)
     );
+  }
+
+  @action
+  registerList() {
+    this.moreTopicsPreferenceTracking.registerTopicList({
+      name: I18n.t("discourse_ai.related_topics.pill"),
+      id: this.listId,
+      icon: "magic",
+    });
+  }
+
+  @action
+  removeList() {
+    this.moreTopicsPreferenceTracking.removeTopicList(this.listId);
   }
 }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -165,7 +165,9 @@ plugins:
      - text-embedding-ada-002
      - multilingual-e5-large
   ai_embeddings_generate_for_pms: false
-  ai_embeddings_semantic_related_topics_enabled: false
+  ai_embeddings_semantic_related_topics_enabled: 
+    default: false
+    client: true
   ai_embeddings_semantic_related_topics: 5
   ai_embeddings_semantic_related_include_closed_topics: true
   ai_embeddings_pg_connection_string: ""


### PR DESCRIPTION
Besides updating the connector using the new tracking preference service interface, this PR fixes a bug where due to `ai_embeddings_semantic_related_topics_enabled` not having `client: true` the initializer never ran, and we didn't show the related topics list when scrolling to the bottom of a long topic.