### PR TITLE
DEV: Dynamically set popper placement

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -45,6 +45,7 @@ export default class AiHelperContextMenu extends Component {
   @tracked lastUsedOption = null;
   @tracked showDiffModal = false;
   @tracked diff;
+  @tracked popperPosition = "top-start";
 
   CONTEXT_MENU_STATES = {
     triggers: "TRIGGERS",
@@ -205,18 +206,34 @@ export default class AiHelperContextMenu extends Component {
   }
 
   handleBoundaries() {
-    const boundaryElement = document
+    const textAreaWrapper = document
       .querySelector(".d-editor-textarea-wrapper")
       .getBoundingClientRect();
+    const buttonBar = document
+      .querySelector(".d-editor-button-bar")
+      .getBoundingClientRect();
+
+    const boundaryElement = {
+      top: buttonBar.bottom,
+      bottom: textAreaWrapper.bottom,
+    };
 
     const contextMenuRect = this._contextMenu.getBoundingClientRect();
 
+    // Hide context menu if it's scrolled out of bounds:
     if (contextMenuRect.top < boundaryElement.top) {
       this._contextMenu.classList.add("out-of-bounds");
     } else if (contextMenuRect.bottom > boundaryElement.bottom) {
       this._contextMenu.classList.add("out-of-bounds");
     } else {
       this._contextMenu.classList.remove("out-of-bounds");
+    }
+
+    // Position context menu at based on if interfering with button bar
+    if (this.caretCoords.y - contextMenuRect.height < boundaryElement.top) {
+      this.popperPosition = "bottom-start";
+    } else {
+      this.popperPosition = "top-start";
     }
   }
 
@@ -240,7 +257,7 @@ export default class AiHelperContextMenu extends Component {
     };
 
     this._popper = createPopper(this.virtualElement, this._contextMenu, {
-      placement: "top-start",
+      placement: this.popperPosition,
       modifiers: [
         {
           name: "offset",

--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -45,7 +45,7 @@ export default class AiHelperContextMenu extends Component {
   @tracked lastUsedOption = null;
   @tracked showDiffModal = false;
   @tracked diff;
-  @tracked popperPosition = "top-start";
+  @tracked popperPlacement = "top-start";
 
   CONTEXT_MENU_STATES = {
     triggers: "TRIGGERS",
@@ -231,9 +231,9 @@ export default class AiHelperContextMenu extends Component {
 
     // Position context menu at based on if interfering with button bar
     if (this.caretCoords.y - contextMenuRect.height < boundaryElement.top) {
-      this.popperPosition = "bottom-start";
+      this.popperPlacement = "bottom-start";
     } else {
-      this.popperPosition = "top-start";
+      this.popperPlacement = "top-start";
     }
   }
 
@@ -257,7 +257,7 @@ export default class AiHelperContextMenu extends Component {
     };
 
     this._popper = createPopper(this.virtualElement, this._contextMenu, {
-      placement: this.popperPosition,
+      placement: this.popperPlacement,
       modifiers: [
         {
           name: "offset",

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -53,6 +53,7 @@
 
   &.out-of-bounds {
     visibility: hidden;
+    pointer-events: none;
   }
 
   ul {


### PR DESCRIPTION
This PR updates the placement of the context menu so that it will be placed at the top of the selection **except** when near the button bar. In such cases it will be placed at the bottom of the selection. This is done to ensure that the context menu doesn't interfere with the button bar and selecting buttons on it.

### Preview

https://github.com/discourse/discourse-ai/assets/30090424/4bdf990d-040d-48a2-a791-78f649aa69e8

