### PR TITLE
FIX: don't include <details> in context

### DIFF
--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -139,22 +139,18 @@ module DiscourseAi
 
         return if reply.blank?
 
-        reply_post.tap do |bot_reply|
-          publish_update(bot_reply, done: true)
+        publish_update(reply_post, done: true)
 
-          bot_reply.revise(
-            bot.bot_user,
-            { raw: reply },
-            skip_validations: true,
-            skip_revision: true,
-          )
+        reply_post.revise(bot.bot_user, { raw: reply }, skip_validations: true, skip_revision: true)
 
-          bot_reply.post_custom_prompt ||= bot_reply.build_post_custom_prompt(custom_prompt: [])
-          prompt = bot_reply.post_custom_prompt.custom_prompt || []
+        # not need to add a custom prompt for a single reply
+        if new_custom_prompts.length > 1
+          reply_post.post_custom_prompt ||= reply_post.build_post_custom_prompt(custom_prompt: [])
+          prompt = reply_post.post_custom_prompt.custom_prompt || []
           prompt.concat(new_custom_prompts)
-          prompt << [reply, bot.bot_user.username]
-          bot_reply.post_custom_prompt.update!(custom_prompt: prompt)
+          reply_post.post_custom_prompt.update!(custom_prompt: prompt)
         end
+        reply_post
       end
 
       private

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -150,6 +150,7 @@ module DiscourseAi
           prompt.concat(new_custom_prompts)
           reply_post.post_custom_prompt.update!(custom_prompt: prompt)
         end
+
         reply_post
       end
 

--- a/lib/completions/dialects/gemini.rb
+++ b/lib/completions/dialects/gemini.rb
@@ -130,8 +130,13 @@ module DiscourseAi
         def flatten_context(context)
           context.map do |a_context|
             if a_context[:type] == "multi_turn"
-              # Drop old tool calls and only keep bot response.
-              a_context[:content].find { |c| c[:type] == "assistant" }
+              # Some multi-turn, like the ones that generate images, doesn't chain a next
+              # response. We don't have an assistant call for those, so we use the tool_call instead.
+              # We cannot use tool since it confuses the model, making it stop calling tools in next responses,
+              # and replying with a JSON.
+
+              a_context[:content].find { |c| c[:type] == "assistant" } ||
+                a_context[:content].find { |c| c[:type] == "tool_call" }
             else
               a_context
             end

--- a/spec/lib/modules/ai_bot/tools/dall_e_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/dall_e_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DiscourseAi::AiBot::Tools::DallE do
 
   describe "#process" do
     it "can generate correct info with azure" do
-      post = Fabricate(:post)
+      _post = Fabricate(:post)
 
       SiteSetting.ai_openai_api_key = "abc"
       SiteSetting.ai_openai_dall_e_3_url = "https://test.azure.com/some_url"
@@ -43,8 +43,6 @@ RSpec.describe DiscourseAi::AiBot::Tools::DallE do
     end
 
     it "can generate correct info" do
-      post = Fabricate(:post)
-
       SiteSetting.ai_openai_api_key = "abc"
 
       image =


### PR DESCRIPTION
We need to be careful adding <details> into context of conversations
it can cause LLMs to hallucinate results
