### PR TITLE
FIX: more results not appearing on scroll

### DIFF
--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
@@ -112,7 +112,11 @@ export default class SemanticSearch extends Component {
 
   @action
   toggleAIResults() {
-    document.body.classList.toggle("showing-ai-results");
+    if (this.showingAIResults) {
+      this.args.outletArgs.addSearchResults([], "topic_id");
+    } else {
+      this.args.outletArgs.addSearchResults(this.AIResults, "topic_id");
+    }
     this.showingAIResults = !this.showingAIResults;
   }
 
@@ -120,7 +124,6 @@ export default class SemanticSearch extends Component {
   resetAIResults() {
     this.AIResults = [];
     this.showingAIResults = false;
-    document.body.classList.remove("showing-ai-results");
   }
 
   @action
@@ -149,7 +152,6 @@ export default class SemanticSearch extends Component {
               post.generatedByAI = true;
             });
 
-            this.args.outletArgs.addSearchResults(model.posts, "topic_id");
             this.AIResults = model.posts;
           })
           .catch(popupAjaxError)

--- a/assets/stylesheets/modules/embeddings/common/semantic-search.scss
+++ b/assets/stylesheets/modules/embeddings/common/semantic-search.scss
@@ -61,7 +61,6 @@
   }
 
   .ai-result {
-    display: none;
     border-radius: var(--d-border-radius);
 
     .ai-result__icon {
@@ -71,11 +70,5 @@
       font-size: var(--font-up-2);
       color: var(--tertiary);
     }
-  }
-}
-
-.showing-ai-results {
-  .ai-result {
-    display: flex;
   }
 }


### PR DESCRIPTION
**This PR fixes an issue where more results (page 2 and on) were not appearing on scroll.**

Previously we were using CSS to visually hide AI results from the page by default. This resulted in the end of page results never being hit when scrolling to the bottom, and thereby preventing `loadMore()` from being called to render additional results.

In this PR we update the implementation of AI results so the results are physically added and removed from the DOM when toggled, allowing for `loadMore()` to be accurately called.

_Again no specs here for now till we update the LLM abstraction._