### PR TITLE
FIX: use async versions of clipboardCopy

### DIFF
--- a/assets/javascripts/discourse/lib/copy-conversation.js
+++ b/assets/javascripts/discourse/lib/copy-conversation.js
@@ -1,8 +1,17 @@
 import { ajax } from "discourse/lib/ajax";
-import { clipboardCopy } from "discourse/lib/utilities";
+import { clipboardCopyAsync } from "discourse/lib/utilities";
 import I18n from "discourse-i18n";
 
 export default async function (topic, fromPostNumber, toPostNumber) {
+  await clipboardCopyAsync(async () => {
+    const text = await generateClipboard(topic, fromPostNumber, toPostNumber);
+    return new Blob([text], {
+      type: "text/plain",
+    });
+  });
+}
+
+async function generateClipboard(topic, fromPostNumber, toPostNumber) {
   const stream = topic.get("postStream");
 
   let postNumbers = [];
@@ -51,5 +60,5 @@ export default async function (topic, fromPostNumber, toPostNumber) {
     window.discourseAiClipboard = text;
   }
 
-  await clipboardCopy(text);
+  return text;
 }


### PR DESCRIPTION
Chrome and Firefox work with standard clipboardCopy, but since
we are making an ajax call Safari fails cause there is too much
delay detected.

To avoid this issue we trade in promises which are acceptable and
work in iOS.
