### PR TITLE
FIX: typo in Automation::AVAILABLE_MODELS

### DIFF
--- a/lib/automation.rb
+++ b/lib/automation.rb
@@ -5,7 +5,7 @@ module DiscourseAi
     AVAILABLE_MODELS = [
       { id: "gpt-4-turbo", name: "discourse_automation.ai_models.gpt_4_turbo" },
       { id: "gpt-4", name: "discourse_automation.ai_models.gpt_4" },
-      { id: "gpt-3-5-turbo", name: "discourse_automation.ai_models.gpt_3_5_turbo" },
+      { id: "gpt-3.5-turbo", name: "discourse_automation.ai_models.gpt_3_5_turbo" },
       { id: "claude-2", name: "discourse_automation.ai_models.claude_2" },
       { id: "gemini-pro", name: "discourse_automation.ai_models.gemini_pro" },
     ]


### PR DESCRIPTION
Bug report: https://meta.discourse.org/t/gpt-3-5-turbo-is-not-working-for-ai-periodical-reports/292858