### PR TITLE
FIX: Trigger initial semantic search.

### DIFF
--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.hbs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.hbs
@@ -3,6 +3,7 @@
     <div
       class="semantic-search__results"
       {{did-insert this.setup}}
+      {{did-insert this.debouncedSearch}}
       {{will-destroy this.teardown}}
     >
       {{#if this.searching}}


### PR DESCRIPTION
I thought this wasn't neccessary and we could safely rely on the appEvent during the initial search. It only fires if #searchEnabled is true, meaning the search term is valid.