### PR TITLE
FIX: exclude non visible topics from report context

### DIFF
--- a/lib/automation/report_context_generator.rb
+++ b/lib/automation/report_context_generator.rb
@@ -33,6 +33,7 @@ module DiscourseAi
             .where("posts.created_at >= ?", @start_date)
             .joins(topic: :category)
             .includes(:topic, :user)
+            .where("topics.visible")
             .where("posts.created_at < ?", @start_date + @duration)
             .where("posts.post_type = ?", Post.types[:regular])
             .where("posts.hidden_at IS NULL")

--- a/spec/lib/modules/automation/report_context_generator_spec.rb
+++ b/spec/lib/modules/automation/report_context_generator_spec.rb
@@ -59,6 +59,14 @@ module DiscourseAi
           end
         end
 
+        it "will exclude non visible topics" do
+          post_with_likes3.topic.update(visible: false)
+
+          context = ReportContextGenerator.generate(start_date: 1.day.ago, duration: 2.day)
+
+          expect(context).not_to include("topic_id: #{topic_with_likes.id}")
+        end
+
         it "always includes info from last posts on topic" do
           context =
             ReportContextGenerator.generate(start_date: 1.day.ago, duration: 2.day, max_posts: 1)


### PR DESCRIPTION
Generally non visible topics are not that interesting, do not add
this noise to the report context
