### PR TITLE
FIX: Context menu not appearing in Firefox

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -85,12 +85,25 @@ export default class AiHelperContextMenu extends Component {
   }
 
   @bind
-  selectionChanged(event) {
-    if (!event.target.activeElement.classList.contains("d-editor-input")) {
+  selectionChanged() {
+    if (document.activeElement !== this._dEditorInput) {
       return;
     }
 
-    if (window.getSelection().toString().length === 0) {
+    const canSelect = Boolean(
+      window.getSelection() &&
+        document.activeElement &&
+        document.activeElement.value
+    );
+
+    this.selectedText = canSelect
+      ? document.activeElement.value.substring(
+          document.activeElement.selectionStart,
+          document.activeElement.selectionEnd
+        )
+      : "";
+
+    if (this.selectedText.length === 0) {
       if (this.loading) {
         // prevent accidentally closing context menu while results loading
         return;
@@ -100,7 +113,6 @@ export default class AiHelperContextMenu extends Component {
       return;
     }
 
-    this.selectedText = event.target.getSelection().toString();
     this._onSelectionChanged();
   }
 


### PR DESCRIPTION
## This PR fixes some issues where the context menu would not appear in Firefox.

### 1. `event.target`
In Firefox, `event.target.activeElement` does not exist, instead we need to use `event.target`, however the issue is that in all other browsers `event.target` inside `<textarea>` elements points to the HTML DOM, not a specific element. In all other browsers we need to use `event.target.activeElement` to point to the `<textarea>`

To resolve this so that works on all browsers we use `document.activeElement` and compare it with `this._dEditorInput` to see if it is the same.

### 2. `window.getSelection().toString()`
In Firefox, `window.getSelection().toString()` will always result in an empty string. Due to this bug in Firefox, we instead use `selectionStart` and `selectionEnd` to identify what is selected from the `document.activeElement`'s value.

This PR has been tested on Firefox, Chromium, and Safari to ensure all functionality works correctly.