### PR TITLE
UX: Add proper attribution to illustrate post images

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -128,6 +128,8 @@ en:
         custom_prompt: "Custom Prompt"
         explain: "Explain"
         illustrate_post: "Illustrate Post"
+      painter:
+        attribution: "Image by Stable Diffusion XL"
 
     ai_bot:
       personas:

--- a/lib/ai_helper/painter.rb
+++ b/lib/ai_helper/painter.rb
@@ -20,7 +20,10 @@ module DiscourseAi
           f.binmode
           f.write(Base64.decode64(artifact))
           f.rewind
-          upload = UploadCreator.new(f, I18n.t("discourse_ai.ai_helper.painter.attribution")).create_for(user.id)
+          upload =
+            UploadCreator.new(f, I18n.t("discourse_ai.ai_helper.painter.attribution")).create_for(
+              user.id,
+            )
           f.unlink
 
           UploadSerializer.new(upload, root: false)

--- a/lib/ai_helper/painter.rb
+++ b/lib/ai_helper/painter.rb
@@ -20,7 +20,7 @@ module DiscourseAi
           f.binmode
           f.write(Base64.decode64(artifact))
           f.rewind
-          upload = UploadCreator.new(f, "ai_helper_image_#{i}.png").create_for(user.id)
+          upload = UploadCreator.new(f, I18n.t("discourse_ai.ai_helper.painter.attribution")).create_for(user.id)
           f.unlink
 
           UploadSerializer.new(upload, root: false)


### PR DESCRIPTION
This PR adds attribution ("_Image by Stable Diffusion XL_") to images generated by stable diffusion using the AI helper's illustrate post feature.

This is an interim solution. In the future, we will also add AI generated caption along with this as well as support for Dall E as an option.