### PR TITLE
DEV: improve error bedrock error messages

### DIFF
--- a/lib/completions/endpoints/base.rb
+++ b/lib/completions/endpoints/base.rb
@@ -135,6 +135,9 @@ module DiscourseAi
                   end
 
                   decoded_chunk = decode(chunk)
+                  if decoded_chunk.nil?
+                    raise CompletionFailed, "#{self.class.name}: Failed to decode LLM completion"
+                  end
                   response_raw << decoded_chunk
 
                   redo_chunk = leftover + decoded_chunk


### PR DESCRIPTION
When bedrock rate limits it returns a 200 BUT also returns a JSON
document with the error.

Previously we had no special case here so we complained about nil

New code properly logs the problem
