### PR TITLE
FEATURE: remember previously selected persona

### DIFF
--- a/assets/javascripts/discourse/connectors/composer-fields/persona-selector.gjs
+++ b/assets/javascripts/discourse/connectors/composer-fields/persona-selector.gjs
@@ -30,16 +30,17 @@ export default class BotSelector extends Component {
   @service currentUser;
 
   STORE_NAMESPACE = "discourse_ai_persona_selector_";
-  store = new KeyValueStore(this.STORE_NAMESPACE);
+  preferredPersonaStore = new KeyValueStore(this.STORE_NAMESPACE);
 
   constructor() {
     super(...arguments);
+
     if (this.botOptions && this.composer) {
-      const id = this.store.getObject("id");
-      if (id) {
-        this._value = parseInt(id, 10);
+      const personaId = this.preferredPersonaStore.getObject("id");
+      if (personaId) {
+        this._value = parseInt(personaId, 10);
       } else {
-        this._value = this.botOptions[0].id;
+        this._value = this.botOptions[0].personaId;
       }
 
       this.composer.metaData = { ai_persona_id: this._value };
@@ -66,10 +67,10 @@ export default class BotSelector extends Component {
     return this._value;
   }
 
-  set value(val) {
-    this._value = val;
-    this.store.setObject({ key: "id", value: val });
-    this.composer.metaData = { ai_persona_id: val };
+  set value(newValue) {
+    this._value = newValue;
+    this.preferredPersonaStore.setObject({ key: "id", value: newValue });
+    this.composer.metaData = { ai_persona_id: newValue };
   }
 
   <template>

--- a/assets/javascripts/discourse/connectors/composer-fields/persona-selector.gjs
+++ b/assets/javascripts/discourse/connectors/composer-fields/persona-selector.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { inject as service } from "@ember/service";
+import KeyValueStore from "discourse/lib/key-value-store";
 import DropdownSelectBox from "select-kit/components/dropdown-select-box";
 
 function isBotMessage(composer, currentUser) {
@@ -27,10 +28,20 @@ export default class BotSelector extends Component {
   }
 
   @service currentUser;
+
+  STORE_NAMESPACE = "discourse_ai_persona_selector_";
+  store = new KeyValueStore(this.STORE_NAMESPACE);
+
   constructor() {
     super(...arguments);
     if (this.botOptions && this.composer) {
-      this._value = this.botOptions[0].id;
+      const id = this.store.getObject("id");
+      if (id) {
+        this._value = parseInt(id, 10);
+      } else {
+        this._value = this.botOptions[0].id;
+      }
+
       this.composer.metaData = { ai_persona_id: this._value };
     }
   }
@@ -57,12 +68,14 @@ export default class BotSelector extends Component {
 
   set value(val) {
     this._value = val;
+    this.store.setObject({ key: "id", value: val });
     this.composer.metaData = { ai_persona_id: val };
   }
 
   <template>
     <div class="gpt-persona">
       <DropdownSelectBox
+        class="persona-selector__dropdown"
         @value={{this.value}}
         @content={{this.botOptions}}
         @options={{hash icon="robot"}}

--- a/plugin.rb
+++ b/plugin.rb
@@ -88,5 +88,6 @@ after_initialize do
     require_relative "spec/support/openai_completions_inference_stubs"
     require_relative "spec/support/anthropic_completion_stubs"
     require_relative "spec/support/stable_diffusion_stubs"
+    require_relative "spec/support/embeddings_generation_stubs"
   end
 end

--- a/spec/lib/modules/embeddings/jobs/generate_embeddings_spec.rb
+++ b/spec/lib/modules/embeddings/jobs/generate_embeddings_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../../support/embeddings_generation_stubs"
-
 RSpec.describe Jobs::GenerateEmbeddings do
   subject(:job) { described_class.new }
 

--- a/spec/lib/modules/embeddings/semantic_search_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_search_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../support/embeddings_generation_stubs"
-
 RSpec.describe DiscourseAi::Embeddings::SemanticSearch do
   fab!(:post) { Fabricate(:post) }
   fab!(:user) { Fabricate(:user) }

--- a/spec/lib/modules/embeddings/vector_representations/all_mpnet_base_v2_spec.rb
+++ b/spec/lib/modules/embeddings/vector_representations/all_mpnet_base_v2_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../../support/embeddings_generation_stubs"
 require_relative "vector_rep_shared_examples"
 
 RSpec.describe DiscourseAi::Embeddings::VectorRepresentations::AllMpnetBaseV2 do

--- a/spec/lib/modules/embeddings/vector_representations/multilingual_e5_large_spec.rb
+++ b/spec/lib/modules/embeddings/vector_representations/multilingual_e5_large_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../../support/embeddings_generation_stubs"
 require_relative "vector_rep_shared_examples"
 
 RSpec.describe DiscourseAi::Embeddings::VectorRepresentations::MultilingualE5Large do

--- a/spec/lib/modules/embeddings/vector_representations/text_embedding_ada_002_spec.rb
+++ b/spec/lib/modules/embeddings/vector_representations/text_embedding_ada_002_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../../support/embeddings_generation_stubs"
 require_relative "vector_rep_shared_examples"
 
 RSpec.describe DiscourseAi::Embeddings::VectorRepresentations::TextEmbeddingAda002 do

--- a/spec/system/ai_bot/persona_spec.rb
+++ b/spec/system/ai_bot/persona_spec.rb
@@ -14,12 +14,13 @@ RSpec.describe "AI personas", type: :system, js: true do
     visit "/"
     find(".d-header .ai-bot-button").click()
     persona_selector = PageObjects::Components::SelectKit.new(".persona-selector__dropdown")
+    persona_selector.expand
     persona_selector.select_row_by_value(-2)
 
     visit "/"
     find(".d-header .ai-bot-button").click()
     persona_selector = PageObjects::Components::SelectKit.new(".persona-selector__dropdown")
-
+    persona_selector.expand
     expect(persona_selector).to have_selected_value(-2)
   end
 

--- a/spec/system/ai_bot/persona_spec.rb
+++ b/spec/system/ai_bot/persona_spec.rb
@@ -4,8 +4,23 @@ RSpec.describe "AI personas", type: :system, js: true do
 
   before do
     SiteSetting.ai_bot_enabled = true
-    SiteSetting.ai_bot_enabled_chat_bots = "gpt-4|gpt-3.5-turbo"
+    SiteSetting.ai_bot_enabled_chat_bots = "gpt-4"
     sign_in(admin)
+
+    Group.refresh_automatic_groups!
+  end
+
+  it "remembers the last selected persona" do
+    visit "/"
+    find(".d-header .ai-bot-button").click()
+    persona_selector = PageObjects::Components::SelectKit.new(".persona-selector__dropdown")
+    persona_selector.select_row_by_value(-2)
+
+    visit "/"
+    find(".d-header .ai-bot-button").click()
+    persona_selector = PageObjects::Components::SelectKit.new(".persona-selector__dropdown")
+
+    expect(persona_selector).to have_selected_value(-2)
   end
 
   it "allows creation of a persona" do

--- a/spec/system/embeddings/semantic_search_spec.rb
+++ b/spec/system/embeddings/semantic_search_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../support/embeddings_generation_stubs"
-require_relative "../../support/openai_completions_inference_stubs"
-
 RSpec.describe "AI Composer helper", type: :system, js: true do
   let(:search_page) { PageObjects::Pages::Search.new }
   let(:query) { "apple_pie" }


### PR DESCRIPTION
People tend to keep to 1 persona when working with the bot,
this adds local browser memory for the last persona you interacted
with so you do not need to select it over and over again.

This is per browser, not per user memory.

Also... clean up tests so they do not need to require stubs which
were breaking the build
