### PR TITLE
FEATURE: Make embeddings turn-key

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -60,6 +60,7 @@ en:
     ai_embeddings_generate_for_pms: "Generate embeddings for personal messages."
     ai_embeddings_semantic_related_topics_enabled: "Use Semantic Search for related topics."
     ai_embeddings_semantic_related_topics: "Maximum number of topics to show in related topic section."
+    ai_embeddings_backfill_batch_size: "Number of embeddings to backfill every 15 minutes."
     ai_embeddings_pg_connection_string: "PostgreSQL connection string for the embeddings module. Needs pgvector extension enabled and a series of tables created. See docs for more info."
     ai_embeddings_semantic_search_enabled: "Enable full-page semantic search."
     ai_embeddings_semantic_related_include_closed_topics: "Include closed topics in semantic search results"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -200,6 +200,9 @@ discourse_ai:
     client: true
   ai_embeddings_semantic_related_topics: 5
   ai_embeddings_semantic_related_include_closed_topics: true
+  ai_embeddings_backfill_batch_size:
+    default: 250
+    hidden: true
   ai_embeddings_pg_connection_string:
     default: ""
     hidden: true

--- a/lib/modules/embeddings/entry_point.rb
+++ b/lib/modules/embeddings/entry_point.rb
@@ -11,6 +11,7 @@ module DiscourseAi
         require_relative "vector_representations/bge_large_en"
         require_relative "strategies/truncation"
         require_relative "jobs/regular/generate_embeddings"
+        require_relative "jobs/scheduled/embeddings_backfill"
         require_relative "semantic_related"
         require_relative "semantic_topic_query"
 

--- a/lib/modules/embeddings/jobs/regular/generate_embeddings.rb
+++ b/lib/modules/embeddings/jobs/regular/generate_embeddings.rb
@@ -2,6 +2,8 @@
 
 module Jobs
   class GenerateEmbeddings < ::Jobs::Base
+    sidekiq_options queue: "low"
+
     def execute(args)
       return unless SiteSetting.ai_embeddings_enabled
       return if (topic_id = args[:topic_id]).blank?

--- a/lib/modules/embeddings/jobs/scheduled/embeddings_backfill.rb
+++ b/lib/modules/embeddings/jobs/scheduled/embeddings_backfill.rb
@@ -59,7 +59,7 @@ module Jobs
           rebaked += 1
         end
 
-      return rebaked
+      rebaked
     end
   end
 end

--- a/lib/modules/embeddings/jobs/scheduled/embeddings_backfill.rb
+++ b/lib/modules/embeddings/jobs/scheduled/embeddings_backfill.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Jobs
+  class EmbeddingsBackfill < ::Jobs::Base
+    every 15.minutes
+    sidekiq_options queue: "low"
+    cluster_concurrency 1
+
+    def execute(args)
+      return unless SiteSetting.ai_embeddings_enabled
+
+      limit = SiteSetting.ai_embeddings_backfill_batch_size
+      rebaked = 0
+
+      strategy = DiscourseAi::Embeddings::Strategies::Truncation.new
+      vector_rep =
+        DiscourseAi::Embeddings::VectorRepresentations::Base.current_representation(strategy)
+      table_name = vector_rep.table_name
+
+      topics =
+        Topic
+          .joins("LEFT JOIN #{table_name} ON #{table_name}.topic_id = topics.id")
+          .where(deleted_at: nil)
+          .order("#{table_name}.updated_at ASC NULLS FIRST, topics.id DESC")
+          .limit(limit - rebaked)
+
+      # First, we'll try to backfill embeddings for topics that have none
+      topics
+        .where("#{table_name}.topic_id IS NULL")
+        .find_each do |t|
+          vector_rep.generate_topic_representation_from(t)
+          rebaked += 1
+        end
+
+      return if rebaked >= limit
+
+      # Then, we'll try to backfill embeddings for topics that have outdated
+      # embeddings, be it model or strategy version
+      topics
+        .where(<<~SQL)
+          #{table_name}.model_version < #{vector_rep.version}
+          OR
+          #{table_name}.strategy_version < #{strategy.version}
+        SQL
+        .find_each do |t|
+          vector_rep.generate_topic_representation_from(t)
+          rebaked += 1
+        end
+
+      return if rebaked >= limit
+
+      # Finally, we'll try to backfill embeddings for topics that have outdated
+      # embeddings due to edits or new replies. Here we only do 10% of the limit
+      topics
+        .reorder("random()")
+        .limit((limit - rebaked) / 10)
+        .find_each do |t|
+          vector_rep.generate_topic_representation_from(t)
+          rebaked += 1
+        end
+
+      return rebaked
+    end
+  end
+end

