### PR TITLE
FIX: implement tools framework for Anthropic

### DIFF
--- a/lib/modules/ai_bot/anthropic_bot.rb
+++ b/lib/modules/ai_bot/anthropic_bot.rb
@@ -38,7 +38,11 @@ module DiscourseAi
       def build_message(poster_username, content, system: false, function: nil)
         role = poster_username == bot_user.username ? "Assistant" : "Human"
 
-        "#{role}: #{content}"
+        if system || function
+          content
+        else
+          "#{role}: #{content}"
+        end
       end
 
       def model_for
@@ -61,6 +65,7 @@ module DiscourseAi
           temperature: 0.4,
           max_tokens: 3000,
           post: post,
+          stop_sequences: ["\n\nHuman:", "</function_calls>"],
           &blk
         )
       end

--- a/lib/modules/ai_bot/open_ai_bot.rb
+++ b/lib/modules/ai_bot/open_ai_bot.rb
@@ -96,12 +96,13 @@ module DiscourseAi
 
       private
 
-      def populate_functions(partial:, reply:, functions:, done:)
+      def populate_functions(partial:, reply:, functions:, done:, current_delta:)
         return if !partial
         fn = partial.dig(:choices, 0, :delta, :function_call)
         if fn
           functions.add_function(fn[:name]) if fn[:name].present?
           functions.add_argument_fragment(fn[:arguments]) if !fn[:arguments].nil?
+          functions.custom = true
         end
       end
 

--- a/lib/modules/ai_bot/personas/general.rb
+++ b/lib/modules/ai_bot/personas/general.rb
@@ -19,7 +19,7 @@ module DiscourseAi
         def system_prompt
           <<~PROMPT
             You are a helpful Discourse assistant.
-            You understand and generate Discourse Markdown.
+            You _understand_ and **generate** Discourse Markdown.
             You live in a Discourse Forum Message.
 
             You live in the forum with the URL: {site_url}

--- a/spec/lib/modules/ai_bot/anthropic_bot_spec.rb
+++ b/spec/lib/modules/ai_bot/anthropic_bot_spec.rb
@@ -13,7 +13,7 @@ module ::DiscourseAi
       end
 
       let(:bot) { described_class.new(bot_user) }
-      let(:post) { Fabricate(:post) }
+      fab!(:post)
 
       describe "system message" do
         it "includes the full command framework" do
@@ -24,60 +24,133 @@ module ::DiscourseAi
         end
       end
 
+      it "does not include half parsed function calls in reply" do
+        completion1 = "<function"
+        completion2 = <<~REPLY
+          _calls>
+          <invoke>
+          <tool_name>search</tool_name>
+          <parameters>
+          <search_query>hello world</search_query>
+          </parameters>
+          </invoke>
+          </function_calls>
+          junk
+        REPLY
+
+        completion1 = { completion: completion1 }.to_json
+        completion2 = { completion: completion2 }.to_json
+
+        completion3 = { completion: "<func" }.to_json
+
+        request_number = 0
+
+        last_body = nil
+
+        stub_request(:post, "https://api.anthropic.com/v1/complete").with(
+          body:
+            lambda do |body|
+              last_body = body
+              request_number == 2
+            end,
+        ).to_return(status: 200, body: lambda { |request| +"data: #{completion3}" })
+
+        stub_request(:post, "https://api.anthropic.com/v1/complete").with(
+          body:
+            lambda do |body|
+              request_number += 1
+              request_number == 1
+            end,
+        ).to_return(
+          status: 200,
+          body: lambda { |request| +"data: #{completion1}\ndata: #{completion2}" },
+        )
+
+        bot.reply_to(post)
+
+        post.topic.reload
+
+        raw = post.topic.ordered_posts.last.raw
+
+        prompt = JSON.parse(last_body)["prompt"]
+
+        # function call is bundled into Assitant prompt
+        expect(prompt.split("Human:").length).to eq(2)
+
+        # this should be stripped
+        expect(prompt).not_to include("junk")
+
+        expect(raw).to end_with("<func")
+
+        # leading <function_call> should be stripped
+        expect(raw).to start_with("\n\n<details")
+      end
+
+      it "does not include Assistant: in front of the system prompt" do
+        prompt = nil
+
+        stub_request(:post, "https://api.anthropic.com/v1/complete").with(
+          body:
+            lambda do |body|
+              json = JSON.parse(body)
+              prompt = json["prompt"]
+              true
+            end,
+        ).to_return(
+          status: 200,
+          body: lambda { |request| +"data: " << { completion: "Hello World" }.to_json },
+        )
+
+        bot.reply_to(post)
+
+        expect(prompt).not_to be_nil
+        expect(prompt).not_to start_with("Assistant:")
+      end
+
       describe "parsing a reply prompt" do
         it "can correctly predict that a completion needs to be cancelled" do
           functions = DiscourseAi::AiBot::Bot::FunctionCalls.new
 
           # note anthropic API has a silly leading space, we need to make sure we can handle that
           prompt = +<<~REPLY.strip
