### PR TITLE
FIX: Bring back Azure support.

### DIFF
--- a/lib/completions/dialects/chat_gpt.rb
+++ b/lib/completions/dialects/chat_gpt.rb
@@ -75,6 +75,7 @@ module DiscourseAi
 
               {
                 role: "assistant",
+                content: nil,
                 tool_calls: [{ type: "function", function: function, id: context[:name] }],
               }
             else


### PR DESCRIPTION
We thought Azure's latest API version didn't have tool support yet, but I didn't understand it was complaining about a required field in the tool call message.