### PR TITLE
DEV: Prevent HyDE search from being called multiple times

### DIFF
--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
@@ -124,7 +124,7 @@ export default class SemanticSearch extends Component {
       this.preventAISearch = false;
     }
 
-    if (this.initialSearchTerm) {
+    if (this.initialSearchTerm && !this.searching) {
       return this.performHyDESearch();
     }
 
@@ -132,7 +132,9 @@ export default class SemanticSearch extends Component {
 
     withPluginApi("1.15.0", (api) => {
       api.onAppEvent("full-page-search:trigger-search", () => {
-        return this.performHyDESearch();
+        if (!this.searching) {
+          return this.performHyDESearch();
+        }
       });
     });
   }


### PR DESCRIPTION
`onAppEvent("full-page-search:trigger-search")` is triggered at minimum two times when a search is queried, sometimes three. This was causing a HyDE search request multiple times likely resulting in reaching rate limits (especially on mobile).

This PR prevents HyDE from being called multiple times for a single query by checking if a search is currently in progress before calling `performHyDESearch()`