-            hello world
-            !search(search_query: "hello world", random_stuff: 77)
-            !search(search_query: "hello world 2", random_stuff: 77
+            <function_calls>
+            <invoke>
+            <tool_name>search</tool_name>
+            <parameters>
+            <search_query>hello world</search_query>
+            <random_stuff>77</random_stuff>
+            </parameters>
+            </invoke>
+            </function_calls
           REPLY
 
-          bot.populate_functions(partial: nil, reply: prompt, functions: functions, done: false)
+          bot.populate_functions(
+            partial: nil,
+            reply: prompt,
+            functions: functions,
+            done: false,
+            current_delta: "",
+          )
 
           expect(functions.found?).to eq(true)
           expect(functions.cancel_completion?).to eq(false)
 
-          prompt << ")\n"
+          prompt << ">"
 
-          bot.populate_functions(partial: nil, reply: prompt, functions: functions, done: false)
+          bot.populate_functions(
+            partial: nil,
+            reply: prompt,
+            functions: functions,
+            done: true,
+            current_delta: "",
+          )
 
           expect(functions.found?).to eq(true)
-          expect(functions.cancel_completion?).to eq(false)
 
-          prompt << "a test test"
-
-          bot.populate_functions(partial: nil, reply: prompt, functions: functions, done: false)
-
-          expect(functions.cancel_completion?).to eq(true)
-        end
-
-        it "can correctly detect commands from a prompt" do
-          functions = DiscourseAi::AiBot::Bot::FunctionCalls.new
-
-          # note anthropic API has a silly leading space, we need to make sure we can handle that
-          prompt = <<~REPLY
-            hello world
-            !search(search_query: "hello world", random_stuff: 77)
-            !random(search_query: "hello world", random_stuff: 77)
-            !read(topic_id: 109)
-            !read(random: 109)
-          REPLY
-
-          expect(functions.found?).to eq(false)
-
-          bot.populate_functions(partial: nil, reply: prompt, functions: functions, done: false)
-          expect(functions.found?).to eq(true)
-
-          bot.populate_functions(partial: nil, reply: prompt, functions: functions, done: true)
+          expect(functions.to_a.length).to eq(1)
 
           expect(functions.to_a).to eq(
-            [
-              { name: "search", arguments: "{\"search_query\":\"hello world\"}" },
-              { name: "read", arguments: "{\"topic_id\":\"109\"}" },
-            ],
+            [{ name: "search", arguments: "{\"search_query\":\"hello world\"}" }],
           )
         end
       end

--- a/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
+++ b/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe Jobs::CreateAiReply do
             max_tokens_to_sample: 3000,
             temperature: 0.4,
             stream: true,
+            stop_sequences: ["\n\nHuman:", "</function_calls>"],
           },
         )
       end

--- a/spec/lib/modules/ai_bot/personas/persona_spec.rb
+++ b/spec/lib/modules/ai_bot/personas/persona_spec.rb
@@ -62,16 +62,16 @@ module DiscourseAi::AiBot::Personas
       expect(rendered).to include("test site description")
       expect(rendered).to include("joe, jane")
       expect(rendered).to include(Time.zone.now.to_s)
-      expect(rendered).to include("!search")
-      expect(rendered).to include("!tags")
+      expect(rendered).to include("<tool_name>search</tool_name>")
+      expect(rendered).to include("<tool_name>tags</tool_name>")
       # needs to be configured so it is not available
-      expect(rendered).not_to include("!image")
+      expect(rendered).not_to include("<tool_name>image</tool_name>")
 
       rendered =
         persona.render_system_prompt(topic: topic_with_users, render_function_instructions: false)
 
