### PR TITLE
FEATURE: User sentiment on profile summary page

### DIFF
--- a/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.hbs
+++ b/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.hbs
@@ -1,16 +1,8 @@
-{{#if
-  (and
-    this.siteSettings.ai_sentiment_enabled
-    @outletArgs.model.sentiment
-    this.showSentiment
-  )
-}}
-  <li class="user-summary-stat-outlet sentiment">
-    <span class="value" title={{i18n "discourse_ai.sentiments.summary.title"}}>
-      {{d-icon this.icon}}
-    </span>
-    <span class="label">
-      {{html-safe (i18n "discourse_ai.sentiments.summary.label")}}
-    </span>
-  </li>
-{{/if}}
+<li class="user-summary-stat-outlet sentiment">
+  <span class="value" title={{i18n "discourse_ai.sentiments.summary.title"}}>
+    {{d-icon this.icon}}
+  </span>
+  <span class="label">
+    {{html-safe (i18n "discourse_ai.sentiments.summary.label")}}
+  </span>
+</li>

--- a/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.hbs
+++ b/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.hbs
@@ -1,0 +1,10 @@
+{{#if (and this.siteSettings.ai_sentiment_enabled @outletArgs.model.sentiment this.showSentiment)}}
+  <li class="user-summary-stat-outlet sentiment">
+    <span class="value" title={{(i18n "discourse_ai.sentiments.summary.title")}}>
+      {{d-icon this.icon}}
+    </span>
+    <span class="label">
+      {{html-safe (i18n "discourse_ai.sentiments.summary.label")}}
+    </span>
+  </li>
+{{/if}}

--- a/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.hbs
+++ b/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.hbs
@@ -1,6 +1,6 @@
 {{#if (and this.siteSettings.ai_sentiment_enabled @outletArgs.model.sentiment this.showSentiment)}}
   <li class="user-summary-stat-outlet sentiment">
-    <span class="value" title={{(i18n "discourse_ai.sentiments.summary.title")}}>
+    <span class="value" title={{i18n "discourse_ai.sentiments.summary.title"}}>
       {{d-icon this.icon}}
     </span>
     <span class="label">

--- a/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.hbs
+++ b/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.hbs
@@ -1,4 +1,10 @@
-{{#if (and this.siteSettings.ai_sentiment_enabled @outletArgs.model.sentiment this.showSentiment)}}
+{{#if
+  (and
+    this.siteSettings.ai_sentiment_enabled
+    @outletArgs.model.sentiment
+    this.showSentiment
+  )
+}}
   <li class="user-summary-stat-outlet sentiment">
     <span class="value" title={{i18n "discourse_ai.sentiments.summary.title"}}>
       {{d-icon this.icon}}

--- a/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.js
+++ b/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.js
@@ -1,9 +1,13 @@
 import Component from "@glimmer/component";
-import { inject as service } from "@ember/service";
 
 export default class Sentiment extends Component {
   static shouldRender(outletArgs, helper) {
-    return helper.siteSettings.ai_sentiment_enabled && outletArgs.model.sentiment && helper.currentUser && helper.currentUser.staff;
+    return (
+      helper.siteSettings.ai_sentiment_enabled &&
+      outletArgs.model.sentiment &&
+      helper.currentUser &&
+      helper.currentUser.staff
+    );
   }
 
   get icon() {

--- a/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.js
+++ b/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.js
@@ -2,11 +2,8 @@ import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 
 export default class Sentiment extends Component {
-  @service siteSettings;
-  @service currentUser;
-
-  get showSentiment() {
-    return this.currentUser && this.currentUser.staff;
+  static shouldRender(outletArgs, helper) {
+    return helper.siteSettings.ai_sentiment_enabled && outletArgs.model.sentiment && helper.currentUser && helper.currentUser.staff;
   }
 
   get icon() {

--- a/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.js
+++ b/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.js
@@ -10,7 +10,7 @@ export default class Sentiment extends Component {
   }
 
   get icon() {
-    switch(this.args.outletArgs.model.sentiment) {
+    switch (this.args.outletArgs.model.sentiment) {
       case "positive":
         return "smile";
       case "negative":

--- a/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.js
+++ b/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.js
@@ -1,0 +1,24 @@
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+
+export default class Sentiment extends Component {
+  @service siteSettings;
+  @service currentUser;
+
+  get showSentiment() {
+    return this.currentUser && this.currentUser.staff;
+  }
+
+  get icon() {
+    switch(this.args.outletArgs.model.sentiment) {
+      case "positive":
+        return "smile";
+      case "negative":
+        return "frown";
+      case "neutral":
+        return "meh";
+      default:
+        return "meh";
+    }
+  }
+}

--- a/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.js
+++ b/assets/javascripts/discourse/connectors/user-summary-stat/sentiment.js
@@ -4,6 +4,7 @@ export default class Sentiment extends Component {
   static shouldRender(outletArgs, helper) {
     return (
       helper.siteSettings.ai_sentiment_enabled &&
+      helper.siteSettings.ai_sentiment_show_sentiment_public_profile &&
       outletArgs.model.sentiment &&
       helper.currentUser &&
       helper.currentUser.staff

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -129,6 +129,11 @@ en:
       sentiments:
         dashboard:
           title: "Sentiment"
+        summary:
+          label: "sentiment"
+          title: "Experimental AI-powered sentiment analysis of this person's most recent posts."
+
+      
 
     review:
       types:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -25,6 +25,7 @@ en:
     ai_sentiment_inference_service_api_endpoint: "URL where the API is running for the sentiment module"
     ai_sentiment_inference_service_api_key: "API key for the sentiment API"
     ai_sentiment_models: "Models to use for inference. Sentiment classifies post on the positive/neutral/negative space. Emotion classifies on the anger/disgust/fear/joy/neutral/sadness/surprise space."
+    ai_sentiment_show_sentiment_public_profile: "Make a user dominant sentiment visible on their public profile."
 
     ai_nsfw_detection_enabled: "Enable the NSFW module."
     ai_nsfw_inference_service_api_endpoint: "URL where the API is running for the NSFW module"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -66,6 +66,9 @@ discourse_ai:
     choices:
       - sentiment
       - emotion
+  ai_sentiment_show_sentiment_public_profile:
+    default: true
+    client: true
 
   ai_nsfw_detection_enabled: false
   ai_nsfw_inference_service_api_endpoint:

--- a/lib/sentiment/sentiment_classification.rb
+++ b/lib/sentiment/sentiment_classification.rb
@@ -28,7 +28,8 @@ module DiscourseAi
       end
 
       def request(target_to_classify)
-        target_content = content_of(target_to_classify)
+        target_content =
+          DiscourseAi::Tokenizer::BertTokenizer.truncate(content_of(target_to_classify), 500)
 
         available_models.reduce({}) do |memo, model|
           memo[model] = request_with(model, target_content)

--- a/lib/tasks/modules/sentiment/backfill.rake
+++ b/lib/tasks/modules/sentiment/backfill.rake
@@ -6,9 +6,12 @@ task "ai:sentiment:backfill", [:start_post] => [:environment] do |_, args|
 
   Post
     .joins("INNER JOIN topics ON topics.id = posts.topic_id")
-    .joins(
-      "LEFT JOIN classification_results ON classification_results.target_id = posts.id AND classification_results.target_type = 'Post'",
-    )
+    .joins(<<~SQL)
+      LEFT JOIN classification_results ON
+        classification_results.target_id = posts.id AND
+        classification_results.model_used = 'sentiment' AND
+        classification_results.target_type = 'Post'
+    SQL
     .where("classification_results.target_id IS NULL")
     .where("posts.id >= ?", args[:start_post].to_i || 0)
     .where("category_id IN (?)", public_categories)
@@ -16,8 +19,12 @@ task "ai:sentiment:backfill", [:start_post] => [:environment] do |_, args|
     .order("posts.id ASC")
     .find_each do |post|
       print "."
-      DiscourseAi::PostClassificator.new(
-        DiscourseAi::Sentiment::SentimentClassification.new,
-      ).classify!(post)
+      begin
+        DiscourseAi::PostClassificator.new(
+          DiscourseAi::Sentiment::SentimentClassification.new,
+        ).classify!(post)
+      rescue => e 
+        puts "Error: #{e.message}"
+      end
     end
 end

--- a/lib/tasks/modules/sentiment/backfill.rake
+++ b/lib/tasks/modules/sentiment/backfill.rake
@@ -23,7 +23,7 @@ task "ai:sentiment:backfill", [:start_post] => [:environment] do |_, args|
         DiscourseAi::PostClassificator.new(
           DiscourseAi::Sentiment::SentimentClassification.new,
         ).classify!(post)
-      rescue => e 
+      rescue => e
         puts "Error: #{e.message}"
       end
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -33,6 +33,10 @@ Rails.autoloaders.main.push_dir(File.join(__dir__, "lib"), namespace: ::Discours
 
 require_relative "lib/engine"
 
+register_svg_icon "smile"
+register_svg_icon "frown"
+register_svg_icon "meh"
+
 after_initialize do
   # do not autoload this cause we may have no namespace
   require_relative "discourse_automation/llm_triage"
@@ -54,6 +58,67 @@ after_initialize do
 
   on(:reviewable_transitioned_to) do |new_status, reviewable|
     ModelAccuracy.adjust_model_accuracy(new_status, reviewable)
+  end
+
+  require_dependency "user_summary"
+  class ::UserSummary
+    def sentiment
+      neutral, positive, negative = DB.query_single(<<~SQL, user_id: @user.id)
+        WITH last_interactions_classified AS (
+          SELECT
+            1 AS total,
+            CASE WHEN (classification::jsonb->'positive')::integer >= 60 THEN 1 ELSE 0 END AS positive,
+            CASE WHEN (classification::jsonb->'negative')::integer >= 60 THEN 1 ELSE 0 END AS negative
+          FROM
+            classification_results AS cr
+          INNER JOIN
+            posts AS p ON
+            p.id = cr.target_id AND
+            cr.target_type = 'Post'
+          INNER JOIN topics AS t ON
+            t.id = p.topic_id
+          INNER JOIN categories AS c ON
+            c.id = t.category_id
+          WHERE
+            model_used = 'sentiment' AND
+            p.user_id = :user_id
+          ORDER BY
+            p.created_at DESC
+          LIMIT
+            100
+        )
+        SELECT
+          SUM(total) - SUM(positive) - SUM(negative) AS neutral,
+          SUM(positive) AS positive,
+          SUM(negative) AS negative
+        FROM
+          last_interactions_classified
+      SQL
+
+      neutral = neutral || 0
+      positive = positive || 0
+      negative = negative || 0
+
+      return nil if neutral + positive + negative < 5
+
+      case [neutral / 5, positive, negative].max
+      when positive
+        :positive
+      when negative
+        :negative
+      else
+        :neutral
+      end
+    end
+  end
+
+  require_dependency "user_summary_serializer"
+  class ::UserSummarySerializer
+    attributes :sentiment
+
+    def sentiment
+      object.sentiment.to_s
+    end
   end
 
   if Rails.env.test?


### PR DESCRIPTION
This introduces a new user stat in a user profile summary page.

It will show either neutral/positive/negative according to the dominant
sentiment in the user last interactions.

The user-stat widget is only rendered for staff.


![image](https://github.com/discourse/discourse-ai/assets/1385470/effbef46-9b91-4a11-8fc3-04e6da61e776)


![image](https://github.com/discourse/discourse-ai/assets/1385470/977fe1c4-08c5-4382-84af-406d550f45c7)

![image](https://github.com/discourse/discourse-ai/assets/1385470/f78e331c-74b5-4e7f-9545-b54c05968dd0)
![image](https://github.com/discourse/discourse-ai/assets/1385470/68cee6d2-93eb-4092-929b-2ce524f71514)

