### PR TITLE
FIX: always ensure `#generate` gets a valid input

### DIFF
--- a/lib/ai_bot/tools/summarize.rb
+++ b/lib/ai_bot/tools/summarize.rb
@@ -161,7 +161,7 @@ module DiscourseAi
         end
 
         def section_prompt(topic, text, guidance)
-          insts = <<~TEXT
+          system_prompt = <<~TEXT
           You are a summarization bot.
           You effectively summarise any text.
           You condense it into a shorter version.
@@ -169,13 +169,16 @@ module DiscourseAi
           Try generating links as well the format is #{topic.url}/POST_NUMBER. eg: [ref](#{topic.url}/77)
           TEXT
 
-          { insts: insts, input: <<~TEXT }
+          user_prompt = <<~TEXT
             Guidance: #{guidance}
             You are summarizing the topic: #{topic.title}
             Summarize the following in 400 words:
-    
+
             #{text}
-            TEXT
+          TEXT
+
+          messages = [{ type: :user, content: user_prompt }]
+          DiscourseAi::Completions::Prompt.new(system_prompt, messages: messages)
         end
       end
     end

--- a/lib/automation/llm_triage.rb
+++ b/lib/automation/llm_triage.rb
@@ -32,11 +32,9 @@ module DiscourseAi
 
         llm = DiscourseAi::Completions::Llm.proxy(model)
 
-        prompt = { insts: filled_system_prompt }
-
         result =
           llm.generate(
-            prompt,
+            filled_system_prompt,
             temperature: 0,
             max_tokens: llm.tokenizer.tokenize(search_for_text).length * 2 + 10,
             user: Discourse.system_user,

--- a/lib/completions/llm.rb
+++ b/lib/completions/llm.rb
@@ -93,6 +93,10 @@ module DiscourseAi
           prompt = DiscourseAi::Completions::Prompt.new(messages: prompt)
         end
 
+        if !prompt.is_a?(DiscourseAi::Completions::Prompt)
+          raise ArgumentError, "Prompt must be either a string, array, of Prompt object"
+        end
+
         model_params.keys.each { |key| model_params.delete(key) if model_params[key].nil? }
 
         dialect = dialect_klass.new(prompt, model_name, opts: model_params)


### PR DESCRIPTION
We were not validating input for generate leading to 2 tests not
failing correctly despite functionality being broken.

This ensures that input is validated,and in turn fixes the broken
specs
