### PR TITLE
UX: copy change

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -181,7 +181,7 @@ en:
         default_pm_prefix: "[Untitled AI bot PM]"
         shortcut_title: "Start a PM with an AI bot"
         share: "Share AI conversation"
-        conversation_shared: "Conversation copied to clipboard"
+        conversation_shared: "Conversation copied"
 
         ai_label: "AI"
         ai_title: "Conversation with AI"


### PR DESCRIPTION
Saying "to clipboard" is wordy and obsolete. 
Shortening it to "Conversation copied" is also more consistent with the "Link copied" component.

<img width="640" alt="image" src="https://github.com/discourse/discourse-ai/assets/101828855/b56c1485-59dd-470b-a2f4-0720fef57170">

<img width="640" alt="image" src="https://github.com/discourse/discourse-ai/assets/101828855/b1cba4c8-bf90-4177-9f25-0f977432a174">
