### PR TITLE
DEV: Add wrapping classes and remove `has()` usage

### DIFF
--- a/assets/javascripts/discourse/components/ai-suggestion-dropdown.gjs
+++ b/assets/javascripts/discourse/components/ai-suggestion-dropdown.gjs
@@ -32,11 +32,31 @@ export default class AISuggestionDropdown extends Component {
 
   get showAIButton() {
     const minCharacterCount = 40;
-    return this.composer.model.replyLength > minCharacterCount;
+    const isShowAIButton = this.composer.model.replyLength > minCharacterCount;
+    const composerFields = document.querySelector(".composer-fields");
+    
+    if (composerFields) {
+      if (isShowAIButton) {
+        composerFields.classList.add("showing-ai-suggestions");
+      } else {
+        composerFields.classList.remove("showing-ai-suggestions");
+      }
+    }
+
+    return isShowAIButton;
   }
 
   get disableSuggestionButton() {
     return this.loading;
+  }
+
+  @action
+  applyClasses() {
+    if (this.showAIButton) {
+      document.querySelector(".composer-fields")?.classList.add("showing-ai-suggestions");
+    } else {
+      document.querySelector(".composer-fields")?.classList.remove("showing-ai-suggestions");
+    }
   }
 
   @bind
@@ -111,10 +131,18 @@ export default class AISuggestionDropdown extends Component {
         this.loading = false;
         this.suggestIcon = "sync-alt";
         this.showMenu = true;
+
+        if (this.args.mode === "suggest_category") {
+          document.querySelector(".category-input")?.classList.add("showing-ai-suggestion-menu");
+        }
       });
   }
 
   #closeMenu() {
+    if (this.showMenu && this.args.mode === "suggest_category") {
+      document.querySelector(".category-input")?.classList.remove("showing-ai-suggestion-menu");
+    }
+
     this.suggestIcon = "discourse-sparkles";
     this.showMenu = false;
     this.showErrors = false;

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -249,8 +249,8 @@
   border-left: none;
 }
 
-.title-input:has(.suggestion-button) {
-  // border on focus should be on top of suggestion button
+.showing-ai-suggestions .title-input {
+    // border on focus should be on top of suggestion button
   input:focus {
     z-index: 1;
   }
@@ -288,14 +288,14 @@
   }
 }
 
-.category-input:has(.ai-suggestions-menu) {
+.category-input.showing-ai-suggestion-menu {
   position: relative;
 }
 
 // Prevent suggestion button from wrapping on smaller screens
 @media screen and (max-width: 768px) {
-  #reply-control {
-    .category-input:has(.suggestion-button) {
+  #reply-control .composer-fields.showing-ai-suggestions {
+    .category-input {
       .category-chooser {
         width: 10px;
       }

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -250,7 +250,7 @@
 }
 
 .showing-ai-suggestions .title-input {
-    // border on focus should be on top of suggestion button
+  // border on focus should be on top of suggestion button
   input:focus {
     z-index: 1;
   }


### PR DESCRIPTION
**This PR makes some updates to the AI suggestion button and AI suggestion dropdown.**

In particular:
- Removes the usage of `:has()` for targeting elements when AI suggestions are showing. Although this currently works in most major browsers, it is behind a feature flag still in Firefox, so many will be unable to see the visual changes made based on `has()` until Firefox 121 where it becomes enabled by default. Till then, we will avoid the usage of `has()`
- Add a class to `.composer-fields` element called `.showing-ai-suggestions` which can be used to make changes conditional on whether the AI suggestion buttons are showing
- Adds class to `.category-input` for when AI suggestion menu is being shown so it can easily be relatively positioned.