### PR TITLE
FIX: command selector behavior stopped working

### DIFF
--- a/assets/javascripts/discourse/components/ai-command-selector.js
+++ b/assets/javascripts/discourse/components/ai-command-selector.js
@@ -7,7 +7,7 @@ export default MultiSelectComponent.extend({
   }),
 
   content: computed(function () {
-    return this.commands.value;
+    return this.commands;
   }),
 
   value: "",

--- a/spec/system/ai_bot/persona_spec.rb
+++ b/spec/system/ai_bot/persona_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe "AI personas", type: :system, js: true do
     find(".ai-persona-editor__name").set("Test Persona")
     find(".ai-persona-editor__description").fill_in(with: "I am a test persona")
     find(".ai-persona-editor__system_prompt").fill_in(with: "You are a helpful bot")
+
+    command_selector = PageObjects::Components::SelectKit.new(".ai-persona-editor__commands")
+    command_selector.expand
+    command_selector.select_row_by_value("ReadCommand")
+
     find(".ai-persona-editor__save").click()
 
     expect(page).not_to have_current_path("/admin/plugins/discourse-ai/ai_personas/new")
@@ -45,6 +50,7 @@ RSpec.describe "AI personas", type: :system, js: true do
     expect(persona.name).to eq("Test Persona")
     expect(persona.description).to eq("I am a test persona")
     expect(persona.system_prompt).to eq("You are a helpful bot")
+    expect(persona.commands).to eq(["ReadCommand"])
   end
 
   it "will not allow deletion or editing of system personas" do


### PR DESCRIPTION
When moving ai-command-selector from gjs to js the underlying
behavior changed, this corrects it and adds a test case.