-      expect(rendered).not_to include("!search")
-      expect(rendered).not_to include("!tags")
+      expect(rendered).not_to include("<tool_name>search</tool_name>")
+      expect(rendered).not_to include("<tool_name>tags</tool_name>")
     end
 
     describe "custom personas" do

--- a/spec/shared/inference/function_list_spec.rb
+++ b/spec/shared/inference/function_list_spec.rb
@@ -27,20 +27,49 @@ module DiscourseAi::Inference
       list
     end
 
-    it "can handle complex parsing" do
-      raw_prompt = <<~PROMPT
-        !get_weather(location: "sydney,melbourne", unit: "f")
-        !get_weather  (location: sydney)
-        !get_weather(location  : "sydney's", unit: "m", invalid: "invalid")
-        !get_weather(unit: "f", invalid: "invalid")
-      PROMPT
-      parsed = function_list.parse_prompt(raw_prompt)
+    let :image_function_list do
+      function = Function.new(name: "image", description: "generates an image")
 
+      function.add_parameter(
+        name: "prompts",
+        type: "array",
+        item_type: "string",
+        required: true,
+        description: "the prompts",
+      )
+
+      list = FunctionList.new
+      list << function
+      list
+    end
+
+    it "can handle function call parsing" do
+      raw_prompt = <<~PROMPT
+      <function_calls>
+      <invoke>
+      <tool_name>image</tool_name>
+      <parameters>
+      <prompts>
+      [
+      "an oil painting",
+      "a cute fluffy orange",
+      "3 apple's",
+      "a cat"
+      ]
+      </prompts>
+      </parameters>
+      </invoke>
+      </function_calls>
+      PROMPT
+      parsed = image_function_list.parse_prompt(raw_prompt)
       expect(parsed).to eq(
         [
-          { name: "get_weather", arguments: { location: "sydney,melbourne", unit: "f" } },
-          { name: "get_weather", arguments: { location: "sydney" } },
-          { name: "get_weather", arguments: { location: "sydney's" } },
+          {
+            name: "image",
+            arguments: {
+              prompts: ["an oil painting", "a cute fluffy orange", "3 apple's", "a cat"],
+            },
+          },
         ],
       )
     end
@@ -51,10 +80,27 @@ module DiscourseAi::Inference
       # this is fragile, by design, we need to test something here
       #
       expected = <<~PROMPT
-        {
-        // Get the weather in a city (default to c)
-        !get_weather(location: string [required] /* the city name */, unit: string [optional] /* the unit of measurement celcius c or fahrenheit f [valid values: c,f] */)
-        }
+        <tools>
+        <tool_description>
+        <tool_name>get_weather</tool_name>
+        <description>Get the weather in a city (default to c)</description>
+        <parameters>
+        <parameter>
+        <name>location</name>
+        <type>string</type>
+        <description>the city name</description>
+        <required>true</required>
+        </parameter>
+        <parameter>
+        <name>unit</name>
+        <type>string</type>
+        <description>the unit of measurement celcius c or fahrenheit f</description>
+        <required>false</required>
+        <options>c,f</options>
+        </parameter>
+        </parameters>
+        </tool_description>
+        </tools>
       PROMPT
       expect(prompt).to include(expected)
     end


### PR DESCRIPTION
Previous to this changeset we used a custom system for tools/command
support for Anthropic.

We defined commands by using !command as a signal to execute it

Following Anthropic Claude 2.1, there is an official supported syntax (beta)
for tools execution.

eg:

```
+      <function_calls>
+      <invoke>
+      <tool_name>image</tool_name>
+      <parameters>
+      <prompts>
+      [
+      "an oil painting",
+      "a cute fluffy orange",
+      "3 apple's",
+      "a cat"
+      ]
+      </prompts>
+      </parameters>
+      </invoke>
+      </function_calls>
```

This implements the spec per Anthropic, it should be stable enough
to also work on other LLMs.

Keep in mind that OpenAI is not impacted here at all, as it has its
own custom system for function calls.

Additionally:

- Fixes the title system prompt so it works with latest Anthropic
- Uses new spec for "system" messages by Anthropic
- Tweak forum helper persona to guide Anthropic a tiny be better

Overall results are pretty awesome and Anthropic Claude performs
really well now on Discourse
