### PR TITLE
FIX: Include OP when building title suggestion prompt.

### DIFF
--- a/lib/modules/ai_bot/bot.rb
+++ b/lib/modules/ai_bot/bot.rb
@@ -298,7 +298,7 @@ module DiscourseAi
           You will never respond with anything but a topic title.
           Suggest a 7 word title for the following topic without quoting any of it:
 
-          #{post.topic.posts[1..-1].map(&:raw).join("\n\n")[0..prompt_limit]}
+          #{post.topic.posts.map(&:raw).join("\n\n")[0..prompt_limit]}
         TEXT
       end
 


### PR DESCRIPTION
When the OP is the only post in the topic, we'll send a prompt without user content to the LLM, and the suggested title will make no sense.