### PR TITLE
FEATURE: allow personas to supply top_p and temperature params

### DIFF
--- a/app/controllers/discourse_ai/admin/ai_personas_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_personas_controller.rb
@@ -62,6 +62,8 @@ module DiscourseAi
             :enabled,
             :system_prompt,
             :priority,
+            :top_p,
+            :temperature,
             allowed_group_ids: [],
           )
 

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -157,6 +157,14 @@ class AiPersona < ActiveRecord::Base
         options
       end
 
+      define_method :temperature do
+        @ai_persona&.temperature
+      end
+
+      define_method :top_p do
+        @ai_persona&.top_p
+      end
+
       define_method :system_prompt do
         @ai_persona&.system_prompt || "You are a helpful bot."
       end
@@ -166,7 +174,8 @@ class AiPersona < ActiveRecord::Base
   private
 
   def system_persona_unchangeable
-    if system_prompt_changed? || commands_changed? || name_changed? || description_changed?
+    if top_p_changed? || temperature_changed? || system_prompt_changed? || commands_changed? ||
+         name_changed? || description_changed?
       errors.add(:base, I18n.t("discourse_ai.ai_bot.personas.cannot_edit_system_persona"))
     end
   end
@@ -186,7 +195,7 @@ end
 #  id                :bigint           not null, primary key
 #  name              :string(100)      not null
 #  description       :string(2000)     not null
-#  commands          :string           default([]), not null, is an Array
+#  commands          :json             not null
 #  system_prompt     :string(10000000) not null
 #  allowed_group_ids :integer          default([]), not null, is an Array
 #  created_by_id     :integer
@@ -194,7 +203,9 @@ end
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  system            :boolean          default(FALSE), not null
-#  priority          :integer          default(0), not null
+#  priority          :boolean          default(FALSE), not null
+#  temperature       :float
+#  top_p             :float
 #
 # Indexes
 #

--- a/app/serializers/localized_ai_persona_serializer.rb
+++ b/app/serializers/localized_ai_persona_serializer.rb
@@ -11,7 +11,9 @@ class LocalizedAiPersonaSerializer < ApplicationSerializer
              :priority,
              :commands,
              :system_prompt,
-             :allowed_group_ids
+             :allowed_group_ids,
+             :temperature,
+             :top_p
 
   def name
     object.class_instance.name

--- a/assets/javascripts/discourse/admin/models/ai-persona.js
+++ b/assets/javascripts/discourse/admin/models/ai-persona.js
@@ -10,6 +10,8 @@ const ATTRIBUTES = [
   "enabled",
   "system",
   "priority",
+  "top_p",
+  "temperature",
 ];
 
 class CommandOption {

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -73,6 +73,14 @@ export default class PersonaEditor extends Component {
     }
   }
 
