### PR TITLE
UX: Prevent context menu overflow outside of container

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -192,12 +192,35 @@ export default class AiHelperContextMenu extends Component {
     this.menuState = this.CONTEXT_MENU_STATES.review;
   }
 
+  handleBoundaries() {
+    const boundaryElement = document
+      .querySelector(".d-editor-textarea-wrapper")
+      .getBoundingClientRect();
+
+    const contextMenuRect = this._contextMenu.getBoundingClientRect();
+
+    if (contextMenuRect.top < boundaryElement.top) {
+      this._contextMenu.classList.add("out-of-bounds");
+    } else {
+      this._contextMenu.classList.remove("out-of-bounds");
+    }
+
+    if (contextMenuRect.bottom > boundaryElement.bottom) {
+      this._contextMenu.classList.add("out-of-bounds");
+    } else {
+      this._contextMenu.classList.remove("out-of-bounds");
+    }
+  }
+
   @afterRender
   positionContextMenu() {
     this._contextMenu = document.querySelector(".ai-helper-context-menu");
     this.caretCoords = getCaretPosition(this._dEditorInput, {
       pos: caretPosition(this._dEditorInput),
     });
+
+    // prevent overflow of context menu outside of editor
+    this.handleBoundaries();
 
     this.virtualElement = {
       getBoundingClientRect: this.generateGetBoundingClientRect(

--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -201,11 +201,7 @@ export default class AiHelperContextMenu extends Component {
 
     if (contextMenuRect.top < boundaryElement.top) {
       this._contextMenu.classList.add("out-of-bounds");
-    } else {
-      this._contextMenu.classList.remove("out-of-bounds");
-    }
-
-    if (contextMenuRect.bottom > boundaryElement.bottom) {
+    } else if (contextMenuRect.bottom > boundaryElement.bottom) {
       this._contextMenu.classList.add("out-of-bounds");
     } else {
       this._contextMenu.classList.remove("out-of-bounds");

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -51,6 +51,10 @@
   list-style: none;
   z-index: 999;
 
+  &.out-of-bounds {
+    visibility: hidden;
+  }
+
   ul {
     margin: 0;
     list-style: none;


### PR DESCRIPTION
This PR resolves a UX issue when the context menu was able to overflow outside of the container:

## Before
https://github.com/discourse/discourse-ai/assets/30090424/bf073209-1167-489f-a7a5-8ea8d461c627

## After
https://github.com/discourse/discourse-ai/assets/30090424/cf8f762a-7db3-4b07-83dd-10a9ef191720

