### PR TITLE
FIX: 500 error when reviewable has a missing message

### DIFF
--- a/app/models/reviewable_ai_chat_message.rb
+++ b/app/models/reviewable_ai_chat_message.rb
@@ -35,9 +35,7 @@ class ReviewableAiChatMessage < Reviewable
   def build_actions(actions, guardian, args)
     return unless pending?
 
-    if chat_message.blank?
-      return build_action(actions, :ignore, icon: "external-link-alt")
-    end
+    return build_action(actions, :ignore, icon: "external-link-alt") if chat_message.blank?
 
     agree =
       actions.add_bundle("#{id}-agree", icon: "thumbs-up", label: "reviewables.actions.agree.title")

--- a/app/models/reviewable_ai_chat_message.rb
+++ b/app/models/reviewable_ai_chat_message.rb
@@ -34,7 +34,10 @@ class ReviewableAiChatMessage < Reviewable
 
   def build_actions(actions, guardian, args)
     return unless pending?
-    return if chat_message.blank?
+
+    if chat_message.blank?
+      return build_action(actions, :ignore, icon: "external-link-alt")
+    end
 
     agree =
       actions.add_bundle("#{id}-agree", icon: "thumbs-up", label: "reviewables.actions.agree.title")

--- a/app/serializers/reviewable_ai_chat_message_serializer.rb
+++ b/app/serializers/reviewable_ai_chat_message_serializer.rb
@@ -10,7 +10,7 @@ class ReviewableAiChatMessageSerializer < ReviewableSerializer
   has_one :chat_channel, serializer: AiChatChannelSerializer, root: false, embed: :objects
 
   def chat_channel
-    object.chat_message.chat_channel
+    object.chat_message&.chat_channel
   end
 
   def target_id

--- a/assets/javascripts/discourse/components/reviewable-ai-chat-message.hbs
+++ b/assets/javascripts/discourse/components/reviewable-ai-chat-message.hbs
@@ -1,15 +1,17 @@
-<div class="flagged-post-header">
-  <LinkTo
-    @route="chat.channel.near-message"
-    @models={{array
-      this.chatChannel.slugifiedTitle
-      this.chatChannel.id
-      @reviewable.target_id
-    }}
-  >
-    <ChatChannelTitle @channel={{this.chatChannel}} />
-  </LinkTo>
-</div>
+{{#if this.chatChannel}}
+  <div class="flagged-post-header">
+    <LinkTo
+      @route="chat.channel.near-message"
+      @models={{array
+        this.chatChannel.slugifiedTitle
+        this.chatChannel.id
+        @reviewable.target_id
+      }}
+    >
+      <ChatChannelTitle @channel={{this.chatChannel}} />
+    </LinkTo>
+  </div>
+{{/if}}
 
 <div class="post-contents-wrapper">
   <ReviewableCreatedBy @user={{@reviewable.target_created_by}} @tagName="" />

--- a/assets/javascripts/discourse/components/reviewable-ai-chat-message.js
+++ b/assets/javascripts/discourse/components/reviewable-ai-chat-message.js
@@ -3,6 +3,9 @@ import ChatChannel from "discourse/plugins/chat/discourse/models/chat-channel";
 
 export default class ReviewableAiChatMessage extends Component {
   get chatChannel() {
+    if (!this.args.reviewable.chat_channel) {
+      return;
+    }
     return ChatChannel.create(this.args.reviewable.chat_channel);
   }
 }

--- a/spec/system/toxicity/reviewable_ai_chat_message_spec.rb
+++ b/spec/system/toxicity/reviewable_ai_chat_message_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe "Toxicity-flagged chat messages", type: :system, js: true do
   end
 
   context "when the message is hard deleted" do
-      before do
-        chat_message.destroy!
-      end
+    before { chat_message.destroy! }
 
     it "does not throw an error" do
       visit("/review")

--- a/spec/system/toxicity/reviewable_ai_chat_message_spec.rb
+++ b/spec/system/toxicity/reviewable_ai_chat_message_spec.rb
@@ -23,4 +23,22 @@ RSpec.describe "Toxicity-flagged chat messages", type: :system, js: true do
 
     expect(page).to have_selector(".reviewable-ai-chat-message .reviewable-actions")
   end
+
+  context "when the message is hard deleted" do
+      before do
+        chat_message.destroy!
+      end
+
+    it "does not throw an error" do
+      visit("/review")
+
+      expect(page).to have_selector(".reviewable-ai-chat-message .reviewable-actions")
+    end
+
+    it "adds the option to ignore the flag" do
+      visit("/review")
+
+      expect(page).to have_selector(".reviewable-actions .chat-message-ignore")
+    end
+  end
 end


### PR DESCRIPTION
After this PR if, for some reason, a flagged chat message is not found or has been hard deleted, it does not throw an error and allows the flag to be ignored from the UI