### PR TITLE
FIX: Flaky Spec

### DIFF
--- a/spec/system/ai_helper/ai_composer_helper_spec.rb
+++ b/spec/system/ai_helper/ai_composer_helper_spec.rb
@@ -342,8 +342,6 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
     before { SiteSetting.ai_embeddings_enabled = true }
 
     it "updates the category with the suggested category" do
-      skip("broken on CI") if ENV["CI"]
-
       response =
         Category
           .take(3)
@@ -357,11 +355,11 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
       ai_suggestion_dropdown.click_suggest_category_button
       wait_for { ai_suggestion_dropdown.has_dropdown? }
 
-      suggestion = "amazing-category-1"
-      ai_suggestion_dropdown.select_suggestion_by_name("amazing-category-1")
+      suggestion = category_2.name
+      ai_suggestion_dropdown.select_suggestion_by_name(category_2.slug)
       category_selector = page.find(".category-chooser summary")
 
-      expect(category_selector["data-name"].downcase.gsub(" ", "-")).to eq(suggestion)
+      expect(category_selector["data-name"]).to eq(suggestion)
     end
   end
 


### PR DESCRIPTION
This PR fixes the flaky spec in `ai_composer_helper_spec.rb`:
`context "when suggesting the category with AI category suggester" do`