### PR TITLE
DEV: Improvements to AI helper context menu

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -42,6 +42,7 @@ export default class AiHelperContextMenu extends Component {
   };
   prompts = [];
   promptTypes = {};
+  minSelectionChars = 3;
 
   @tracked _menuState = this.CONTEXT_MENU_STATES.triggers;
   @tracked _popper;
@@ -107,7 +108,6 @@ export default class AiHelperContextMenu extends Component {
   @bind
   selectionChanged() {
     if (document.activeElement !== this._dEditorInput) {
-      this.closeContextMenu();
       return;
     }
 
@@ -126,6 +126,10 @@ export default class AiHelperContextMenu extends Component {
 
     if (this.selectedText?.length === 0) {
       this.closeContextMenu();
+      return;
+    }
+
+    if (this.selectedText?.length < this.minSelectionChars) {
       return;
     }
 

--- a/spec/system/ai_helper/ai_composer_helper_spec.rb
+++ b/spec/system/ai_helper/ai_composer_helper_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
       expect(ai_helper_context_menu).to have_context_menu
     end
 
+    it "does not show the context menu when selecting insuffient text" do
+      visit("/latest")
+      page.find("#create-topic").click
+      composer.fill_content(OpenAiCompletionsInferenceStubs.translated_response)
+      page.execute_script(
+        "const input = document.querySelector('.d-editor-input'); input.setSelectionRange(0, 2);",
+      )
+      expect(ai_helper_context_menu).to have_no_context_menu
+    end
+
     it "shows context menu in 'trigger' state when first showing" do
       trigger_context_menu(OpenAiCompletionsInferenceStubs.translated_response)
       expect(ai_helper_context_menu).to be_showing_triggers


### PR DESCRIPTION
This PR takes care of two things for the AI helper context menu:
1. `FIX` AI Helper context menu should work in Safari macOS
2. `IMPROVE` Trigger the context menu only if selected text is greater than a minimum character limit of 3