--- a/lib/modules/embeddings/jobs/scheduled/embeddings_backfill.rb
+++ b/lib/modules/embeddings/jobs/scheduled/embeddings_backfill.rb
@@ -22,7 +22,6 @@ module Jobs
           .joins("LEFT JOIN #{table_name} ON #{table_name}.topic_id = topics.id")
           .where(archetype: Archetype.default)
           .where(deleted_at: nil)
-          .order("#{table_name}.updated_at ASC NULLS FIRST, topics.id DESC")
           .limit(limit - rebaked)
 
       # First, we'll try to backfill embeddings for topics that have none
@@ -33,9 +32,9 @@ module Jobs
           rebaked += 1
         end
 
-      return if rebaked >= limit
+      vector_rep.consider_indexing
 
-      consider_indexing(vector_rep)
+      return if rebaked >= limit
 
       # Then, we'll try to backfill embeddings for topics that have outdated
       # embeddings, be it model or strategy version
@@ -55,25 +54,16 @@ module Jobs
       # Finally, we'll try to backfill embeddings for topics that have outdated
       # embeddings due to edits or new replies. Here we only do 10% of the limit
       topics
-        .reorder("random()")
+        .where("#{table_name}.updated_at < ?", 7.days.ago)
+        .order("random()")
         .limit((limit - rebaked) / 10)
-        .find_each do |t|
-          vector_rep.generate_topic_representation_from(t)
+        .pluck(:id)
+        .each do |id|
+          vector_rep.generate_topic_representation_from(Topic.find_by(id: id))
           rebaked += 1
         end
 
       rebaked
-    end
-
-    private
-
-    def consider_indexing(vector_rep)
-      limiter = RateLimiter.new(nil, "ai_embeddings_backfill_indexing", 1, 1.week)
-
-      if limiter.can_perform?
-        vector_rep.create_index(memory: "100MB")
-        limiter.performed!
-      end
     end
   end
 end

--- a/lib/modules/embeddings/strategies/truncation.rb
+++ b/lib/modules/embeddings/strategies/truncation.rb
@@ -30,7 +30,7 @@ module DiscourseAi
 
           info << topic.title
           info << "\n\n"
-          info << topic.category.name
+          info << topic.category.name if topic&.category&.name
           if SiteSetting.tagging_enabled
             info << "\n\n"
             info << topic.tags.pluck(:name).join(", ")

--- a/lib/modules/embeddings/vector_representations/base.rb
+++ b/lib/modules/embeddings/vector_representations/base.rb
@@ -12,20 +12,54 @@ module DiscourseAi
           @strategy = strategy
         end
 
-        def create_index(lists, probes)
+        def create_index(memory: "100MB")
           index_name = "#{table_name}_search"
 
