### PR TITLE
FIX: Illustrate post icon and translation not appearing correctly

### DIFF
--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -141,7 +141,7 @@ module DiscourseAi
           %w[post]
         when "summarize"
           %w[post]
-        when "illustrate_posts"
+        when "illustrate_post"
           %w[composer]
         else
           %w[composer post]

--- a/lib/ai_helper/entry_point.rb
+++ b/lib/ai_helper/entry_point.rb
@@ -7,7 +7,7 @@ module DiscourseAi
           Rails.root.join("plugins", "discourse-ai", "db", "fixtures", "ai_helper"),
         )
 
-        additional_icons = %w[spell-check language]
+        additional_icons = %w[spell-check language images]
         additional_icons.each { |icon| plugin.register_svg_icon(icon) }
 
         plugin.on(:chat_thread_created) do |thread|


### PR DESCRIPTION
Fixes illustrate post option not appearing correctly in UI. It should also only appear in composer not in posts helper.
