### PR TITLE
DEV: Run AI search before submit if query params present

### DIFF
--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
@@ -24,6 +24,7 @@ export default class SemanticSearch extends Component {
   @tracked searching = false;
   @tracked AIResults = [];
   @tracked showingAIResults = false;
+  initialSearchTerm = this.args.outletArgs.search;
 
   get disableToggleSwitch() {
     if (this.searching || this.AIResults.length === 0) {
@@ -60,6 +61,11 @@ export default class SemanticSearch extends Component {
   }
 
   get searchTerm() {
+    if (this.initialSearchTerm !== this.args.outletArgs.search) {
+      this.initialSearchTerm = undefined;
+      this.resetAIResults();
+    }
+
     return this.args.outletArgs.search;
   }
 
@@ -92,7 +98,7 @@ export default class SemanticSearch extends Component {
       return;
     }
 
-    if (this.searchTerm) {
+    if (this.initialSearchTerm) {
       return this.performHyDESearch();
     }
 


### PR DESCRIPTION
Previously, the AI HyDE search was only being performed when the search button was pressed. However, this resulted in AI results never working if you search from the regular search menu and press the advanced button. It also would not work previously if you visit a search url directly with query params such as: `/search?expanded=true&q=testing`

**This PR** checks if a search term is present before deciding to perform the HyDE search or not. If there is a query param with a search term, the AI search will be run automatically. If not, it will wait for the <kbd>:mag: Search</kbd> button to be pressed before running the AI search.

This PR also fixes some linting issues with the `semantic-search.gjs` file

## Before
https://github.com/discourse/discourse-ai/assets/30090424/8863b999-db68-4516-b453-db77085802ab



## After

https://github.com/discourse/discourse-ai/assets/30090424/8a269b89-0daf-485d-a392-9978b4de2e44

