### PR TITLE
FIX: Show illustrate post only if stability API key present

### DIFF
--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -13,9 +13,7 @@ module DiscourseAi
           prompts = cp.where(enabled: true)
           # Only show the illustrate_post prompt if the API key is present
           prompts =
-            prompts.where.not(
-              name: "illustrate_post",
-            ) if !SiteSetting.ai_stability_api_key.present?
+            prompts.where.not(name: "illustrate_post") if !SiteSetting.ai_stability_api_key.present?
         end
 
         prompts.map do |prompt|

--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -5,8 +5,18 @@ module DiscourseAi
     class Assistant
       def available_prompts(name_filter: nil)
         cp = CompletionPrompt
+        prompts = []
 
-        prompts = name_filter ? [cp.enabled_by_name(name_filter)] : cp.where(enabled: true)
+        if name_filter
+          prompts = [cp.enabled_by_name(name_filter)]
+        else
+          prompts = cp.where(enabled: true)
+          # Only show the illustrate_post prompt if the API key is present
+          prompts =
+            prompts.where.not(
+              name: "illustrate_post",
+            ) if !SiteSetting.ai_stability_api_key.present?
+        end
 
         prompts.map do |prompt|
           translation =

--- a/spec/lib/modules/ai_helper/assistant_spec.rb
+++ b/spec/lib/modules/ai_helper/assistant_spec.rb
@@ -10,6 +10,54 @@ RSpec.describe DiscourseAi::AiHelper::Assistant do
     defends himself, but instead exclaims: 'You too, my son!' Shakespeare and Quevedo capture the pathetic cry.
   STRING
 
+  describe("#available_prompts") do
+    context "when no name filter is provided" do
+      it "returns all available prompts" do
+        prompts = subject.available_prompts
+
+        expect(prompts.length).to eq(6)
+        expect(prompts.map { |p| p[:name] }).to contain_exactly(
+          "translate",
+          "generate_titles",
+          "proofread",
+          "markdown_table",
+          "custom_prompt",
+          "explain",
+        )
+      end
+    end
+
+    context "when name filter is provided" do
+      it "returns the prompt with the given name" do
+        prompts = subject.available_prompts(name_filter: "translate")
+
+        expect(prompts.length).to eq(1)
+        expect(prompts.first[:name]).to eq("translate")
+      end
+    end
+
+    context "when stability API key is present" do
+      before do
+        SiteSetting.ai_stability_api_key = "foo"
+      end
+
+      it "returns the illustrate_post prompt in the list of all prompts" do
+        prompts = subject.available_prompts
+
+        expect(prompts.length).to eq(7)
+        expect(prompts.map { |p| p[:name] }).to contain_exactly(
+          "translate",
+          "generate_titles",
+          "proofread",
+          "markdown_table",
+          "custom_prompt",
+          "explain",
+          "illustrate_post"
+        )
+      end
+    end
+  end
+
   describe "#generate_and_send_prompt" do
     context "when using a prompt that returns text" do
       let(:mode) { CompletionPrompt::TRANSLATE }

--- a/spec/lib/modules/ai_helper/assistant_spec.rb
+++ b/spec/lib/modules/ai_helper/assistant_spec.rb
@@ -37,9 +37,7 @@ RSpec.describe DiscourseAi::AiHelper::Assistant do
     end
 
     context "when stability API key is present" do
-      before do
-        SiteSetting.ai_stability_api_key = "foo"
-      end
+      before { SiteSetting.ai_stability_api_key = "foo" }
 
       it "returns the illustrate_post prompt in the list of all prompts" do
         prompts = subject.available_prompts
@@ -52,7 +50,7 @@ RSpec.describe DiscourseAi::AiHelper::Assistant do
           "markdown_table",
           "custom_prompt",
           "explain",
-          "illustrate_post"
+          "illustrate_post",
         )
       end
     end

--- a/spec/requests/ai_helper/assistant_controller_spec.rb
+++ b/spec/requests/ai_helper/assistant_controller_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe DiscourseAi::AiHelper::AssistantController do
         sign_in(user)
         user.group_ids = [Group::AUTO_GROUPS[:trust_level_1]]
         SiteSetting.ai_helper_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
+        SiteSetting.ai_stability_api_key = "foo"
       end
 
       it "returns a list of prompts when no name_filter is provided" do


### PR DESCRIPTION
Following the feature https://github.com/discourse/discourse-ai/pull/367 adding post illustrations. The **Illustrate Post** option will always result in an error if stable diffusion was not enabled. This PR fixes the issue by only allowing the AI helper option to be shown if the site setting `ai_stability_api_key` is present.