+  get showTemperature() {
+    return this.editingModel?.temperature || !this.editingModel?.system;
+  }
+
+  get showTopP() {
+    return this.editingModel?.top_p || !this.editingModel?.system;
+  }
+
   @action
   delete() {
     return this.dialog.confirm({
@@ -213,6 +221,36 @@ export default class PersonaEditor extends Component {
           disabled={{this.editingModel.system}}
         />
       </div>
+      {{#if this.showTemperature}}
+        <div class="control-group">
+          <label>{{I18n.t "discourse_ai.ai_persona.temperature"}}</label>
+          <Input
+            @type="number"
+            class="ai-persona-editor__temperature"
+            @value={{this.editingModel.temperature}}
+            disabled={{this.editingModel.system}}
+          />
+          <DTooltip
+            @icon="question-circle"
+            @content={{I18n.t "discourse_ai.ai_persona.temperature_help"}}
+          />
+        </div>
+      {{/if}}
+      {{#if this.showTopP}}
+        <div class="control-group">
+          <label>{{I18n.t "discourse_ai.ai_persona.top_p"}}</label>
+          <Input
+            @type="number"
+            class="ai-persona-editor__top_p"
+            @value={{this.editingModel.top_p}}
+            disabled={{this.editingModel.system}}
+          />
+          <DTooltip
+            @icon="question-circle"
+            @content={{I18n.t "discourse_ai.ai_persona.top_p_help"}}
+          />
+        </div>
+      {{/if}}
       <div class="control-group ai-persona-editor__action_panel">
         <DButton
           class="btn-primary ai-persona-editor__save"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -118,6 +118,10 @@ en:
         new: New
         title: "AI Personas"
         delete: Delete
+        temperature: Temperature
+        temperature_help: Temperature to use for the LLM, increase to increase creativity (leave empty to use model default, generally a value from 0.0 to 2.0)
+        top_p: Top P
+        top_p_help: Top P to use for the LLM, increase to increase randomness (leave empty to use model default, generally a value from 0.0 to 1.0)
         priority: Priority
         priority_help: Priority personas are displayed to users at the top of the persona list. If multiple personas have priority, they will be sorted alphabetically.
         command_options: "Command Options"

--- a/db/fixtures/ai_bot/603_bot_ai_personas.rb
+++ b/db/fixtures/ai_bot/603_bot_ai_personas.rb
@@ -34,5 +34,7 @@ DiscourseAi::AiBot::Personas::Persona.system_personas.each do |persona_class, id
   instance = persona_class.new
   persona.commands = instance.tools.map { |tool| tool.to_s.split("::").last }
   persona.system_prompt = instance.system_prompt
+  persona.top_p = instance.top_p
+  persona.temperature = instance.temperature
   persona.save!(validate: false)
 end

--- a/db/migrate/20240202010752_add_temperature_top_p_to_ai_personas.rb
+++ b/db/migrate/20240202010752_add_temperature_top_p_to_ai_personas.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddTemperatureTopPToAiPersonas < ActiveRecord::Migration[7.0]
+  def change
+    add_column :ai_personas, :temperature, :float, null: true
+    add_column :ai_personas, :top_p, :float, null: true
+  end
+end

--- a/lib/ai_bot/bot.rb
+++ b/lib/ai_bot/bot.rb
@@ -48,13 +48,19 @@ module DiscourseAi
         low_cost = false
         raw_context = []
 
+        user = context[:user]
+
+        llm_kwargs = { user: user }
+        llm_kwargs[:temperature] = persona.temperature if persona.temperature
+        llm_kwargs[:top_p] = persona.top_p if persona.top_p
+
         while total_completions <= MAX_COMPLETIONS && ongoing_chain
           current_model = model(prefer_low_cost: low_cost)
           llm = DiscourseAi::Completions::Llm.proxy(current_model)
           tool_found = false
 
           result =
-            llm.generate(prompt, user: context[:user]) do |partial, cancel|
+            llm.generate(prompt, **llm_kwargs) do |partial, cancel|
               if (tool = persona.find_tool(partial))
                 tool_found = true
                 ongoing_chain = tool.chain_next_response?

--- a/lib/ai_bot/personas/persona.rb
+++ b/lib/ai_bot/personas/persona.rb
@@ -23,7 +23,6 @@ module DiscourseAi
 
           def all(user:)
             # listing tools has to be dynamic cause site settings may change
-
             AiPersona.all_personas.filter do |persona|
               next false if !user.in_any_groups?(persona.allowed_group_ids)
 
@@ -83,6 +82,14 @@ module DiscourseAi
 
         def required_tools
           []
+        end
+
+        def temperature
+          nil
+        end
+
+        def top_p
+          nil
         end
 
         def options

--- a/lib/ai_bot/personas/sql_helper.rb
+++ b/lib/ai_bot/personas/sql_helper.rb
@@ -31,6 +31,10 @@ module DiscourseAi
           [Tools::DbSchema]
         end
 
+        def temperature
+          0.2
+        end
+
         def system_prompt
           <<~PROMPT
             You are a PostgreSQL expert.

--- a/lib/completions/endpoints/fake.rb
+++ b/lib/completions/endpoints/fake.rb
@@ -95,7 +95,17 @@ module DiscourseAi
           @chunk_count = chunk_count
         end
 
+        def self.last_call
+          @last_call
+        end
+
+        def self.last_call=(params)
+          @last_call = params
+        end
+
         def perform_completion!(dialect, user, model_params = {})
+          self.class.last_call = { dialect: dialect, user: user, model_params: model_params }
+
           content = self.class.fake_content
 
           if block_given?


### PR DESCRIPTION
Code assistance generally are more focused at a lower temperature
This amends it so SQL Helper runs at 0.2 temperature vs the more
common default across LLMs of 1.0.

Reduced temperature leads to more focused, concise and predictable
answers for the SQL Helper
