### PR TITLE
DEV: Don’t use `Chat::MessageCreator` in specs

### DIFF
--- a/spec/lib/modules/toxicity/entry_point_spec.rb
+++ b/spec/lib/modules/toxicity/entry_point_spec.rb
@@ -38,16 +38,17 @@ describe DiscourseAi::Toxicity::EntryPoint do
 
     context "when creating a chat message" do
       fab!(:public_chat_channel) { Fabricate(:chat_channel) }
-      let(:creator) do
-        Chat::MessageCreator.new(
-          chat_channel: public_chat_channel,
-          user: user,
-          content: "This is my new test",
-        )
-      end
 
       it "queues a job when creating a chat message" do
-        expect { creator.create }.to change(Jobs::ToxicityClassifyChatMessage.jobs, :size).by(1)
+        expect {
+          Fabricate(
+            :chat_message,
+            chat_channel: public_chat_channel,
+            user: user,
+            message: "This is my new test",
+            use_service: true,
+          )
+        }.to change(Jobs::ToxicityClassifyChatMessage.jobs, :size).by(1)
       end
     end
 


### PR DESCRIPTION
As message creation is being rewritten in
https://github.com/discourse/discourse/pull/22390, a new way of using the underlying service to create chat messages has been implemented in https://github.com/discourse/discourse/pull/23222.

This patch uses the new fabricator option which will prevent breaking specs from this plugin when the main PR will be merged.