### PR TITLE
FEATURE: Add creative persona

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -113,6 +113,9 @@ en:
         researcher:
           name: Researcher
           description: "AI Bot with Google access that can research information for you"
+        creative:
+          name: Creative
+          description: "AI Bot with no external integrations specialized in creative tasks"
       default_pm_prefix: "[Untitled AI bot PM]"
       topic_not_found: "Summary unavailable, topic not found!"
       searching: "Searching for: '%{query}'"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -236,7 +236,7 @@ discourse_ai:
       - time
   ai_bot_enabled_personas:
     type: list
-    default: "general|artist|sql_helper|settings_explorer|researcher"
+    default: "general|artist|sql_helper|settings_explorer|researcher|creative"
     choices:
       - general
       - artist

--- a/lib/modules/ai_bot/entry_point.rb
+++ b/lib/modules/ai_bot/entry_point.rb
@@ -47,6 +47,7 @@ module DiscourseAi
         require_relative "personas/sql_helper"
         require_relative "personas/settings_explorer"
         require_relative "personas/researcher"
+        require_relative "personas/creative"
       end
 
       def inject_into(plugin)

--- a/lib/modules/ai_bot/personas/creative.rb
+++ b/lib/modules/ai_bot/personas/creative.rb
@@ -1,0 +1,19 @@
+#frozen_string_literal: true
+
+module DiscourseAi
+  module AiBot
+    module Personas
+      class Creative < Persona
+        def commands
+          []
+        end
+
+        def system_prompt
+          <<~PROMPT
+            You are a helpful bot
+          PROMPT
+        end
+      end
+    end
+  end
+end

--- a/lib/modules/ai_bot/personas/persona.rb
+++ b/lib/modules/ai_bot/personas/persona.rb
@@ -8,6 +8,7 @@ module DiscourseAi
         personas << Personas::Artist if SiteSetting.ai_stability_api_key.present?
         personas << Personas::SettingsExplorer
         personas << Personas::Researcher if SiteSetting.ai_google_custom_search_api_key.present?
+        personas << Personas::Creative
 
         personas_allowed = SiteSetting.ai_bot_enabled_personas.split("|")
         personas.filter { |persona| personas_allowed.include?(persona.to_s.demodulize.underscore) }

--- a/spec/lib/modules/ai_bot/personas/persona_spec.rb
+++ b/spec/lib/modules/ai_bot/personas/persona_spec.rb
@@ -84,6 +84,7 @@ module DiscourseAi::AiBot::Personas
           Artist,
           SettingsExplorer,
           Researcher,
+          Creative,
         )
       end
 
@@ -92,6 +93,7 @@ module DiscourseAi::AiBot::Personas
           General,
           SqlHelper,
           SettingsExplorer,
+          Creative,
         )
       end
 


### PR DESCRIPTION
This adds a new creative persona that has access to the underlying
model and no external integrations.

It allows people to use Claude/GPT models in a Discourse agnostic
way.
