### PR TITLE
FIX: Get topic's category instead of array's

### DIFF
--- a/app/views/list/related_topics.html.erb
+++ b/app/views/list/related_topics.html.erb
@@ -40,7 +40,7 @@
                   </div>
                 <% end %>
               </div>
-              <% if t.pinned_until && (t.pinned_until > Time.zone.now) && (t.pinned_globally || @list.category) && t.excerpt %>
+              <% if t.pinned_until && (t.pinned_until > Time.zone.now) && (t.pinned_globally || t.category) && t.excerpt %>
                 <p class='excerpt'>
                   <%= t.excerpt.html_safe %>
                 </p>


### PR DESCRIPTION
Related: https://github.com/discourse/discourse-automation/pull/243

Currently we're seeing 500s when related_topics are getting rendered. We should get the topic's category rather than on the array.

```
ActionView::Template::Error (undefined method `category' for [#<Topic id ... ]
```

Patching this quickly, will add a test soon. 💥 