### PR TITLE
FIX: ChatChannel no longer inherits from RestModel.

### DIFF
--- a/assets/javascripts/discourse/components/reviewable-ai-chat-message.js
+++ b/assets/javascripts/discourse/components/reviewable-ai-chat-message.js
@@ -1,13 +1,8 @@
 import Component from "@glimmer/component";
-import { inject as service } from "@ember/service";
+import ChatChannel from "discourse/plugins/chat/discourse/models/chat-channel";
 
 export default class ReviewableAiChatMessage extends Component {
-  @service store;
-
   get chatChannel() {
-    return this.store.createRecord(
-      "chat-channel",
-      this.args.reviewable.chat_channel
-    );
+    return ChatChannel.create(this.args.reviewable.chat_channel);
   }
 }

--- a/spec/system/toxicity/reviewable_ai_chat_message_spec.rb
+++ b/spec/system/toxicity/reviewable_ai_chat_message_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "../../support/toxicity_inference_stubs"
+
+RSpec.describe "Toxicity-flagged chat messages", type: :system, js: true do
+  fab!(:chat_message) { Fabricate(:chat_message) }
+  fab!(:admin) { Fabricate(:admin) }
+
+  before do
+    sign_in(admin)
+    SiteSetting.ai_toxicity_enabled = true
+    SiteSetting.ai_toxicity_flag_automatically = true
+
+    ToxicityInferenceStubs.stub_chat_message_classification(chat_message, toxic: true)
+
+    DiscourseAi::ChatMessageClassificator.new(
+      DiscourseAi::Toxicity::ToxicityClassification.new,
+    ).classify!(chat_message)
+  end
+
+  it "displays them in the review queue" do
+    visit("/review")
+
+    expect(page).to have_selector(".reviewable-ai-chat-message .reviewable-actions")
+  end
+end


### PR DESCRIPTION
Trying to hydrate using the store will fail. We need to use the model create function instead.