### PR TITLE
UX: Prevent input text from covering suggestion button

### DIFF
--- a/assets/javascripts/discourse/components/ai-suggestion-dropdown.gjs
+++ b/assets/javascripts/discourse/components/ai-suggestion-dropdown.gjs
@@ -43,7 +43,6 @@ export default class AISuggestionDropdown extends Component {
   </template>
 
   @service dialog;
-  @service site;
   @service siteSettings;
   @service composer;
   @tracked loading = false;
@@ -106,7 +105,7 @@ export default class AISuggestionDropdown extends Component {
     }
 
     if (this.args.mode === this.SUGGESTION_TYPES.category) {
-    const selectedCategoryId = this.site.categories.find((c) => c.slug === suggestion).id;
+    const selectedCategoryId = this.composer.categories.find((c) => c.slug === suggestion).id;
     composer.set("categoryId", selectedCategoryId);
     return this.#closeMenu();
     }

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -205,7 +205,7 @@
   position: absolute;
   top: 1px;
   right: 1px;
-  background: none;
+  background: var(--secondary);
   border: none;
 }
 


### PR DESCRIPTION
**This PR prevents input text from being covered by the suggestion button.** 
This PR also removes the injected site service as category data is already present via the composer service.

### Before
<img width="131" alt="Screenshot 2023-09-07 at 10 23 19" src="https://github.com/discourse/discourse-ai/assets/30090424/df346a01-892a-4db0-9853-5790257152ff">

### After
<img width="133" alt="Screenshot 2023-09-07 at 10 23 41" src="https://github.com/discourse/discourse-ai/assets/30090424/dd685854-8b9d-454a-8610-911b7db2ffe7">

