### PR TITLE
FEATURE: scale up result count for search depending on model

### DIFF
--- a/assets/javascripts/initializers/ai-bot-replies.js
+++ b/assets/javascripts/initializers/ai-bot-replies.js
@@ -8,7 +8,7 @@ import { registerWidgetShim } from "discourse/widgets/render-glimmer";
 import { composeAiBotMessage } from "discourse/plugins/discourse-ai/discourse/lib/ai-bot-helper";
 
 function isGPTBot(user) {
-  return user && [-110, -111, -112].includes(user.id);
+  return user && [-110, -111, -112, -113].includes(user.id);
 }
 
 function attachHeaderIcon(api) {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -155,6 +155,9 @@ en:
       searching: "Searching for: '%{query}'"
       command_options:
         search:
+          max_results:
+            name: "Maximum number of results"
+            description: "Maximum number of results to include in the search - if empty default rules will be used and count will be scaled depending on model used. Highest value is 100."
           base_query:
             name: "Base Search Query"
             description: "Base query to use when searching. Example: '#urgent' will prepend '#urgent' to the search query and only include topics with the urgent category or tag."

--- a/spec/requests/admin/ai_personas_controller_spec.rb
+++ b/spec/requests/admin/ai_personas_controller_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
             "description" =>
               I18n.t("discourse_ai.ai_bot.command_options.search.base_query.description"),
           },
+          "max_results" => {
+            "type" => "integer",
+            "name" => I18n.t("discourse_ai.ai_bot.command_options.search.max_results.name"),
+            "description" =>
+              I18n.t("discourse_ai.ai_bot.command_options.search.max_results.description"),
+          },
         },
       )
 


### PR DESCRIPTION
We were limiting to 20 results unconditionally cause we had to make
sure search always fit in an 8k context window.

Models such as GPT 3.5 Turbo (16k) and GPT 4 Turbo / Claude 2.1 (over 150k)
allow us to return a lot more results.

This means we have a much richer understanding cause context is far
larger.

This also allows a persona to tweak this number, in some cases admin
may want to be conservative and save on tokens by limiting results

This also tweaks the `limit` param which GPT-4 liked to set to tell
model only to use it when it needs to (and describes default behavior)
