### PR TITLE
FIX: Conditionally render AI suggestion buttons

### DIFF
--- a/assets/javascripts/discourse/connectors/after-composer-category-input/ai-category-suggestion.gjs
+++ b/assets/javascripts/discourse/connectors/after-composer-category-input/ai-category-suggestion.gjs
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
 import AISuggestionDropdown from "../../components/ai-suggestion-dropdown";
 import { inject as service } from "@ember/service";
+import showAIHelper from "../../lib/show-ai-helper";
+
 
 export default class AICategorySuggestion extends Component {
   <template>
@@ -8,6 +10,10 @@ export default class AICategorySuggestion extends Component {
       <AISuggestionDropdown @mode="suggest_category" @composer={{@outletArgs.composer}} class="suggest-category-button"/>
     {{/if}}
   </template>
+
+  static shouldRender(outletArgs, helper) {
+    return showAIHelper(outletArgs, helper);
+  }
 
   @service siteSettings;
 }

--- a/assets/javascripts/discourse/connectors/after-composer-tag-input/ai-tag-suggestion.gjs
+++ b/assets/javascripts/discourse/connectors/after-composer-tag-input/ai-tag-suggestion.gjs
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import AISuggestionDropdown from "../../components/ai-suggestion-dropdown";
 import { inject as service } from "@ember/service";
+import showAIHelper from "../../lib/show-ai-helper";
 
 
 export default class AITagSuggestion extends Component {
@@ -9,6 +10,10 @@ export default class AITagSuggestion extends Component {
       <AISuggestionDropdown @mode="suggest_tags" @composer={{@outletArgs.composer}} class="suggest-tags-button"/>
     {{/if}}
   </template>
+
+  static shouldRender(outletArgs, helper) {
+    return showAIHelper(outletArgs, helper);
+  }
 
   @service siteSettings;
 }

--- a/assets/javascripts/discourse/connectors/after-composer-title-input/ai-title-suggestion.gjs
+++ b/assets/javascripts/discourse/connectors/after-composer-title-input/ai-title-suggestion.gjs
@@ -1,8 +1,13 @@
 import Component from '@glimmer/component';
 import AISuggestionDropdown from "../../components/ai-suggestion-dropdown";
+import showAIHelper from "../../lib/show-ai-helper";
 
 export default class AITitleSuggestion extends Component {
   <template>
     <AISuggestionDropdown @mode="suggest_title" @composer={{@outletArgs.composer}} class="suggest-titles-button" />
   </template>
+
+  static shouldRender(outletArgs, helper) {
+    return showAIHelper(outletArgs, helper);
+  }
 }

--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -8,27 +8,11 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { createPopper } from "@popperjs/core";
 import { caretPosition, getCaretPosition } from "discourse/lib/utilities";
 import { inject as service } from "@ember/service";
+import showAIHelper from "../../lib/show-ai-helper";
 
 export default class AiHelperContextMenu extends Component {
   static shouldRender(outletArgs, helper) {
-    const helperEnabled =
-      helper.siteSettings.discourse_ai_enabled &&
-      helper.siteSettings.composer_ai_helper_enabled;
-
-    const allowedGroups = helper.siteSettings.ai_helper_allowed_groups
-      .split("|")
-      .map((id) => parseInt(id, 10));
-    const canUseAssistant = helper.currentUser?.groups.some((g) =>
-      allowedGroups.includes(g.id)
-    );
-
-    const canShowInPM = helper.siteSettings.ai_helper_allowed_in_pm;
-
-    if (outletArgs?.composer?.privateMessage) {
-      return helperEnabled && canUseAssistant && canShowInPM;
-    }
-
-    return helperEnabled && canUseAssistant;
+    return showAIHelper(outletArgs, helper);
   }
 
   @service siteSettings;

--- a/assets/javascripts/discourse/lib/show-ai-helper.js
+++ b/assets/javascripts/discourse/lib/show-ai-helper.js
@@ -1,0 +1,20 @@
+export default function showAIHelper(outletArgs, helper) {
+  const helperEnabled =
+    helper.siteSettings.discourse_ai_enabled &&
+    helper.siteSettings.composer_ai_helper_enabled;
+
+  const allowedGroups = helper.siteSettings.ai_helper_allowed_groups
+    .split("|")
+    .map((id) => parseInt(id, 10));
+  const canUseAssistant = helper.currentUser?.groups.some((g) =>
+    allowedGroups.includes(g.id)
+  );
+
+  const canShowInPM = helper.siteSettings.ai_helper_allowed_in_pm;
+
+  if (outletArgs?.composer?.privateMessage) {
+    return helperEnabled && canUseAssistant && canShowInPM;
+  }
+
+  return helperEnabled && canUseAssistant;
+}


### PR DESCRIPTION
The AI suggestion buttons should conditionally be rendered based on the same logic we use for the composer AI helper context menu. This PR fixes that by sharing the logic and using it across each button's `shouldRender()` method. This PR also adds some system specs so this issue does not arise again in the future.