### PR TITLE
update test to use new chat update message service

### DIFF
--- a/spec/lib/modules/toxicity/entry_point_spec.rb
+++ b/spec/lib/modules/toxicity/entry_point_spec.rb
@@ -52,15 +52,15 @@ describe DiscourseAi::Toxicity::EntryPoint do
       end
     end
 
-    xcontext "when editing a chat message" do
-      # This fabricator trigger events because it uses the MessageCreator.
+    context "when editing a chat message" do
+      # This fabricator trigger events because it uses the UpdateMessage service.
       # Using let makes the test fail.
       fab!(:chat_message) { Fabricate(:chat_message) }
       let(:updater) do
-        Chat::MessageUpdater.new(
+        Chat::UpdateMessage.call(
           guardian: Guardian.new(chat_message.user),
-          chat_message: chat_message,
-          new_content: "This is my updated message",
+          message_id: chat_message.id,
+          message: "This is my updated message",
         )
       end
 


### PR DESCRIPTION
This should be merged after the service is made available within chat (PR open but not merged yet).