### PR TITLE
FIX: Error 500 from search with only filters

### DIFF
--- a/lib/modules/embeddings/semantic_search.rb
+++ b/lib/modules/embeddings/semantic_search.rb
@@ -36,9 +36,7 @@ module DiscourseAi
         search = Search.new(query, { guardian: guardian })
         search_term = search.term
 
-        if search_term.nil? || search_term.length < SiteSetting.min_search_term_length
-          return []
-        end
+        return [] if search_term.nil? || search_term.length < SiteSetting.min_search_term_length
 
         strategy = DiscourseAi::Embeddings::Strategies::Truncation.new
         vector_rep =

--- a/lib/modules/embeddings/semantic_search.rb
+++ b/lib/modules/embeddings/semantic_search.rb
@@ -36,6 +36,10 @@ module DiscourseAi
         search = Search.new(query, { guardian: guardian })
         search_term = search.term
 
+        if search_term.nil? || search_term.length < SiteSetting.min_search_term_length
+          return []
+        end
+
         strategy = DiscourseAi::Embeddings::Strategies::Truncation.new
         vector_rep =
           DiscourseAi::Embeddings::VectorRepresentations::Base.current_representation(strategy)


### PR DESCRIPTION
This PR fixes an issue where AI semantic search will return a `500` error when only filters are passed and no search term is present. We resolve this by explicitly checking for the presence of a search term and ensuring it is the minimum required length, otherwise we return an empty list.

## Before
<img width="1003" alt="Screenshot 2023-11-22 at 10 55 11" src="https://github.com/discourse/discourse-ai/assets/30090424/0eb1a7a0-c56a-4689-aa39-c8651008b317">


## After
<img width="1005" alt="Screenshot 2023-11-22 at 10 52 11" src="https://github.com/discourse/discourse-ai/assets/30090424/a36dff84-3d6a-4f9e-b690-3846f17a88c1">


