### PR TITLE
FEATURE: try including views/username/likes in search results

### DIFF
--- a/lib/ai_bot/commands/search_command.rb
+++ b/lib/ai_bot/commands/search_command.rb
@@ -208,9 +208,14 @@ module DiscourseAi::AiBot::Commands
           row = {
             title: post.topic.title,
             url: Discourse.base_path + post.url,
+            username: post.user&.username,
             excerpt: post.excerpt,
             created: post.created_at,
             category: category_names,
+            likes: post.like_count,
+            topic_views: post.topic.views,
+            topic_likes: post.topic.like_count,
+            topic_replies: post.topic.posts_count - 1,
           }
 
           if SiteSetting.tagging_enabled

--- a/spec/lib/modules/ai_bot/commands/search_command_spec.rb
+++ b/spec/lib/modules/ai_bot/commands/search_command_spec.rb
@@ -127,9 +127,11 @@ RSpec.describe DiscourseAi::AiBot::Commands::SearchCommand do
       expect(results[:rows].to_s).to include("/subfolder" + post1.url)
     end
 
-    it "returns category and tags" do
-      post1 = Fabricate(:post, topic: topic_with_tags)
+    it "returns rich topic information" do
+      post1 = Fabricate(:post, like_count: 1, topic: topic_with_tags)
       search = described_class.new(bot: nil, post: post1, args: nil)
+      post1.topic.update!(views: 100, posts_count: 2, like_count: 10)
+
       results = search.process(user: post1.user.username)
 
       row = results[:rows].first
@@ -139,6 +141,21 @@ RSpec.describe DiscourseAi::AiBot::Commands::SearchCommand do
 
       tags = row[results[:column_names].index("tags")]
       expect(tags).to eq("funny, sad")
+
+      likes = row[results[:column_names].index("likes")]
+      expect(likes).to eq(1)
+
+      username = row[results[:column_names].index("username")]
+      expect(username).to eq(post1.user.username)
+
+      likes = row[results[:column_names].index("topic_likes")]
+      expect(likes).to eq(10)
+
+      views = row[results[:column_names].index("topic_views")]
+      expect(views).to eq(100)
+
+      replies = row[results[:column_names].index("topic_replies")]
+      expect(replies).to eq(1)
     end
 
     it "scales results to number of tokens" do


### PR DESCRIPTION
This is somewhat experimental, but the context of likes/view/username
can help the llm find out what content is more important or even
common users that produce great content

This inflates the amount of tokens somewhat, but given it is all numbers
and search columns titles are only included once this is not severe
