### PR TITLE
UX: start progress dot animation instantly if it's the only content

### DIFF
--- a/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
+++ b/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
@@ -71,7 +71,7 @@ article.streaming .cooked {
     color: var(--tertiary-medium);
   }
 
-  > span.progress-dot:only-child::after {
+  > .progress-dot:only-child::after {
     // if the progress dot is the only content
     // we are likely waiting longer for a response
     // so it can start animating instantly

--- a/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
+++ b/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
@@ -57,18 +57,26 @@ article.streaming nav.post-controls .actions button.cancel-streaming {
   }
 }
 
-article.streaming .cooked .progress-dot::after {
-  content: "\25CF";
-  font-family: Söhne Circle, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu,
-    Cantarell, Noto Sans, sans-serif;
-  line-height: normal;
-  margin-left: 0.25rem;
-  vertical-align: baseline;
+article.streaming .cooked {
+  .progress-dot::after {
+    content: "\25CF";
+    font-family: Söhne Circle, system-ui, -apple-system, Segoe UI, Roboto,
+      Ubuntu, Cantarell, Noto Sans, sans-serif;
+    line-height: normal;
+    margin-left: 0.25rem;
+    vertical-align: baseline;
+    animation: flashing 1.5s 3s infinite;
+    display: inline-block;
+    font-size: 1rem;
+    color: var(--tertiary-medium);
+  }
 
-  animation: flashing 1.5s 3s infinite;
-  display: inline-block;
-  font-size: 1rem;
-  color: var(--tertiary-medium);
+  > span.progress-dot:only-child::after {
+    // if the progress dot is the only content
+    // we are likely waiting longer for a response
+    // so it can start animating instantly
+    animation: flashing 1.5s infinite;
+  }
 }
 
 .ai-bot-available-bot-options {


### PR DESCRIPTION
This is a minor adjustment for the ai bot that makes the loading dot start its animation instantly if it's the only content available... this makes it feel less static if it takes a little longer to start streaming a reply 

![Kapture 2024-01-22 at 12 55 59](https://github.com/discourse/discourse-ai/assets/1681963/f8af90b6-6e9b-42a1-8c19-bfe0e75ab3bf)


once other content is added, it falls back to the behavior of waiting 3 seconds before animation (because animating while text is streaming is a bit odd)