### PR TITLE
FIX: allow for blank fields in Google results

### DIFF
--- a/lib/modules/ai_bot/commands/google_command.rb
+++ b/lib/modules/ai_bot/commands/google_command.rb
@@ -55,7 +55,9 @@ module DiscourseAi::AiBot::Commands
     end
 
     def minimize_field(result, field, max_tokens: 100)
-      data = result[field].squish
+      data = result[field]
+      return "" if data.blank?
+
       data = ::DiscourseAi::Tokenizer::BertTokenizer.truncate(data, max_tokens).squish
       data
     end

--- a/spec/lib/modules/ai_bot/commands/google_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/google_command_spec.rb
@@ -32,13 +32,20 @@ RSpec.describe DiscourseAi::AiBot::Commands::GoogleCommand do
 
       json_text = {
         searchInformation: {
-          totalResults: "1",
+          totalResults: "2",
         },
         items: [
           {
             title: "title1",
             link: "link1",
             snippet: "snippet1",
+            displayLink: "displayLink1",
+            formattedUrl: "formattedUrl1",
+            oops: "do no include me ... oops",
+          },
+          {
+            title: "title2",
+            link: "link2",
             displayLink: "displayLink1",
             formattedUrl: "formattedUrl1",
             oops: "do no include me ... oops",
@@ -60,10 +67,11 @@ RSpec.describe DiscourseAi::AiBot::Commands::GoogleCommand do
 
       info = google.process(query: "some search term").to_json
 
-      expect(google.description_args[:count]).to eq(1)
+      expect(google.description_args[:count]).to eq(2)
       expect(info).to include("title1")
       expect(info).to include("snippet1")
       expect(info).to include("some+search+term")
+      expect(info).to include("title2")
       expect(info).to_not include("oops")
 
       google.invoke!


### PR DESCRIPTION
Under certain cases, for example:

```
there is this japanese band called kirimi, tell me more about them, try searching 3 times and at least 2 times in japanese before answering.
```

Results come back with blank snippets. This adds protection so this
is allowed and code does not simply blow up.
