### PR TITLE
DEV: Preload prompt list on component initialization

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -62,6 +62,15 @@ export default class AiHelperContextMenu extends Component {
   @tracked _dEditorInput;
   @tracked _contextMenu;
 
+  constructor() {
+    super(...arguments);
+
+    // Fetch prompts only if it hasn't been fetched yet
+    if (this.helperOptions.length === 0) {
+      this.loadPrompts();
+    }
+  }
+
   willDestroy() {
     super.willDestroy(...arguments);
     document.removeEventListener("selectionchange", this.selectionChanged);


### PR DESCRIPTION
Previously the prompts would be fetched on first loading the prompt section and then cached, however, if the network was slow or the request failed it would look obvious while interacting with the context menu component.

This PR ensures the prompts are preloaded when the component is first initialized (i.e. composer is opened) so there is no delay when clicking the AI button.