### PR TITLE
DEV: Remove context menu timeout

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -7,7 +7,6 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { createPopper } from "@popperjs/core";
 import { caretPosition, getCaretPosition } from "discourse/lib/utilities";
-import discourseLater from "discourse-common/lib/later";
 import { inject as service } from "@ember/service";
 
 export default class AiHelperContextMenu extends Component {

--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -237,13 +237,6 @@ export default class AiHelperContextMenu extends Component {
       .finally(() => {
         this.loading = false;
         this._dEditorInput.classList.remove("loading");
-
-        // Make reset options disappear by closing the context menu after 5 seconds
-        if (this.menuState === this.CONTEXT_MENU_STATES.resets) {
-          discourseLater(() => {
-            this.closeContextMenu();
-          }, 5000);
-        }
       });
   }
 

--- a/spec/system/ai_helper/ai_composer_helper_spec.rb
+++ b/spec/system/ai_helper/ai_composer_helper_spec.rb
@@ -143,22 +143,6 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
         expect(ai_helper_context_menu).to be_showing_resets
       end
 
-      it "hides reset options after 5 seconds" do
-        trigger_context_menu(OpenAiCompletionsInferenceStubs.spanish_text)
-        ai_helper_context_menu.click_ai_button
-        ai_helper_context_menu.select_helper_model(
-          OpenAiCompletionsInferenceStubs.text_mode_to_id(mode),
-        )
-
-        wait_for do
-          composer.composer_input.value == OpenAiCompletionsInferenceStubs.translated_response.strip
-        end
-
-        expect(ai_helper_context_menu).to be_showing_resets
-        sleep 5
-        expect(ai_helper_context_menu).to be_not_showing_resets
-      end
-
       it "reverts results when Undo button is clicked" do
         trigger_context_menu(OpenAiCompletionsInferenceStubs.spanish_text)
         ai_helper_context_menu.click_ai_button


### PR DESCRIPTION
Previously after generating with AI, the "reset" options (Undo / Try Again) will automatically be hidden after 5 seconds. This however, is annoying when you are still reading the changes.

This PR removes the timeout and only relies on clicking outside to hide the reset options
![Screenshot 2023-08-23 at 14 28 17](https://github.com/discourse/discourse-ai/assets/30090424/c32bfa35-b181-4e3f-95c7-21934f1a14ab)
