### PR TITLE
FIX: Flaky spec

### DIFF
--- a/spec/system/ai_helper/ai_composer_helper_spec.rb
+++ b/spec/system/ai_helper/ai_composer_helper_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
   let(:diff_modal) { PageObjects::Modals::DiffModal.new }
   let(:ai_suggestion_dropdown) { PageObjects::Components::AISuggestionDropdown.new }
   fab!(:category) { Fabricate(:category) }
+  fab!(:category_2) { Fabricate(:category) }
   fab!(:video) { Fabricate(:tag) }
   fab!(:music) { Fabricate(:tag) }
   fab!(:cloud) { Fabricate(:tag) }
@@ -317,7 +318,7 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
 
       wait_for { ai_suggestion_dropdown.has_dropdown? }
 
-      ai_suggestion_dropdown.select_suggestion(2)
+      ai_suggestion_dropdown.select_suggestion_by_value(2)
       expected_title = "The Quiet Piece that Moves Literature: A Gaucho's Story"
 
       expect(find("#reply-title").value).to eq(expected_title)
@@ -354,8 +355,8 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
       ai_suggestion_dropdown.click_suggest_category_button
       wait_for { ai_suggestion_dropdown.has_dropdown? }
 
-      suggestion = ai_suggestion_dropdown.suggestion_name(0)
-      ai_suggestion_dropdown.select_suggestion(0)
+      suggestion = "amazing-category-1"
+      ai_suggestion_dropdown.select_suggestion_by_name("amazing-category-1")
       category_selector = page.find(".category-chooser summary")
 
       expect(category_selector["data-name"].downcase.gsub(" ", "-")).to eq(suggestion)
@@ -383,7 +384,7 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
       wait_for { ai_suggestion_dropdown.has_dropdown? }
 
       suggestion = ai_suggestion_dropdown.suggestion_name(0)
-      ai_suggestion_dropdown.select_suggestion(0)
+      ai_suggestion_dropdown.select_suggestion_by_value(0)
       tag_selector = page.find(".mini-tag-chooser summary")
 
       expect(tag_selector["data-name"]).to eq(suggestion)

--- a/spec/system/page_objects/components/ai_suggestion_dropdown.rb
+++ b/spec/system/page_objects/components/ai_suggestion_dropdown.rb
@@ -20,8 +20,12 @@ module PageObjects
         find(TAG_BUTTON_SELECTOR, visible: :all).click
       end
 
-      def select_suggestion(index)
+      def select_suggestion_by_value(index)
         find("#{MENU_SELECTOR} li[data-value=\"#{index}\"]").click
+      end
+
+      def select_suggestion_by_name(name)
+        find("#{MENU_SELECTOR} li[data-name=\"#{name}\"]").click
       end
 
       def suggestion_name(index)


### PR DESCRIPTION
This PR fixes a flaky spec for the category suggester dropdown.

Previously, the spec looked for category by its value attribute and compared the `data-name` to be the same as the suggested name. However, when the Uncategorized category is present and used, it returns `1` for `data-name`. So this spec, ensures that the fabricated category is always used rather than allowing Uncategorized to be used.