### PR TITLE
DEV: Fix SemanticRelated module load error

### DIFF
--- a/app/views/list/related_topics.html.erb
+++ b/app/views/list/related_topics.html.erb
@@ -15,23 +15,23 @@
         </tr>
       </thead>
       <tbody>
-        <% @list.each_with_index do |t,i| %>
-          <tr class="topic-list-item">
+        <% @list.each_with_index do |topic, idx| %>
+          <tr class="topic-list-item" id="topic-list-item-<%= topic.id %>">
             <td class="main-link" itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
-              <meta itemprop='position' content='<%= i + 1 %>'>
+              <meta itemprop='position' content='<%= idx + 1 %>'>
               <span class="link-top-line">
-                <a itemprop='url' href='<%= t.url %>' class='title raw-link raw-topic-link'><%= t.title %></a>
+                <a itemprop='url' href='<%= topic.url %>' class='title raw-link raw-topic-link'><%= topic.title %></a>
               </span>
               <div class="link-bottom-line">
-                <% if (!@category || @category.has_children?) && t.category && !t.category.uncategorized? %>
-                  <a href='<%= t.category.url %>' class='badge-wrapper bullet'>
-                    <span class='badge-category-bg' style='background-color: #<%= t.category.color %>'></span>
+                <% if (!@category || @category.has_children?) && topic.category && !topic.category.uncategorized? %>
+                  <a href='<%= topic.category.url %>' class='badge-wrapper bullet'>
+                    <span class='badge-category-bg' style='background-color: #<%= topic.category.color %>'></span>
                     <span class='badge-category clear-badge'>
-                      <span class='category-name'><%= t.category.name %></span>
+                      <span class='category-name'><%= topic.category.name %></span>
                     </span>
                   </a>
                 <% end %>
-                <% if tags = t.visible_tags(guardian) %>
+                <% if tags = topic.visible_tags(guardian) %>
                   <div class="discourse-tags">
                     <% tags.each_with_index do |tag, index| %>
                       <a href='<%= tag.full_url %>' class='discourse-tag'><%= tag.name %></a>
@@ -42,13 +42,13 @@
               </div>
             </td>
             <td class="replies">
-              <span class='posts' title='<%= t 'posts' %>'><%= t.posts_count - 1 %></span>
+              <span class='posts' title='<%= t 'posts' %>'><%= topic.posts_count - 1 %></span>
             </td>
             <td class="views">
-              <span class='views' title='<%= t 'views' %>'><%= t.views %></span>
+              <span class='views' title='<%= t 'views' %>'><%= topic.views %></span>
             </td>
             <td>
-              <%= I18n.l(t.last_posted_at || t.created_at, format: :date_only) %>
+              <%= I18n.l(topic.last_posted_at || topic.created_at, format: :date_only) %>
             </td>
           </tr>
         <% end %>

--- a/lib/embeddings/entry_point.rb
+++ b/lib/embeddings/entry_point.rb
@@ -38,7 +38,7 @@ module DiscourseAi
         end
 
         plugin.register_html_builder("server:topic-show-after-posts-crawler") do |controller|
-          SemanticRelated.related_topics_for_crawler(controller)
+          ::DiscourseAi::Embeddings::SemanticRelated.related_topics_for_crawler(controller)
         end
 
         # embeddings generation.

--- a/spec/requests/topic_spec.rb
+++ b/spec/requests/topic_spec.rb
@@ -12,15 +12,15 @@ describe ::TopicsController do
   before do
     SiteSetting.ai_embeddings_semantic_related_topics_enabled = true
     SiteSetting.ai_embeddings_semantic_related_topics = 2
+
+    DiscourseAi::Embeddings::SemanticRelated
+      .any_instance
+      .stubs(:related_topic_ids_for)
+      .returns([topic1.id, topic2.id, topic3.id])
   end
 
   context "when a user is logged on" do
     it "includes related topics in payload when configured" do
-      DiscourseAi::Embeddings::SemanticRelated
-        .any_instance
-        .stubs(:related_topic_ids_for)
-        .returns([topic1.id, topic2.id, topic3.id])
-
       get("#{topic.relative_url}.json")
       expect(response.status).to eq(200)
       json = response.parsed_body
@@ -35,6 +35,20 @@ describe ::TopicsController do
 
       expect(json["suggested_topics"].length).to eq(0)
       expect(json["related_topics"].length).to eq(2)
+    end
+  end
+
+  describe "crawler" do
+    let(:crawler_user_agent) do
+      "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+    end
+
+    it "renders related topics in the crawler view" do
+      get topic.relative_url, env: { "HTTP_USER_AGENT" => crawler_user_agent }
+      body = response.body
+      expect(body).to have_tag(:div, with: { id: "related-topics" })
+      expect(body).to have_tag(:tr, with: { id: "topic-list-item-#{topic1.id}" })
+      expect(body).to have_tag(:tr, with: { id: "topic-list-item-#{topic2.id}" })
     end
   end
 end


### PR DESCRIPTION
Followup 2636efcd1bf6eaa0a6d0d868affb9d41d49bdda2,
whenever ruby code was changed locally this would break
module loading, giving an "uninitialized constant
DiscourseAi::Embeddings::EntryPoint::SemanticRelated" error.
