### PR TITLE
FEATURE: Add custom prompts to post helper options

### DIFF
--- a/assets/javascripts/discourse/components/ai-helper-custom-prompt.gjs
+++ b/assets/javascripts/discourse/components/ai-helper-custom-prompt.gjs
@@ -1,4 +1,4 @@
-import Component from '@glimmer/component';
+import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";
 import { action } from "@ember/object";
@@ -9,10 +9,7 @@ import not from "truth-helpers/helpers/not";
 
 export default class AiHelperCustomPrompt extends Component {
   <template>
-    <div
-      class="ai-custom-prompt"
-      {{didInsert this.setupCustomPrompt}}
-    >
+    <div class="ai-custom-prompt" {{didInsert this.setupCustomPrompt}}>
       <Input
         @value={{@value}}
         placeholder={{i18n

--- a/assets/javascripts/discourse/components/ai-helper-custom-prompt.gjs
+++ b/assets/javascripts/discourse/components/ai-helper-custom-prompt.gjs
@@ -7,7 +7,6 @@ import DButton from "discourse/components/d-button";
 import i18n from "discourse-common/helpers/i18n";
 import not from "truth-helpers/helpers/not";
 
-
 export default class AiHelperCustomPrompt extends Component {
   <template>
     <div

--- a/assets/javascripts/discourse/components/ai-helper-custom-prompt.gjs
+++ b/assets/javascripts/discourse/components/ai-helper-custom-prompt.gjs
@@ -1,0 +1,50 @@
+import Component from '@glimmer/component';
+import { tracked } from "@glimmer/tracking";
+import { Input } from "@ember/component";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import DButton from "discourse/components/d-button";
+import i18n from "discourse-common/helpers/i18n";
+import not from "truth-helpers/helpers/not";
+
+
+export default class AiHelperCustomPrompt extends Component {
+  <template>
+    <div
+      class="ai-custom-prompt"
+      {{didInsert this.setupCustomPrompt}}
+    >
+      <Input
+        @value={{@value}}
+        placeholder={{i18n
+          "discourse_ai.ai_helper.context_menu.custom_prompt.placeholder"
+        }}
+        class="ai-custom-prompt__input"
+        @enter={{this.sendInput}}
+      />
+
+      <DButton
+        @class="ai-custom-prompt__submit btn-primary"
+        @icon="discourse-sparkles"
+        @action={{@submit}}
+        @actionParam={{@promptArgs}}
+        @disabled={{not @value.length}}
+      />
+    </div>
+  </template>
+
+  @tracked _customPromptInput;
+
+  @action
+  setupCustomPrompt() {
+    this._customPromptInput = document.querySelector(
+      ".ai-custom-prompt__input"
+    );
+    this._customPromptInput.focus();
+  }
+
+  @action
+  sendInput() {
+    return this.args.submit(this.args.promptArgs);
+  }
+}

--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.hbs
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.hbs
@@ -17,27 +17,11 @@
         <ul class="ai-helper-context-menu__options">
           {{#each this.helperOptions as |option|}}
             {{#if (eq option.name "custom_prompt")}}
-              <div
-                class="ai-custom-prompt"
-                {{did-insert this.setupCustomPrompt}}
-              >
-                <Input
-                  @value={{this.customPromptValue}}
-                  placeholder={{i18n
-                    "discourse_ai.ai_helper.context_menu.custom_prompt.placeholder"
-                  }}
-                  class="ai-custom-prompt__input"
-                  @enter={{action (fn this.updateSelected option)}}
-                />
-
-                <DButton
-                  @class="ai-custom-prompt__submit btn-primary"
-                  @icon="discourse-sparkles"
-                  @action={{this.updateSelected}}
-                  @actionParam={{option}}
-                  @disabled={{not this.customPromptValue.length}}
-                />
-              </div>
+              <AiHelperCustomPrompt
+                @value={{this.customPromptValue}}
+                @promptArgs={{option}}
+                @submit={{this.updateSelected}}
+              />
             {{else}}
               <li data-name={{option.translated_name}} data-value={{option.id}}>
                 <DButton

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -108,39 +108,19 @@
     align-items: center;
     flex-flow: row wrap;
   }
+}
 
-  &__custom-prompt {
-    display: flex;
-    flex-flow: row wrap;
-    padding: 0.5rem;
+.ai-custom-prompt {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
 
-    &-header {
-      margin-bottom: 0.5rem;
+  &__input[type="text"] {
+    border-color: var(--primary-400);
+    margin-bottom: 0;
 
-      .btn {
-        padding: 0;
-      }
-    }
-
-    .ai-custom-prompt-input {
-      min-height: 90px;
-      width: 100%;
-    }
-  }
-
-  .ai-custom-prompt {
-    display: flex;
-    gap: 0.25rem;
-    margin-bottom: 0.5rem;
-
-    &__input {
-      background: var(--primary-low);
-      border-color: var(--primary-low);
-      margin-bottom: 0;
-
-      &::placeholder {
-        color: var(--primary-medium);
-      }
+    &::placeholder {
+      color: var(--primary-medium);
     }
   }
 }
@@ -326,6 +306,15 @@
     align-items: flex-start;
     gap: 0.25rem;
     justify-content: flex-start;
+
+    > button:last-child {
+      margin-bottom: 0.5rem;
+    }
+
+    .ai-custom-prompt {
+      padding: 0.5rem;
+      margin-bottom: 0;
+    }
   }
 
   &__suggestion {

--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -85,6 +85,8 @@ module DiscourseAi
           </input>
           <output>
           </output>
+          <result>
+          </result>
         ]
 
         result.dup.tap { |dup_result| tags_to_remove.each { |tag| dup_result.gsub!(tag, "") } }
@@ -130,7 +132,7 @@ module DiscourseAi
         when "tone"
           %w[composer]
         when "custom_prompt"
-          %w[composer]
+          %w[composer post]
         when "rewrite"
           %w[composer]
         when "explain"


### PR DESCRIPTION
This PR adds the custom prompt feature to outside composer AI post helper:

https://github.com/discourse/discourse-ai/assets/30090424/d1092354-8795-478b-b599-6aa65dea94f6

Still some issues with system specs for AI translate/explain and other suggest options, will address in separate PR.