### PR TITLE
DEV: Replace deprecated min_trust_to_create_post

### DIFF
--- a/spec/lib/modules/embeddings/entry_point_spec.rb
+++ b/spec/lib/modules/embeddings/entry_point_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe DiscourseAi::Embeddings::EntryPoint do
-  fab!(:user) { Fabricate(:user) }
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
   describe "registering event callbacks" do
     context "when creating a topic" do

--- a/spec/lib/modules/nsfw/entry_point_spec.rb
+++ b/spec/lib/modules/nsfw/entry_point_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe DiscourseAi::Nsfw::EntryPoint do
-  fab!(:user) { Fabricate(:user) }
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
   describe "registering event callbacks" do
     fab!(:image_upload) { Fabricate(:upload) }

--- a/spec/lib/modules/sentiment/entry_point_spec.rb
+++ b/spec/lib/modules/sentiment/entry_point_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../../../support/sentiment_inference_stubs"
 
 RSpec.describe DiscourseAi::Sentiment::EntryPoint do
-  fab!(:user) { Fabricate(:user) }
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
   describe "registering event callbacks" do
     context "when creating a post" do

--- a/spec/lib/modules/toxicity/entry_point_spec.rb
+++ b/spec/lib/modules/toxicity/entry_point_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe DiscourseAi::Toxicity::EntryPoint do
-  fab!(:user) { Fabricate(:user) }
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
   describe "registering event callbacks" do
     before { SiteSetting.ai_toxicity_enabled = true }


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/24740, `min_trust_to_create_topic` site setting was replaced by `create_topic_allowed_groups`. This PR replaces the former, deprecated one, with the latter.