### PR TITLE
UX: Hide suggest edit button in fast edit when triggering from AI

### DIFF
--- a/assets/javascripts/discourse/connectors/fast-edit-footer-after/ai-edit-suggestion-button.gjs
+++ b/assets/javascripts/discourse/connectors/fast-edit-footer-after/ai-edit-suggestion-button.gjs
@@ -26,8 +26,7 @@ export default class AiEditSuggestionButton extends Component {
   get disabled() {
     return (
       this.loading ||
-      this.suggestion?.length > 0 ||
-      this.args.outletArgs.newValue
+      this.suggestion?.length > 0
     );
   }
 
@@ -68,13 +67,15 @@ export default class AiEditSuggestionButton extends Component {
   }
 
   <template>
-    <DButton
-      class="btn-small btn-ai-suggest-edit"
-      @action={{this.suggest}}
-      @icon="discourse-sparkles"
-      @label="discourse_ai.ai_helper.fast_edit.suggest_button"
-      @isLoading={{this.loading}}
-      @disabled={{this.disabled}}
-    />
+    {{#unless @outletArgs.newValue}}
+      <DButton
+        class="btn-small btn-ai-suggest-edit"
+        @action={{this.suggest}}
+        @icon="discourse-sparkles"
+        @label="discourse_ai.ai_helper.fast_edit.suggest_button"
+        @isLoading={{this.loading}}
+        @disabled={{this.disabled}}
+      />
+    {{/unless}}
   </template>
 }

--- a/assets/javascripts/discourse/connectors/fast-edit-footer-after/ai-edit-suggestion-button.gjs
+++ b/assets/javascripts/discourse/connectors/fast-edit-footer-after/ai-edit-suggestion-button.gjs
@@ -24,10 +24,7 @@ export default class AiEditSuggestionButton extends Component {
   }
 
   get disabled() {
-    return (
-      this.loading ||
-      this.suggestion?.length > 0
-    );
+    return this.loading || this.suggestion?.length > 0;
   }
 
   async loadMode() {


### PR DESCRIPTION
This PR hides the <kbd>:sparkles: Suggest Edit</kbd> button from the fast edit window when triggered from Ask AI -> Proofread, and instead only shows the suggest edit button if it was triggered directly from the <kbd>:pencil: Edit</kbd> button.