### PR TITLE
FIX: Incorrect sort order label appearing when it should not

### DIFF
--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
@@ -103,8 +103,7 @@ export default class SemanticSearch extends Component {
     if (!this.searchEnabled) {
       return;
     }
-
-    if (this.searchPreferencesManager.sortOrder !== 0) {
+    if (this.searchPreferencesManager?.sortOrder !== undefined && this.searchPreferencesManager?.sortOrder !== 0) {
       this.preventAISearch = true;
       return;
     } else {


### PR DESCRIPTION
`this.searchPreferencesManager.sortOrder` is initially `undefined` causing the label: "_AI Search disabled for this sort order, sort by Relevance to enable._" to appear when it should not. This PR adds a check to ensure the property is defined before checking its order type.