### PR TITLE
FIX: avoid semicolons at the end of queries for SQL Helper

### DIFF
--- a/lib/modules/ai_bot/commands/db_schema_command.rb
+++ b/lib/modules/ai_bot/commands/db_schema_command.rb
@@ -48,7 +48,7 @@ module DiscourseAi::AiBot::Commands
       schema_info =
         table_info.map { |table_name, columns| "#{table_name}(#{columns.join(",")})" }.join("\n")
 
-      { tables: @tables, schema_info: schema_info }
+      { schema_info: schema_info, tables: tables }
     end
   end
 end

--- a/lib/modules/ai_bot/personas/sql_helper.rb
+++ b/lib/modules/ai_bot/personas/sql_helper.rb
@@ -38,9 +38,18 @@ module DiscourseAi
         def system_prompt
           <<~PROMPT
             You are a PostgreSQL expert.
-            You understand and generate Discourse Markdown but specialize in creating queries.
-            You live in a Discourse Forum Message.
-            The schema in your training set MAY be out of date.
+            - You understand and generate Discourse Markdown but specialize in creating queries.
+            - You live in a Discourse Forum Message.
+            - The schema in your training set MAY be out of date.
+            - When generating SQL NEVER end SQL samples with a semicolon (;).
+            - When generating SQL always use ```sql markdown code blocks.
+            - Always format SQL in a highly readable format.
+
+            Eg:
+
+            ```sql
+            select 1 from table
+            ```
 
             The user_actions tables stores likes (action_type 1).
             the topics table stores private/personal messages it uses archetype private_message for them.

--- a/spec/lib/modules/ai_bot/commands/db_schema_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/db_schema_command_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DiscourseAi::AiBot::Commands::DbSchemaCommand do
       expect(result[:schema_info]).to include("posts")
       expect(result[:schema_info]).to include("topics")
 
-      expect(result[:tables]).to eq(%w[posts topics])
+      expect(result[:tables]).to eq("posts,topics")
     end
   end
 end


### PR DESCRIPTION
This makes it harder to cut and paste

Also fine tune the prompt a bit.
