### PR TITLE
FIX: Adjust for overlap in AI buttons

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -262,6 +262,10 @@
   }
 }
 
+#reply-control .showing-ai-suggestions .category-chooser {
+  max-width: calc(100% - 41px); // width of AI button
+}
+
 .suggest-tags-button,
 .suggest-category-button {
   display: block;


### PR DESCRIPTION
**Before**
<img width="400" alt="image" src="https://github.com/discourse/discourse-ai/assets/30537603/f8cb35cf-1387-44d3-9c95-35170947057a">


**After**
<img width="400" alt="image" src="https://github.com/discourse/discourse-ai/assets/30537603/3421aff1-718f-4d43-ae57-fee27c082f4b">
