### PR TITLE
FIX: Invalidate semantic search cache entries when hyde or embedding model changes

### DIFF
--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.js
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.js
@@ -16,7 +16,7 @@ export default class extends Component {
 
   @service appEvents;
 
-  @tracked searching = false;
+  @tracked searching = true;
   @tracked collapsedResults = true;
   @tracked results = [];
 
@@ -57,7 +57,7 @@ export default class extends Component {
 
   @bind
   performHyDESearch() {
-    if (!this.searchTerm || !this.searchEnabled || this.searching) {
+    if (!this.searchTerm || !this.searchEnabled) {
       return;
     }
 


### PR DESCRIPTION
Also fixes a bug in the UI where we displaying a no results message before searching.