### PR TITLE
DEV: Add revert button in diff modal

### DIFF
--- a/assets/javascripts/discourse/components/modal/diff-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/diff-modal.gjs
@@ -35,7 +35,11 @@ export default class ModalDiffModal extends Component {
           @action={{this.triggerConfirmChanges}}
           @label="discourse_ai.ai_helper.context_menu.confirm"
         />
-        <DModalCancel @close={{@closeModal}} />
+        <DButton
+          class="btn-flat"
+          @action={{this.triggerRevertChanges}}
+          @label="discourse_ai.ai_helper.context_menu.revert"
+        />
       </:footer>
     </DModal>
   </template>
@@ -44,5 +48,11 @@ export default class ModalDiffModal extends Component {
   triggerConfirmChanges() {
     this.args.closeModal();
     this.args.confirm();
+  }
+
+  @action
+  triggerRevertChanges() {
+    this.args.closeModal();
+    this.args.revert();
   }
 }

--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.hbs
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.hbs
@@ -123,6 +123,7 @@
     @diff={{this.diff}}
     @oldValue={{this.selectedText}}
     @newValue={{this.newSelectedText}}
+    @revert={{this.undoAIAction}}
     @closeModal={{fn (mut this.showDiffModal) false}}
   />
 {{/if}}


### PR DESCRIPTION
This PR changes the behaviour of the cancel button in the diff modal. Previously the cancel button would simply close the modal. As [requested on Meta](https://meta.discourse.org/t/proofread-text-feature-view-changes-what-does-the-cancel-button-do/280715/3?u=keegan), this PR changes it so that the cancel button is replaced with a revert button, so that the confirm/revert actions can be taken directly from the modal.

## Before
![Screenshot 2023-10-06 at 11 24 43](https://github.com/discourse/discourse-ai/assets/30090424/177c37ed-fe77-4902-a642-939e28d56457)

## After
![Screenshot 2023-10-06 at 11 24 20](https://github.com/discourse/discourse-ai/assets/30090424/80c546a9-035f-4a25-99b6-6f726a13ede9)
