### PR TITLE
UX: Automatically detect text direction for AI generated text

### DIFF
--- a/assets/javascripts/discourse/connectors/post-text-buttons/ai-helper-options-menu.gjs
+++ b/assets/javascripts/discourse/connectors/post-text-buttons/ai-helper-options-menu.gjs
@@ -260,7 +260,7 @@ export default class AIHelperOptionsMenu extends Component {
             {{willDestroy this.unsubscribe}}
           >
             {{#if this.suggestion}}
-              <div class="ai-post-helper__suggestion__text">
+              <div class="ai-post-helper__suggestion__text" dir="auto">
                 {{this.suggestion}}
               </div>
               <di class="ai-post-helper__suggestion__buttons">


### PR DESCRIPTION
Previously, when users asked the AI to generate responses in languages like Arabic or Hebrew (RTL languages), the answer would follow whatever direction the site was set to. For example, if the site was set to LTR, an answer in an RTL language would be displayed in LTR mode, making the answer very hard to read.

This PR introduces the [dir="auto"](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) attribute to the element containing the AI answer. This improvement makes the browser automatically detect the direction of the content and set the appropriate direction, ensuring that the AI answer aligns correctly with the language's reading direction regardless of the site's overall mode.

Before:

![image](https://github.com/discourse/discourse-ai/assets/17474474/f8efe9e9-8891-439a-bd66-1c8703908bba)


After:

![image](https://github.com/discourse/discourse-ai/assets/17474474/7414cd1e-b407-4226-a287-4c38bd2c4cd7)


Internal topic: t/117852/10.