### PR TITLE
FEATURE: Move the default embeddings model to bge-large-en

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -231,7 +231,7 @@ discourse_ai:
   ai_embeddings_model:
     type: enum
     list_type: compact
-    default: "all-mpnet-base-v2"
+    default: "bge-large-en"
     allow_any: false
     choices:
       - all-mpnet-base-v2

--- a/spec/lib/modules/ai_bot/tools/search_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/search_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe DiscourseAi::AiBot::Tools::Search do
 
         hyde_embedding = [0.049382, 0.9999]
         EmbeddingsGenerationStubs.discourse_service(
-          SiteSetting.ai_embeddings_model,
+          "bge-large-en-v1.5",
           query,
           hyde_embedding,
         )
@@ -80,7 +80,7 @@ RSpec.describe DiscourseAi::AiBot::Tools::Search do
         post1 = Fabricate(:post, topic: topic_with_tags)
         search = described_class.new({ search_query: "hello world, sam", status: "public" })
 
-        DiscourseAi::Embeddings::VectorRepresentations::AllMpnetBaseV2
+        DiscourseAi::Embeddings::VectorRepresentations::BgeLargeEn
           .any_instance
           .expects(:asymmetric_topics_similarity_search)
           .returns([post1.topic_id])

--- a/spec/lib/modules/ai_bot/tools/search_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/search_spec.rb
@@ -71,7 +71,11 @@ RSpec.describe DiscourseAi::AiBot::Tools::Search do
         SiteSetting.ai_embeddings_discourse_service_api_endpoint = "http://test.com"
 
         hyde_embedding = [0.049382, 0.9999]
-        EmbeddingsGenerationStubs.discourse_service("bge-large-en-v1.5", query, hyde_embedding)
+        EmbeddingsGenerationStubs.discourse_service(
+          SiteSetting.ai_embeddings_model,
+          query,
+          hyde_embedding,
+        )
 
         post1 = Fabricate(:post, topic: topic_with_tags)
         search = described_class.new({ search_query: "hello world, sam", status: "public" })

--- a/spec/lib/modules/ai_bot/tools/search_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/search_spec.rb
@@ -71,11 +71,7 @@ RSpec.describe DiscourseAi::AiBot::Tools::Search do
         SiteSetting.ai_embeddings_discourse_service_api_endpoint = "http://test.com"
 
         hyde_embedding = [0.049382, 0.9999]
-        EmbeddingsGenerationStubs.discourse_service(
-          "bge-large-en-v1.5",
-          query,
-          hyde_embedding,
-        )
+        EmbeddingsGenerationStubs.discourse_service("bge-large-en-v1.5", query, hyde_embedding)
 
         post1 = Fabricate(:post, topic: topic_with_tags)
         search = described_class.new({ search_query: "hello world, sam", status: "public" })

--- a/spec/lib/modules/embeddings/jobs/generate_embeddings_spec.rb
+++ b/spec/lib/modules/embeddings/jobs/generate_embeddings_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Jobs::GenerateEmbeddings do
     before do
       SiteSetting.ai_embeddings_discourse_service_api_endpoint = "http://test.com"
       SiteSetting.ai_embeddings_enabled = true
-      SiteSetting.ai_embeddings_model = "all-mpnet-base-v2"
+      SiteSetting.ai_embeddings_model = "bge-large-en"
     end
 
     fab!(:topic) { Fabricate(:topic) }

--- a/spec/lib/modules/embeddings/semantic_search_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DiscourseAi::Embeddings::SemanticSearch do
 
       hyde_embedding = [0.049382, 0.9999]
       EmbeddingsGenerationStubs.discourse_service(
-        SiteSetting.ai_embeddings_model,
+        DiscourseAi::Embeddings::VectorRepresentations::BgeLargeEn.,
         hypothetical_post,
         hyde_embedding,
       )
@@ -24,7 +24,7 @@ RSpec.describe DiscourseAi::Embeddings::SemanticSearch do
     after { described_class.clear_cache_for(query) }
 
     def stub_candidate_ids(candidate_ids)
-      DiscourseAi::Embeddings::VectorRepresentations::AllMpnetBaseV2
+      DiscourseAi::Embeddings::VectorRepresentations::BgeLargeEn
         .any_instance
         .expects(:asymmetric_topics_similarity_search)
         .returns(candidate_ids)

--- a/spec/lib/modules/embeddings/semantic_search_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DiscourseAi::Embeddings::SemanticSearch do
 
       hyde_embedding = [0.049382, 0.9999]
       EmbeddingsGenerationStubs.discourse_service(
-        'bge-large-en-v1.5',
+        "bge-large-en-v1.5",
         hypothetical_post,
         hyde_embedding,
       )

--- a/spec/lib/modules/embeddings/semantic_search_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DiscourseAi::Embeddings::SemanticSearch do
 
       hyde_embedding = [0.049382, 0.9999]
       EmbeddingsGenerationStubs.discourse_service(
-        DiscourseAi::Embeddings::VectorRepresentations::BgeLargeEn.,
+        DiscourseAi::Embeddings::VectorRepresentations::BgeLargeEn.name,
         hypothetical_post,
         hyde_embedding,
       )

--- a/spec/lib/modules/embeddings/semantic_search_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DiscourseAi::Embeddings::SemanticSearch do
 
       hyde_embedding = [0.049382, 0.9999]
       EmbeddingsGenerationStubs.discourse_service(
-        "bge-large-en-v1.5",
+        SiteSetting.ai_embeddings_model,
         hypothetical_post,
         hyde_embedding,
       )

--- a/spec/lib/modules/embeddings/semantic_search_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DiscourseAi::Embeddings::SemanticSearch do
 
       hyde_embedding = [0.049382, 0.9999]
       EmbeddingsGenerationStubs.discourse_service(
-        DiscourseAi::Embeddings::VectorRepresentations::BgeLargeEn.name,
+        'bge-large-en-v1.5',
         hypothetical_post,
         hyde_embedding,
       )

--- a/spec/lib/modules/embeddings/semantic_topic_query_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_topic_query_spec.rb
@@ -12,7 +12,7 @@ describe DiscourseAi::Embeddings::EntryPoint do
       fab!(:target) { Fabricate(:topic) }
 
       def stub_semantic_search_with(results)
-        DiscourseAi::Embeddings::VectorRepresentations::AllMpnetBaseV2
+        DiscourseAi::Embeddings::VectorRepresentations::BgeLargeEn
           .any_instance
           .expects(:symmetric_topics_similarity_search)
           .returns(results.concat([target.id]))

--- a/spec/support/embeddings_generation_stubs.rb
+++ b/spec/support/embeddings_generation_stubs.rb
@@ -3,6 +3,7 @@
 class EmbeddingsGenerationStubs
   class << self
     def discourse_service(model, string, embedding)
+      model = "bge-large-en-v1.5" if model == "bge-large-en"
       WebMock
         .stub_request(
           :post,


### PR DESCRIPTION
bge-large-en via https://github.com/huggingface/text-embeddings-inference has both faster inference and better recall than our previous default