### PR TITLE
FIX: Set ivfflat.probes using topic count, not post count

### DIFF
--- a/lib/embeddings/vector_representations/base.rb
+++ b/lib/embeddings/vector_representations/base.rb
@@ -112,7 +112,13 @@ module DiscourseAi
           DB.exec("RESET maintenance_work_mem;")
 
           database = DB.query_single("SELECT current_database();").first
-          DB.exec("ALTER DATABASE #{database} SET ivfflat.probes = #{probes};")
+
+          # This is a global setting, if we set it based on post count
+          # we will be unable to use the index for topics
+          # Hopefully https://github.com/pgvector/pgvector/issues/235 will make this better
+          if table_name == topic_table_name
+            DB.exec("ALTER DATABASE #{database} SET ivfflat.probes = #{probes};")
+          end
         end
 
         def vector_from(text)


### PR DESCRIPTION
Fixes a regression from 140359c which caused we to set this globally based on post count, rendering the cost of an index scan on the topics table too high and making the planner, correctly, not use the index anymore.

Hopefully https://github.com/pgvector/pgvector/issues/235 lands soon.