### PR TITLE
FIX: adjust tag composer input to avoid wrapping

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -294,12 +294,15 @@
 
 // Prevent suggestion button from wrapping
 #reply-control {
-  .with-category .showing-ai-suggestions .category-input,
-  .with-tags .showing-ai-suggestions .mini-tag-chooser {
+  .with-category .showing-ai-suggestions .category-input {
     flex-wrap: nowrap;
     .select-kit {
-      max-width: calc(100% - 34px);
+      max-width: calc(100% - 2.25em);
     }
+  }
+
+  .with-tags .showing-ai-suggestions .mini-tag-chooser.select-kit {
+    max-width: calc(100% - 2.25em);
   }
 }
 


### PR DESCRIPTION
The CSS for categories was fine, but it's structured a little differently for tags... 

`.mini-tag-chooser .select-kit` needs to be `.mini-tag-chooser.select-kit` — also switched to `em`s so this scales with font-size changes. 

Before: 
![Screenshot 2023-11-28 at 5 23 35 PM](https://github.com/discourse/discourse-ai/assets/1681963/005e2bbe-abc3-4e28-a4d9-8f1bfd07b3ed)


After:
![Screenshot 2023-11-28 at 5 25 28 PM](https://github.com/discourse/discourse-ai/assets/1681963/0d79ab37-8919-4786-b0a7-fbb45333105f)
