### PR TITLE
FIX: keep parity of shape for image command

### DIFF
--- a/lib/modules/ai_bot/commands/image_command.rb
+++ b/lib/modules/ai_bot/commands/image_command.rb
@@ -129,10 +129,7 @@ module DiscourseAi::AiBot::Commands
       [/grid]
     RAW
 
-      {
-        prompts: uploads.map { |item| { prompt: item[:prompt], seed: item[:seed] } },
-        displayed_to_user: true,
-      }
+      { prompts: uploads.map { |item| item[:prompt] }, seeds: uploads.map { |item| item[:seed] } }
     end
   end
 end

--- a/spec/lib/modules/ai_bot/commands/image_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/image_command_spec.rb
@@ -34,13 +34,7 @@ RSpec.describe DiscourseAi::AiBot::Commands::ImageCommand do
 
       info = image.process(prompts: prompts).to_json
 
-      expect(JSON.parse(info)).to eq(
-        "prompts" => [
-          { "prompt" => "a pink cow", "seed" => 99 },
-          { "prompt" => "a red cow", "seed" => 99 },
-        ],
-        "displayed_to_user" => true,
-      )
+      expect(JSON.parse(info)).to eq("prompts" => ["a pink cow", "a red cow"], "seeds" => [99, 99])
       expect(image.custom_raw).to include("upload://")
       expect(image.custom_raw).to include("[grid]")
       expect(image.custom_raw).to include("a pink cow")


### PR DESCRIPTION
Function calling will start hallucinating if you reshape results.

Previously we were morphing from:

`{ prompts: ["prompt 1", "prompt 2"] }`

to

`{ prompts: { prompt: "prompt 1", seed: 222}, { ... `

This meant that over a few call sequences function_call starts hallucinating an incorrect shape.

This change grounds us even on GPT-3.5
