### PR TITLE
DEV: Fix .discourse-compatibility typo

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,4 +1,4 @@
-< 3.2.0.beta2-beta: 3bced1c6f525553fe2b5b79d29bd66c1cf2a47d5
+< 3.2.0.beta2-dev: 3bced1c6f525553fe2b5b79d29bd66c1cf2a47d5
 3.1.999: c0415bb7eb878b1b7abf112d65cba981030df8df
 < 3.2.0.beta1-dev: 3e7c99de894b03e9161d9481da118fe893991a1d
 3.1.0.beta3: 057fbe1ce6


### PR DESCRIPTION
Followup to e21405a600abb2b7e7ef0b8cc8598d16089fe117