### PR TITLE
DEV: Increase embeddings backfill job frequency

### DIFF
--- a/app/jobs/scheduled/embeddings_backfill.rb
+++ b/app/jobs/scheduled/embeddings_backfill.rb
@@ -2,7 +2,7 @@
 
 module Jobs
   class EmbeddingsBackfill < ::Jobs::Scheduled
-    every 15.minutes
+    every 5.minutes
     sidekiq_options queue: "low"
     cluster_concurrency 1
 


### PR DESCRIPTION
The idea is to increase the frequency so we can run with smaller batch sizes.
Big batches cause problems when running backups, so it's better to have shorter but
more frequent jobs.
