### PR TITLE
UX: Menu placement bottom for AI

### DIFF
--- a/assets/javascripts/discourse/connectors/post-text-buttons/ai-helper-options-menu.gjs
+++ b/assets/javascripts/discourse/connectors/post-text-buttons/ai-helper-options-menu.gjs
@@ -26,6 +26,7 @@ export default class AIHelperOptionsMenu extends Component {
   @service modal;
   @service siteSettings;
   @service currentUser;
+  @service menu;
   @tracked helperOptions = [];
   @tracked menuState = this.MENU_STATES.triggers;
   @tracked loading = false;
@@ -58,6 +59,7 @@ export default class AIHelperOptionsMenu extends Component {
   async showAIHelperOptions() {
     this.showMainButtons = false;
     this.menuState = this.MENU_STATES.options;
+    this.menu.activeMenu.options.placement = "bottom";
   }
 
   @bind


### PR DESCRIPTION
This PR moves the placement of the FloatKit menu to be positioned to `"bottom"` when <kbd>:sparkles: Ask AI</kbd> is pressed. This allows for a better UX when the streamed explain text is shown so that the menu expands vertically.

## Before

https://github.com/discourse/discourse-ai/assets/30090424/d772d02e-c3ac-453f-ae86-4f669e304908


## After

https://github.com/discourse/discourse-ai/assets/30090424/d197e02a-cbca-4e98-996c-48a83886aca2

