### PR TITLE
FIX: Bedrock was complaining  input was too long

### DIFF
--- a/lib/completions/endpoints/aws_bedrock.rb
+++ b/lib/completions/endpoints/aws_bedrock.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "aws-sigv4"
+
 module DiscourseAi
   module Completions
     module Endpoints
@@ -12,7 +14,7 @@ module DiscourseAi
         end
 
         def default_options
-          { max_tokens_to_sample: 20_000 }
+          { max_tokens_to_sample: 2_000 }
         end
 
         def provider_id


### PR DESCRIPTION
Bug introduced while migrating to the new LLM service. Default max tokens to sample should be 2k, not 20. As a result, bedrock complains input is too long.