### PR TITLE
FIX: Show warning when trying to generate suggestions without content

### DIFF
--- a/assets/javascripts/discourse/connectors/after-composer-title-input/ai-title-suggester.gjs
+++ b/assets/javascripts/discourse/connectors/after-composer-title-input/ai-title-suggester.gjs
@@ -6,6 +6,9 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { bind } from "discourse-common/utils/decorators";
+import { inject as service } from "@ember/service";
+import I18n from "I18n";
+
 
 export default class AITitleSuggester extends Component {
   <template>
@@ -33,6 +36,7 @@ export default class AITitleSuggester extends Component {
     {{/if}}
   </template>
 
+  @service dialog;
   @tracked loading = false;
   @tracked showMenu = false;
   @tracked generatedTitleSuggestions = [];
@@ -54,10 +58,6 @@ export default class AITitleSuggester extends Component {
   }
 
   get disableSuggestionButton() {
-    if (this.composerInput?.length === 0) {
-      return true;
-    }
-
     return this.loading;
   }
 
@@ -94,6 +94,10 @@ export default class AITitleSuggester extends Component {
 
   @action
   async suggestTitles() {
+    if (this.composerInput?.length === 0) {
+      return this.dialog.alert(I18n.t("discourse_ai.ai_helper.missing_content"));
+    }
+
     this.loading = true;
     this.suggestTitleIcon = "spinner";
 

--- a/assets/javascripts/discourse/connectors/after-composer-title-input/ai-title-suggester.gjs
+++ b/assets/javascripts/discourse/connectors/after-composer-title-input/ai-title-suggester.gjs
@@ -50,10 +50,14 @@ export default class AITitleSuggester extends Component {
   }
 
   get composerInput() {
-    return document.querySelector(".d-editor-input").value || this.args.outletArgs.composer.reply;
+    return document.querySelector(".d-editor-input")?.value || this.args.outletArgs.composer.reply;
   }
 
   get disableSuggestionButton() {
+    if (this.composerInput?.length === 0) {
+      return true;
+    }
+
     return this.loading;
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -17,6 +17,7 @@ en:
         description: "Choose one of the options below, and the AI will suggest you a new version of the text."
         selection_hint: "Hint: You can also select a portion of the text before opening the helper to rewrite only that."
         suggest_titles: "Suggest titles with AI"
+        missing_content: "Please enter some content to generate suggestions."
         context_menu:
           trigger: "AI"
           undo: "Undo"


### PR DESCRIPTION
This PR doesn't submit the request and instead gives a popup message when you try to suggest titles without content

![Screenshot 2023-08-29 at 11 56 34](https://github.com/discourse/discourse-ai/assets/30090424/1ee17ef4-6ccf-4718-bf04-92c53dca6e00)
