### PR TITLE
FIX: Changes to the sentiment reports.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -102,12 +102,12 @@ en:
   reports:
     overall_sentiment:
       title: "Overall sentiment"
-      description: "The average percentage of positive and negative sentiments in public posts."
+      description: "This chart compares the number of posts classified either positive or negative."
       xaxis: "Positive(%)"
       yaxis: "Date"
     post_emotion:
       title: "Post emotion"
-      description: "The average percentage of emotions present in public posts grouped by the poster's trust level."
+      description: "Number of posts classified with one of the following emotions, grouped by poster's trust level."
       xaxis:
       yaxis:
 


### PR DESCRIPTION
This PR aims to clarify sentiment reports by replacing averages with a count of posts that have one of their values above a threshold (60), meaning we have some level of confidence they are, in fact, positive or negative.

Same thing happen with post emotions, with the difference that a post can have multiple values above it (30). Additionally, we dropped the "Neutral" axis.

We also reworded the tooltip next to each report title, and added an early return to signal we have no data available instead of displaying an empty chart.