### PR TITLE
FIX: Context menu should not appear if selected text is deleted

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -160,6 +160,10 @@ export default class AiHelperContextMenu extends Component {
     if (event.key === "Escape") {
       return this.closeContextMenu();
     }
+
+    if (event.key === "Backspace" && this.selectedText) {
+      return this.closeContextMenu();
+    }
   }
 
   @debounce(INPUT_DELAY)


### PR DESCRIPTION
In Chromium browsers, the AI context menu is still appearing despite selected text being deleted. This is likely due to the workaround set in place for the Firefox bug (https://github.com/discourse/discourse-ai/pull/154).

In this PR we check for a selection and backspace to automatically close the context menu.