### PR TITLE
FIX: Add check for PMs before showing AI helper context menu

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -23,6 +23,12 @@ export default class AiHelperContextMenu extends Component {
       allowedGroups.includes(g.id)
     );
 
+    const canShowInPM = helper.siteSettings.ai_helper_allowed_in_pm;
+
+    if (outletArgs.composer.privateMessage) {
+      return helperEnabled && canUseAssistant && canShowInPM;
+    }
+
     return helperEnabled && canUseAssistant;
   }
 


### PR DESCRIPTION
This PR is another follow up to https://github.com/discourse/discourse-ai/pull/148, which adds a check to ensure the context menu is conditionally shown in PMs based on the site setting: `ai_helper_allowed_in_pm`