### PR TITLE
UX: Change AI Helper toggle icon to sparkles

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.hbs
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.hbs
@@ -5,7 +5,7 @@
         <ul class="ai-helper-context-menu__trigger">
           <li>
             <DButton
-              @icon="magic"
+              @icon="discourse-sparkles"
               @action={{this.toggleAiHelperOptions}}
               @label="discourse_ai.ai_helper.context_menu.trigger"
               class="btn-flat"


### PR DESCRIPTION
This PR adds consistency by changing the AI helper toggle to use `discourse-sparkles` icon instead of FontAwesome's `magic` icon.

## Before
<img width="100" alt="Screenshot 2023-09-05 at 11 53 35" src="https://github.com/discourse/discourse-ai/assets/30090424/19ad4165-8798-40c8-af11-37d6ed480a1c">

## After
<img width="88" alt="Screenshot 2023-09-05 at 11 53 18" src="https://github.com/discourse/discourse-ai/assets/30090424/98767b58-eb23-435c-8c3b-0a71c7efb55b">
