### PR TITLE
FIX: Prevent no results label from showing when untrue

### DIFF
--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
@@ -35,17 +35,7 @@ export default class SemanticSearch extends Component {
   }
 
   get searchStateText() {
-    if (this.preventAISearch) {
-      return I18n.t("discourse_ai.embeddings.semantic_search_disabled_sort");
-    }
-    if (this.searching) {
-      return I18n.t("discourse_ai.embeddings.semantic_search_loading");
-    }
-
-    if (this.AIResults.length === 0) {
-      return I18n.t("discourse_ai.embeddings.semantic_search_results.none");
-    }
-
+    // Search results:
     if (this.AIResults.length > 0) {
       if (this.showingAIResults) {
         return I18n.t(
@@ -63,12 +53,34 @@ export default class SemanticSearch extends Component {
         );
       }
     }
+
+    // Search disabled for sort order:
+    if (this.preventAISearch) {
+      return I18n.t("discourse_ai.embeddings.semantic_search_disabled_sort");
+    }
+
+    // Search loading:
+    if (this.searching) {
+      return I18n.t("discourse_ai.embeddings.semantic_search_loading");
+    }
+
+    // Typing to search:
+    if (
+      this.AIResults.length === 0 &&
+      this.searchTerm !== this.initialSearchTerm
+    ) {
+      return I18n.t("discourse_ai.embeddings.semantic_search_results.new");
+    }
+
+    // No results:
+    if (this.AIResults.length === 0) {
+      return I18n.t("discourse_ai.embeddings.semantic_search_results.none");
+    }
   }
 
   get searchTerm() {
     if (this.initialSearchTerm !== this.args.outletArgs.search) {
       this.initialSearchTerm = undefined;
-      this.resetAIResults();
     }
 
     return this.args.outletArgs.search;
@@ -115,6 +127,8 @@ export default class SemanticSearch extends Component {
     if (this.initialSearchTerm) {
       return this.performHyDESearch();
     }
+
+    this.resetAIResults();
 
     withPluginApi("1.15.0", (api) => {
       api.onAppEvent("full-page-search:trigger-search", () => {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -172,6 +172,7 @@ en:
           toggle: "Showing %{count} results found using AI"
           toggle_hidden: "Hiding %{count} results found using AI"
           none: "Sorry, our AI search found no matching topics."
+          new: "Press 'Search' to begin looking for new results with AI"
         ai_generated_result: "Search result found using AI"
 
       ai_bot:


### PR DESCRIPTION
Sometimes when you make a search and erase the text and begin writing a new search query (before pressing search), the label changes to "Sorry, no our AI search found no matching topics". In this scenario the label is incorrect. Sometimes this label also gets stuck on mobile.

Instead, in this PR we add a new label to account for such a situation. The label instead will show here: "Press 'Search' to begin looking for new results with AI"
