### PR TITLE
FIX: under certain conditions we would get duplicate data from llm

### DIFF
--- a/lib/inference/open_ai_completions.rb
+++ b/lib/inference/open_ai_completions.rb
@@ -45,7 +45,7 @@ module ::DiscourseAi
           end
         headers = { "Content-Type" => "application/json" }
 
-        if url.host.include? ("azure")
+        if url.host.include?("azure")
           headers["api-key"] = SiteSetting.ai_openai_api_key
         else
           headers["Authorization"] = "Bearer #{SiteSetting.ai_openai_api_key}"
@@ -131,7 +131,7 @@ module ::DiscourseAi
               response.read_body do |chunk|
                 if cancelled
                   http.finish
-                  return
+                  break
                 end
 
                 response_raw << chunk


### PR DESCRIPTION
Previously endpoint/base would `+=` decoded_chunk to leftover

This could lead to cases where the leftover buffer had duplicate
previously processed data

Fix ensures we properly skip previously decoded data.
