### PR TITLE
FIX: Flaky spec in AI Helper modal

### DIFF
--- a/spec/system/ai_helper/ai_composer_helper_spec.rb
+++ b/spec/system/ai_helper/ai_composer_helper_spec.rb
@@ -62,6 +62,9 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
       expect(ai_helper_modal).to be_visible
 
       ai_helper_modal.select_helper_model(OpenAiCompletionsInferenceStubs.text_mode_to_id(mode))
+
+      wait_for { ai_helper_modal.has_diff? == true }
+
       ai_helper_modal.save_changes
 
       expect(composer.composer_input.value).to eq(

--- a/spec/system/page_objects/modals/ai_helper.rb
+++ b/spec/system/page_objects/modals/ai_helper.rb
@@ -19,6 +19,10 @@ module PageObjects
       def select_title_suggestion(option_number)
         find("input#title-suggestion-#{option_number}").click
       end
+
+      def has_diff?
+        has_css?(".text-preview .inline-diff")
+      end
     end
   end
 end


### PR DESCRIPTION
An older spec for AI Helper modal in `ai_composer_helper_spec` has been flaky lately. This PR fixes that by ensuring the content has been generated before trying to click the save button.