### PR TITLE
A11Y: Add title attribute to sparkles icon for AI search results

### DIFF
--- a/assets/javascripts/discourse/connectors/after-search-result-entry/search-result-decoration.gjs
+++ b/assets/javascripts/discourse/connectors/after-search-result-entry/search-result-decoration.gjs
@@ -1,9 +1,11 @@
 import Component from '@glimmer/component';
 import icon from "discourse-common/helpers/d-icon";
+import i18n from "discourse-common/helpers/i18n";
+
 
 export default class SearchResultDecoration extends Component {
   <template>
-    <div class="ai-result__icon">
+    <div class="ai-result__icon" title={{i18n "discourse_ai.embeddings.ai_generated_result"}}>
       {{icon "discourse-sparkles"}}
     </div>
   </template>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -113,6 +113,7 @@ en:
           toggle: "Showing %{count} results found using AI"
           toggle_hidden: "Hiding %{count} results found using AI"
           none: "Sorry, our AI search found no matching topics."
+        ai_generated_result: "Search result found using AI"
 
       ai_bot:
         pm_warning: "AI chatbot messages are monitored regularly by moderators."


### PR DESCRIPTION
This PR adds the `title` attribute to the sparkles icon on AI generated search results.

<img width="1034" alt="Screenshot 2023-11-27 at 14 12 31" src="https://github.com/discourse/discourse-ai/assets/30090424/1473f609-a897-4acd-af7a-e2ebdb7cdfdf">
