### PR TITLE
FIX: Use Guardian.basic_user instead of new (anon)

### DIFF
--- a/lib/ai_bot/commands/read_command.rb
+++ b/lib/ai_bot/commands/read_command.rb
@@ -41,11 +41,12 @@ module DiscourseAi::AiBot::Commands
       topic_id = topic_id.to_i
 
       topic = Topic.find_by(id: topic_id)
-      return not_found if !topic || !Guardian.new.can_see?(topic)
+      return not_found if !topic || !Guardian.basic_user.can_see?(topic)
 
       @title = topic.title
 
-      posts = Post.secured(Guardian.new).where(topic_id: topic_id).order(:post_number).limit(40)
+      posts =
+        Post.secured(Guardian.basic_user).where(topic_id: topic_id).order(:post_number).limit(40)
       @url = topic.relative_url(post_number)
 
       posts = posts.where("post_number = ?", post_number) if post_number
@@ -60,7 +61,7 @@ module DiscourseAi::AiBot::Commands
       content << "\ncategories: #{category_names}" if category_names.present?
 
       if topic.tags.length > 0
-        tags = DiscourseTagging.filter_visible(topic.tags, Guardian.new)
+        tags = DiscourseTagging.filter_visible(topic.tags, Guardian.basic_user)
         content << "\ntags: #{tags.map(&:name).join(", ")}\n\n" if tags.length > 0
       end
 

--- a/lib/ai_bot/commands/search_command.rb
+++ b/lib/ai_bot/commands/search_command.rb
@@ -123,7 +123,7 @@ module DiscourseAi::AiBot::Commands
         Search.execute(
           search_string.to_s + " status:public",
           search_type: :full_page,
-          guardian: Guardian.new(),
+          guardian: Guardian.basic_user,
         )
 
       # let's be frugal with tokens, 50 results is too much and stuff gets cut off
@@ -140,10 +140,10 @@ module DiscourseAi::AiBot::Commands
       posts = posts[0..limit - 1]
 
       if should_try_semantic_search
-        semantic_search = DiscourseAi::Embeddings::SemanticSearch.new(Guardian.new())
+        semantic_search = DiscourseAi::Embeddings::SemanticSearch.new(Guardian.basic_user)
         topic_ids = Set.new(posts.map(&:topic_id))
 
-        search = Search.new(search_string, guardian: Guardian.new)
+        search = Search.new(search_string, guardian: Guardian.basic_user)
 
         results = nil
         begin

--- a/lib/ai_bot/commands/summarize_command.rb
+++ b/lib/ai_bot/commands/summarize_command.rb
@@ -51,7 +51,7 @@ module DiscourseAi::AiBot::Commands
       topic = nil
       if topic_id > 0
         topic = Topic.find_by(id: topic_id)
-        topic = nil if !topic || !Guardian.new.can_see?(topic)
+        topic = nil if !topic || !Guardian.basic_user.can_see?(topic)
       end
 
       @last_summary = nil

--- a/spec/lib/modules/embeddings/semantic_search_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_search_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe DiscourseAi::Embeddings::SemanticSearch do
   fab!(:user) { Fabricate(:user) }
 
   let(:query) { "test_query" }
-  let(:subject) { described_class.new(Guardian.new(user)) }
+  let(:subject) { described_class.new(user.guardian) }
 
   describe "#search_for_topics" do
     let(:hypothetical_post) { "This is an hypothetical post generated from the keyword test_query" }
@@ -129,7 +129,7 @@ RSpec.describe DiscourseAi::Embeddings::SemanticSearch do
             posts =
               DiscourseAi::Completions::Llm.with_prepared_responses(
                 ["<ai>#{hypothetical_post}</ai>"],
-              ) { described_class.new(Guardian.new(nil)).search_for_topics(query) }
+              ) { described_class.new(Guardian.basic_user).search_for_topics(query) }
 
             expect(posts).to be_empty
           end

--- a/spec/lib/modules/toxicity/entry_point_spec.rb
+++ b/spec/lib/modules/toxicity/entry_point_spec.rb
@@ -58,7 +58,7 @@ describe DiscourseAi::Toxicity::EntryPoint do
       fab!(:chat_message) { Fabricate(:chat_message) }
       let(:updater) do
         Chat::UpdateMessage.call(
-          guardian: Guardian.new(chat_message.user),
+          guardian: chat_message.user.guardian,
           message_id: chat_message.id,
           message: "This is my updated message",
         )

--- a/spec/models/reviewable_ai_post_spec.rb
+++ b/spec/models/reviewable_ai_post_spec.rb
@@ -6,7 +6,7 @@ describe ReviewableAiPost do
   fab!(:target) { Fabricate(:post) }
 
   describe "#build_actions" do
-    let(:guardian) { Guardian.new }
+    let(:guardian) { Guardian.basic_user }
 
     let(:reviewable) do
       subject.tap do |r|

--- a/spec/serializers/ai_chat_channel_serializer_spec.rb
+++ b/spec/serializers/ai_chat_channel_serializer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AiChatChannelSerializer do
       fab!(:dm_channel) { Fabricate(:direct_message_channel) }
 
       it "display every participant" do
-        serialized = described_class.new(dm_channel, scope: Guardian.new(admin), root: nil)
+        serialized = described_class.new(dm_channel, scope: admin.guardian, root: nil)
 
         expect(serialized.title).to eq(dm_channel.title(nil))
       end
@@ -18,7 +18,7 @@ RSpec.describe AiChatChannelSerializer do
       fab!(:channel) { Fabricate(:chat_channel) }
 
       it "displays the category title" do
-        serialized = described_class.new(channel, scope: Guardian.new(admin), root: nil)
+        serialized = described_class.new(channel, scope: admin.guardian, root: nil)
 
         expect(serialized.title).to eq(channel.title)
       end


### PR DESCRIPTION
c.f. discourse/discourse@de983796e1b66aa2ab039a4fb6e32cec8a65a098

There will soon be additional login_required checks
for Guardian, and the intent of many checks by automated
systems is better fulfilled by using BasicUser, which
simulates a logged in TL0 forum user, rather than an
anon user.
