### PR TITLE
DEV: Add granular control for AI composer helper features

### DIFF
--- a/assets/javascripts/discourse/connectors/after-composer-category-input/ai-category-suggestion.gjs
+++ b/assets/javascripts/discourse/connectors/after-composer-category-input/ai-category-suggestion.gjs
@@ -5,7 +5,7 @@ import { showComposerAIHelper } from "../../lib/show-ai-helper";
 
 export default class AiCategorySuggestion extends Component {
   static shouldRender(outletArgs, helper) {
-    return showComposerAIHelper(outletArgs, helper);
+    return showComposerAIHelper(outletArgs, helper, "suggestions");
   }
 
   @service siteSettings;

--- a/assets/javascripts/discourse/connectors/after-composer-tag-input/ai-tag-suggestion.gjs
+++ b/assets/javascripts/discourse/connectors/after-composer-tag-input/ai-tag-suggestion.gjs
@@ -5,7 +5,7 @@ import { showComposerAIHelper } from "../../lib/show-ai-helper";
 
 export default class AiTagSuggestion extends Component {
   static shouldRender(outletArgs, helper) {
-    return showComposerAIHelper(outletArgs, helper);
+    return showComposerAIHelper(outletArgs, helper, "suggestions");
   }
 
   @service siteSettings;

--- a/assets/javascripts/discourse/connectors/after-composer-title-input/ai-title-suggestion.gjs
+++ b/assets/javascripts/discourse/connectors/after-composer-title-input/ai-title-suggestion.gjs
@@ -4,7 +4,7 @@ import { showComposerAIHelper } from "../../lib/show-ai-helper";
 
 export default class AiTitleSuggestion extends Component {
   static shouldRender(outletArgs, helper) {
-    return showComposerAIHelper(outletArgs, helper);
+    return showComposerAIHelper(outletArgs, helper, "suggestions");
   }
 
   <template>

--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -12,7 +12,7 @@ import { showComposerAIHelper } from "../../lib/show-ai-helper";
 
 export default class AiHelperContextMenu extends Component {
   static shouldRender(outletArgs, helper) {
-    return showComposerAIHelper(outletArgs, helper);
+    return showComposerAIHelper(outletArgs, helper, "context_menu");
   }
 
   @service currentUser;

--- a/assets/javascripts/discourse/lib/show-ai-helper.js
+++ b/assets/javascripts/discourse/lib/show-ai-helper.js
@@ -1,16 +1,18 @@
-export function showComposerAIHelper(outletArgs, helper) {
+export function showComposerAIHelper(outletArgs, helper, featureType) {
   const enableHelper = _helperEnabled(helper.siteSettings);
   const enableAssistant = _canUseAssistant(
     helper.currentUser,
     _findAllowedGroups(helper.siteSettings.ai_helper_allowed_groups)
   );
   const canShowInPM = helper.siteSettings.ai_helper_allowed_in_pm;
+  const enableFeature =
+    helper.siteSettings.ai_helper_enabled_features.includes(featureType);
 
   if (outletArgs?.composer?.privateMessage) {
-    return enableHelper && enableAssistant && canShowInPM;
+    return enableHelper && enableAssistant && canShowInPM && enableFeature;
   }
 
-  return enableHelper && enableAssistant;
+  return enableHelper && enableAssistant && enableFeature;
 }
 
 export function showPostAIHelper(outletArgs, helper) {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -60,6 +60,7 @@ en:
     ai_helper_automatic_chat_thread_title_delay: "Delay in minutes before the AI helper automatically sets the chat thread title."
     ai_helper_automatic_chat_thread_title: "Automatically set the chat thread titles based on thread contents."
     ai_helper_illustrate_post_model: "Model to use for the composer AI helper's illustrate post feature"
+    ai_helper_enabled_features: "Select the features to enable in the AI helper."
 
     ai_embeddings_enabled: "Enable the embeddings module."
     ai_embeddings_discourse_service_api_endpoint: "URL where the API is running for the embeddings module"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -212,6 +212,16 @@ discourse_ai:
       - stable_diffusion_xl
       - dall_e_3
       - disabled
+  ai_helper_enabled_features:
+    client: true
+    default: "suggestions|context_menu"
+    type: list
+    list_type: compact
+    allow_any: false
+    refresh: true
+    choices:
+      - "suggestions"
+      - "context_menu"
 
   ai_embeddings_enabled:
     default: false

--- a/spec/system/ai_helper/ai_composer_helper_spec.rb
+++ b/spec/system/ai_helper/ai_composer_helper_spec.rb
@@ -412,4 +412,25 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
       expect(ai_suggestion_dropdown).to have_no_suggestion_button
     end
   end
+
+  context "when suggestion features are disabled" do
+    let(:mode) { CompletionPrompt::GENERATE_TITLES }
+    before { SiteSetting.ai_helper_enabled_features = "context_menu" }
+
+    it "does not show suggestion buttons in the composer" do
+      visit("/latest")
+      page.find("#create-topic").click
+      composer.fill_content(input)
+      expect(ai_suggestion_dropdown).to have_no_suggestion_button
+    end
+  end
+
+  context "when context menu feature is disabled" do
+    before { SiteSetting.ai_helper_enabled_features = "suggestions" }
+
+    it "does not show context menu in the composer" do
+      trigger_context_menu(input)
+      expect(ai_helper_context_menu).to have_no_context_menu
+    end
+  end
 end


### PR DESCRIPTION
This PR introduces a new plugin setting: `ai_helper_enabled_features` which allows for granular control over the composer AI helper's features. Admins can now select between showing AI helper's suggestion feature, context menu feature, or both.