### PR TITLE
DEV: Remove `gem "aws-eventstream"` entry

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -10,7 +10,6 @@
 
 gem "tokenizers", "0.3.3"
 gem "tiktoken_ruby", "0.0.5"
-gem "aws-eventstream", "1.2.0"
 
 enabled_site_setting :discourse_ai_enabled
 


### PR DESCRIPTION
Core already includes aws-eventstream through aws-sdk-s3 and aws-sdk-sns.

Specifying a dependency in a plugin was blocking an upgrade in core (https://github.com/discourse/discourse/pull/24518)