### PR TITLE
DEV: Add review menu state

### DIFF
--- a/assets/javascripts/discourse/components/modal/diff-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/diff-modal.gjs
@@ -1,0 +1,48 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import DButton from "discourse/components/d-button";
+import DModal from "discourse/components/d-modal";
+import DModalCancel from "discourse/components/d-modal-cancel";
+import I18n from "I18n";
+import { htmlSafe } from "@ember/template";
+
+const t = I18n.t.bind(I18n);
+
+export default class ModalDiffModal extends Component {
+  <template>
+    <DModal
+      class="composer-ai-helper-modal"
+      @title={{t "discourse_ai.ai_helper.context_menu.changes"}}
+      @closeModal={{@closeModal}}
+    >
+      <:body>
+        {{#if @diff}}
+          {{htmlSafe @diff}}
+        {{else}}
+          <div class="composer-ai-helper-modal__old-value">
+            {{@oldValue}}
+          </div>
+
+          <div class="composer-ai-helper-modal__new-value">
+            {{@newValue}}
+          </div>
+        {{/if}}
+      </:body>
+
+      <:footer>
+        <DButton
+          class="btn-primary confirm"
+          @action={{this.triggerConfirmChanges}}
+          @label="discourse_ai.ai_helper.context_menu.confirm"
+        />
+        <DModalCancel @close={{@closeModal}} />
+      </:footer>
+    </DModal>
+  </template>
+  
+  @action
+  triggerConfirmChanges() {
+    this.args.closeModal();
+    this.args.confirm();
+  }
+}

--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.hbs
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.hbs
@@ -51,6 +51,34 @@
           </li>
         </ul>
 
+      {{else if (eq this.menuState this.CONTEXT_MENU_STATES.review)}}
+        <ul class="ai-helper-context-menu__review">
+          <li>
+            <DButton
+              @icon="exchange-alt"
+              @label="discourse_ai.ai_helper.context_menu.view_changes"
+              @action={{this.viewChanges}}
+              class="btn-flat view-changes"
+            />
+          </li>
+          <li>
+            <DButton
+              @icon="undo"
+              @label="discourse_ai.ai_helper.context_menu.revert"
+              @action={{this.undoAIAction}}
+              class="btn-flat revert"
+            />
+          </li>
+          <li>
+            <DButton
+              @icon="check"
+              @label="discourse_ai.ai_helper.context_menu.confirm"
+              @action={{this.confirmChanges}}
+              class="btn-flat confirm"
+            />
+          </li>
+        </ul>
+
       {{else if (eq this.menuState this.CONTEXT_MENU_STATES.resets)}}
         <ul class="ai-helper-context-menu__resets">
           <li>
@@ -76,3 +104,13 @@
     </div>
   {{/if}}
 </div>
+
+{{#if this.showDiffModal}}
+  <Modal::DiffModal
+    @confirm={{this.confirmChanges}}
+    @diff={{this.diff}}
+    @oldValue={{this.selectedText}}
+    @newValue={{this.newSelectedText}}
+    @closeModal={{fn (mut this.showDiffModal) false}}
+  />
+{{/if}}

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -5,7 +5,8 @@
     margin: 10px 0 10px 0;
   }
 
-  .text-preview {
+  .text-preview,
+  .inline-diff {
     ins {
       background-color: var(--success-low);
       text-decoration: underline;
@@ -18,6 +19,17 @@
     .preview-area {
       height: 200px;
     }
+  }
+
+  &__old-value {
+    background-color: var(--danger-low);
+    color: var(--danger);
+    margin-bottom: 1rem;
+  }
+
+  &__new-value {
+    background-color: var(--success-low);
+    color: var(--success);
   }
 
   .selection-hint {
@@ -34,7 +46,7 @@
   background: var(--secondary);
   box-shadow: var(--shadow-dropdown);
   padding: 0.25rem;
-  max-width: 15rem;
+  max-width: 25rem;
   border: 1px solid var(--primary-low);
   list-style: none;
   z-index: 999;
@@ -75,6 +87,12 @@
   }
 
   &__resets {
+    display: flex;
+    align-items: center;
+    flex-flow: row wrap;
+  }
+
+  &__review {
     display: flex;
     align-items: center;
     flex-flow: row wrap;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -22,6 +22,10 @@ en:
           loading: "AI is generating"
           cancel: "Cancel"
           regen: "Try Again"
+          view_changes: "View Changes"
+          confirm: "Confirm"
+          revert: "Revert"
+          changes: "Changes"
       reviewables:
         model_used: "Model used:"
         accuracy: "Accuracy:"

--- a/spec/system/page_objects/components/ai_helper_context_menu.rb
+++ b/spec/system/page_objects/components/ai_helper_context_menu.rb
@@ -10,6 +10,7 @@ module PageObjects
       SUGGESTIONS_STATE_SELECTOR = "#{CONTEXT_MENU_SELECTOR}__suggestions"
       LOADING_STATE_SELECTOR = "#{CONTEXT_MENU_SELECTOR}__loading"
       RESETS_STATE_SELECTOR = "#{CONTEXT_MENU_SELECTOR}__resets"
+      REVIEW_STATE_SELECTOR = "#{CONTEXT_MENU_SELECTOR}__review"
 
       def click_ai_button
         find("#{TRIGGER_STATE_SELECTOR} .btn").click
@@ -25,6 +26,18 @@ module PageObjects
 
       def click_undo_button
         find("#{RESETS_STATE_SELECTOR} .undo").click
+      end
+
+      def click_revert_button
+        find("#{REVIEW_STATE_SELECTOR} .revert").click
+      end
+
+      def click_view_changes_button
+        find("#{REVIEW_STATE_SELECTOR} .view-changes").click
+      end
+
+      def click_confirm_button
+        find("#{REVIEW_STATE_SELECTOR} .confirm").click
       end
 
       def press_undo_keys

--- a/spec/system/page_objects/modals/diff_modal.rb
+++ b/spec/system/page_objects/modals/diff_modal.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Modals
+    class DiffModal < PageObjects::Modals::Base
+      def visible?
+        page.has_css?(".composer-ai-helper-modal", wait: 5)
+      end
+
+      def confirm_changes
+        find(".modal-footer button.confirm", wait: 5).click
+      end
+
+      def old_value
+        find(".composer-ai-helper-modal__old-value").text
+      end
+
+      def new_value
+        find(".composer-ai-helper-modal__new-value").text
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an intermediary step to the AI Helper context menu. It adds a confirmation step where you can <kbd>View Changes</kbd> <kbd>Revert</kbd> <kbd>Apply</kbd>. If you click <kbd>View Changes</kbd> a modal is shown with the changes that are made to the text by AI.

https://github.com/discourse/discourse-ai/assets/30090424/9fa8505f-432f-439f-bb63-8d886739c02e