+          # Using extension maintainer's recommendation for ivfflat indexes
+          # Results are not as good as without indexes, but it's much faster
+          # Disk usage is ~1x the size of the table, so this doubles table total size
+          count = DB.query_single("SELECT count(*) FROM #{table_name};").first
+          lists = [count < 1_000_000 ? count / 1000 : Math.sqrt(count).to_i, 10].max
+          probes = [count < 1_000_000 ? lists / 10 : Math.sqrt(lists).to_i, 1].max
+
+          existing_index = DB.query_single(<<~SQL, index_name: index_name).first
+            SELECT
+              indexdef
+            FROM
+              pg_indexes
+            WHERE
+              indexname = :index_name
+            LIMIT 1
+          SQL
+
+          if existing_index.present?
+            existing_lists = existing_index.match(/lists='(\d+)'/)&.captures&.first&.to_i
+            if existing_lists == lists
+              puts "Index #{index_name} already exists with the same number of lists (#{lists}), skipping"
+              return
+            else
+              puts "Index #{index_name} already exists, but lists is #{existing_lists} instead of #{lists}, updating..."
+            end
+          end
+
+          DB.exec("SET work_mem TO '#{memory}';")
+          DB.exec("SET maintenance_work_mem TO '#{memory}';")
           DB.exec(<<~SQL)
             DROP INDEX IF EXISTS #{index_name};
             CREATE INDEX IF NOT EXISTS
-              #{index}
+              #{index_name}
             ON
               #{table_name}
             USING
               ivfflat (embeddings #{pg_index_type})
             WITH
               (lists = #{lists});
-            SQL
+          SQL
+          DB.exec("RESET work_mem;")
+          DB.exec("RESET maintenance_work_mem;")
+
+          database = DB.query_single("SELECT current_database();").first
+          DB.exec("ALTER DATABASE #{database} SET ivfflat.probes = #{probes};")
         end
 
         def vector_from(text)

--- a/lib/tasks/modules/embeddings/database.rake
+++ b/lib/tasks/modules/embeddings/database.rake
@@ -23,20 +23,8 @@ end
 
 desc "Creates indexes for embeddings"
 task "ai:embeddings:index", [:work_mem] => [:environment] do |_, args|
-  # Using extension maintainer's recommendation for ivfflat indexes
-  # Results are not as good as without indexes, but it's much faster
-  # Disk usage is ~1x the size of the table, so this doubles table total size
-  count = Topic.count
-  lists = count < 1_000_000 ? count / 1000 : Math.sqrt(count).to_i
-  probes = count < 1_000_000 ? lists / 10 : Math.sqrt(lists).to_i
-
-  vector_representation_klass = DiscourseAi::Embeddings::Vectors::Base.find_vector_representation
   strategy = DiscourseAi::Embeddings::Strategies::Truncation.new
+  vector_rep = DiscourseAi::Embeddings::VectorRepresentations::Base.current_representation(strategy)
 
-  DB.exec("SET work_mem TO '#{args[:work_mem] || "100MB"}';")
-  DB.exec("SET maintenance_work_mem TO '#{args[:work_mem] || "100MB"}';")
-  vector_representation_klass.new(strategy).create_index(lists, probes)
-  DB.exec("RESET work_mem;")
-  DB.exec("RESET maintenance_work_mem;")
-  DB.exec("ALTER SYSTEM SET ivfflat.probes = #{probes};")
+  vector_rep.create_index(memory: args[:work_mem] || "100MB")
 end

--- a/lib/tasks/modules/embeddings/database.rake
+++ b/lib/tasks/modules/embeddings/database.rake
@@ -26,5 +26,5 @@ task "ai:embeddings:index", [:work_mem] => [:environment] do |_, args|
   strategy = DiscourseAi::Embeddings::Strategies::Truncation.new
   vector_rep = DiscourseAi::Embeddings::VectorRepresentations::Base.current_representation(strategy)
 
-  vector_rep.create_index(memory: args[:work_mem] || "100MB")
+  vector_rep.consider_indexing(memory: args[:work_mem] || "100MB")
 end


### PR DESCRIPTION
To ease the administrative burden of enabling the embeddings model, this change introduces automatic backfill when the setting is enabled. It also moves the topic visit embedding creation to a lower priority queue in sidekiq and adds an option to skip embedding computation and persistence when we match on the digest.
