### PR TITLE
FIX: New illustrate post suggestions should be auto tracked

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -33,6 +33,7 @@ export default class AiHelperContextMenu extends Component {
   @tracked previousMenuState = null;
   @tracked customPromptValue = "";
   @tracked initialValue = "";
+  @tracked thumbnailSuggestions = null;
 
   CONTEXT_MENU_STATES = {
     triggers: "TRIGGERS",
@@ -371,6 +372,7 @@ export default class AiHelperContextMenu extends Component {
         // resets the values if new suggestion is started:
         this.diff = null;
         this.newSelectedText = null;
+        this.thumbnailSuggestions = null;
 
         if (option.name === "illustrate_post") {
           this._toggleLoadingState(false);


### PR DESCRIPTION
Previously clicking illustrate post in the composer AI helper for one suggestion and then trying another results in the same illustrations being shown. This PR ensures that the `thumbnailSuggestions` are a `@tracked` property so that subsequent calls to illustrate post will result in the modal being populated with new suggestions.