### PR TITLE
FIX: ai_bot_allowed_groups now works with restricted visibility

### DIFF
--- a/assets/javascripts/initializers/ai-bot-replies.js
+++ b/assets/javascripts/initializers/ai-bot-replies.js
@@ -172,18 +172,11 @@ export default {
   initialize(container) {
     const settings = container.lookup("service:site-settings");
     const user = container.lookup("service:current-user");
-    const aiBotEnaled =
-      settings.discourse_ai_enabled && settings.ai_bot_enabled;
 
-    const aiBotsAllowedGroups = settings.ai_bot_allowed_groups
-      .split("|")
-      .map((id) => parseInt(id, 10));
-    const canInteractWithAIBots = user?.groups.some((g) =>
-      aiBotsAllowedGroups.includes(g.id)
-    );
-
-    if (aiBotEnaled && canInteractWithAIBots) {
-      withPluginApi("1.6.0", attachHeaderIcon);
+    if (user?.ai_enabled_chat_bots) {
+      if (settings.ai_bot_add_to_header) {
+        withPluginApi("1.6.0", attachHeaderIcon);
+      }
       withPluginApi("1.6.0", initializeAIBotReplies);
       withPluginApi("1.6.0", initializePersonaDecorator);
     }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -190,7 +190,6 @@ discourse_ai:
     default: false
     client: true
   ai_bot_allowed_groups:
-    client: true
     type: group_list
     list_type: compact
     default: "3|14" # 3: @staff, 14: @trust_level_4

--- a/spec/system/ai_bot/ai_bot_helper_spec.rb
+++ b/spec/system/ai_bot/ai_bot_helper_spec.rb
@@ -1,14 +1,24 @@
 # frozen_string_literal: true
 RSpec.describe "AI chat channel summarization", type: :system, js: true do
-  fab!(:user) { Fabricate(:admin) }
+  fab!(:user) { Fabricate(:user) }
+  fab!(:group) { Fabricate(:group, visibility_level: Group.visibility_levels[:staff]) }
 
   before do
-    sign_in(user)
     SiteSetting.ai_bot_enabled = true
     SiteSetting.ai_bot_enabled_chat_bots = "gpt-4|gpt-3.5-turbo"
+    SiteSetting.ai_bot_allowed_groups = group.id.to_s
+    sign_in(user)
   end
 
-  it "shows the AI bot button, which is clickable" do
+  it "does not show AI button to users not in group" do
+    visit "/latest"
+    expect(page).not_to have_selector(".ai-bot-button")
+  end
+
+  it "shows the AI bot button, which is clickable (even if group is hidden)" do
+    group.add(user)
+    group.save
+
     visit "/latest"
     expect(page).to have_selector(".ai-bot-button")
     find(".ai-bot-button").click
@@ -18,5 +28,9 @@ RSpec.describe "AI chat channel summarization", type: :system, js: true do
 
     # composer is open
     expect(page).to have_selector(".d-editor-container")
+
+    SiteSetting.ai_bot_add_to_header = false
+    visit "/latest"
+    expect(page).not_to have_selector(".ai-bot-button")
   end
 end


### PR DESCRIPTION
Previous to this change we relied on client side settings to
determine if an end user has access to the ai bot.

This meant that if a user was not aware they are a member of a
group (as it is with restricted visibility ones) they would not
see the bot button.

All checking has now moved to the server side, and tests were
added to cover.
