### PR TITLE
FIX: Pages with small composers breaking

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -25,7 +25,7 @@ export default class AiHelperContextMenu extends Component {
 
     const canShowInPM = helper.siteSettings.ai_helper_allowed_in_pm;
 
-    if (outletArgs.composer.privateMessage) {
+    if (outletArgs?.composer?.privateMessage) {
       return helperEnabled && canUseAssistant && canShowInPM;
     }
 


### PR DESCRIPTION
This PR fixes a bug that causes pages with small composers to crash

![Screenshot 2023-08-23 at 14 09 57](https://github.com/discourse/discourse-ai/assets/30090424/316521b0-5c15-4338-9425-96651e3e72f0)
