### PR TITLE
FIX: Un-clickable AI Results

### DIFF
--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
@@ -133,12 +133,13 @@ export default class SemanticSearch extends Component {
         })
           .then(async (results) => {
             const model = (await translateResults(results)) || {};
-            const AIResults = model.posts.map(function (post) {
-              return Object.assign({}, post, { generatedByAI: true });
+
+            model.posts.forEach((post) => {
+              post.generatedByAI = true;
             });
 
-            this.args.outletArgs.addSearchResults(AIResults, "topic_id");
-            this.AIResults = AIResults;
+            this.args.outletArgs.addSearchResults(model.posts, "topic_id");
+            this.AIResults = model.posts;
           })
           .catch(popupAjaxError)
           .finally(() => (this.searching = false));

--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
@@ -29,7 +29,7 @@ export default class SemanticSearch extends Component {
               {{if this.searching 'in-progress'}}"
           >
             <DToggleSwitch
-              disabled={{this.searching}}
+              disabled={{this.disableToggleSwitch}}
               @state={{this.showingAIResults}}
               title="AI search results hidden"
               class="semantic-search__results-toggle"
@@ -64,6 +64,12 @@ export default class SemanticSearch extends Component {
   @tracked searching = false;
   @tracked AIResults = [];
   @tracked showingAIResults = false;
+
+  get disableToggleSwitch() {
+    if (this.searching || this.AIResults.length === 0) {
+      return true;
+    }
+  }
 
   get searchStateText() {
     if (this.searching) {
@@ -133,6 +139,11 @@ export default class SemanticSearch extends Component {
         })
           .then(async (results) => {
             const model = (await translateResults(results)) || {};
+
+            if (model.posts?.length === 0) {
+              this.searching = false;
+              return;
+            }
 
             model.posts.forEach((post) => {
               post.generatedByAI = true;

--- a/assets/stylesheets/modules/embeddings/common/semantic-search.scss
+++ b/assets/stylesheets/modules/embeddings/common/semantic-search.scss
@@ -62,7 +62,6 @@
 
   .ai-result {
     display: none;
-    background: var(--tertiary-very-low);
     border-radius: var(--d-border-radius);
 
     .ai-result__icon {


### PR DESCRIPTION
**This PR fixes an issue where AI results are not clickable.** 

This was due to mapping the original `model.posts` object to add `generatedByAI` attribute which was overwriting the `EmberObject` with a plain JS object causing attributes such as `url` to be removed. Instead we update it to simply add the attribute to the `EmberObject`.

No specs added as specs are still `todo` for after LLM abstraction. However, I've made a personal note to include testing topic url click on spec.

**This PR also applies some smaller fixes related to AI Semantic search:**
- It removes the `background: var(--tertiary-very-low);` that is applied on all AI search results. This makes the UI look cleaner especially when there are only AI results, making the background feel unnecessarily repetitive.
- It disables the toggle switch if there are no AI results.

