### PR TITLE
FEATURE: support OpenAI-Organization header

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -41,6 +41,7 @@ en:
     ai_openai_gpt35_16k_url: "Custom URL used for GPT 3.5 16k chat completions. (for Azure support)"
     ai_openai_gpt4_url: "Custom URL used for GPT 4 chat completions. (for Azure support)"
     ai_openai_gpt4_32k_url: "Custom URL used for GPT 4 32k chat completions. (for Azure support)"
+    ai_openai_organization: "(Optional, leave empty to omit) Organization id used for the OpenAI API. Passed in using the OpenAI-Organization header."
     ai_openai_embeddings_url: "Custom URL used for the OpenAI embeddings API. (in the case of Azure it can be: https://COMPANY.openai.azure.com/openai/deployments/DEPLOYMENT/embeddings?api-version=2023-05-15)"
     ai_openai_api_key: "API key for OpenAI API"
     ai_anthropic_api_key: "API key for Anthropic API"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -93,6 +93,7 @@ discourse_ai:
   ai_openai_gpt4_url: "https://api.openai.com/v1/chat/completions"
   ai_openai_gpt4_32k_url: "https://api.openai.com/v1/chat/completions"
   ai_openai_embeddings_url: "https://api.openai.com/v1/embeddings"
+  ai_openai_organization:
   ai_openai_api_key:
     default: ""
     secret: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -93,7 +93,7 @@ discourse_ai:
   ai_openai_gpt4_url: "https://api.openai.com/v1/chat/completions"
   ai_openai_gpt4_32k_url: "https://api.openai.com/v1/chat/completions"
   ai_openai_embeddings_url: "https://api.openai.com/v1/embeddings"
-  ai_openai_organization:
+  ai_openai_organization: ""
   ai_openai_api_key:
     default: ""
     secret: true

--- a/lib/shared/inference/openai_completions.rb
+++ b/lib/shared/inference/openai_completions.rb
@@ -48,6 +48,10 @@ module ::DiscourseAi
           headers["Authorization"] = "Bearer #{SiteSetting.ai_openai_api_key}"
         end
 
+        if SiteSetting.ai_openai_organization.present?
+          headers["OpenAI-Organization"] = SiteSetting.ai_openai_organization
+        end
+
         payload = { model: model, messages: messages }
 
         payload[:temperature] = temperature if temperature


### PR DESCRIPTION
Per: https://platform.openai.com/docs/api-reference/authentication

There is an organization option which is useful for large orgs

> For users who belong to multiple organizations, you can pass a header to specify which organization is used for an API request. Usage from these API requests will count against the specified organization's subscription quota.
