### PR TITLE
FIX: Show AI helper only if in allowed groups

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -12,10 +12,18 @@ import { inject as service } from "@ember/service";
 
 export default class AiHelperContextMenu extends Component {
   static shouldRender(outletArgs, helper) {
-    return (
+    const helperEnabled =
       helper.siteSettings.discourse_ai_enabled &&
-      helper.siteSettings.composer_ai_helper_enabled
+      helper.siteSettings.composer_ai_helper_enabled;
+
+    const allowedGroups = helper.siteSettings.ai_helper_allowed_groups
+      .split("|")
+      .map((id) => parseInt(id, 10));
+    const canUseAssistant = helper.currentUser?.groups.some((g) =>
+      allowedGroups.includes(g.id)
     );
+
+    return helperEnabled && canUseAssistant;
   }
 
   @service siteSettings;


### PR DESCRIPTION
This PR is a follow up to https://github.com/discourse/discourse-ai/pull/148 and ensures that the AI helper context menu is shown only if the current user is a member of one/more of the  `ai_helper_allowed_groups`