### PR TITLE
FEATURE: mentionable personas and random picker tool, context limits

### DIFF
--- a/app/controllers/discourse_ai/admin/ai_personas_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_personas_controller.rb
@@ -3,7 +3,7 @@
 module DiscourseAi
   module Admin
     class AiPersonasController < ::Admin::AdminController
-      before_action :find_ai_persona, only: %i[show update destroy]
+      before_action :find_ai_persona, only: %i[show update destroy create_user]
 
       def index
         ai_personas =
@@ -30,6 +30,11 @@ module DiscourseAi
         else
           render_json_error ai_persona
         end
+      end
+
+      def create_user
+        user = @ai_persona.create_user!
+        render json: BasicUserSerializer.new(user, root: "user")
       end
 
       def update
@@ -64,6 +69,9 @@ module DiscourseAi
             :priority,
             :top_p,
             :temperature,
+            :default_llm,
+            :user_id,
+            :mentionable,
             allowed_group_ids: [],
           )
 

--- a/app/controllers/discourse_ai/admin/ai_personas_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_personas_controller.rb
@@ -76,6 +76,7 @@ module DiscourseAi
             :default_llm,
             :user_id,
             :mentionable,
+            :max_context_posts,
             allowed_group_ids: [],
           )
 

--- a/app/controllers/discourse_ai/admin/ai_personas_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_personas_controller.rb
@@ -16,7 +16,11 @@ module DiscourseAi
           DiscourseAi::AiBot::Personas::Persona.all_available_tools.map do |tool|
             AiToolSerializer.new(tool, root: false)
           end
-        render json: { ai_personas: ai_personas, meta: { commands: tools } }
+        llms =
+          DiscourseAi::Configuration::LlmEnumerator.values.map do |hash|
+            { id: hash[:value], name: hash[:name] }
+          end
+        render json: { ai_personas: ai_personas, meta: { commands: tools, llms: llms } }
       end
 
       def show

--- a/app/jobs/regular/create_ai_reply.rb
+++ b/app/jobs/regular/create_ai_reply.rb
@@ -7,22 +7,11 @@ module ::Jobs
     def execute(args)
       return unless bot_user = User.find_by(id: args[:bot_user_id])
       return unless post = Post.includes(:topic).find_by(id: args[:post_id])
+      persona_id = args[:persona_id]
 
       begin
-        persona = nil
-        if persona_id = post.topic.custom_fields["ai_persona_id"]
-          persona =
-            DiscourseAi::AiBot::Personas::Persona.find_by(user: post.user, id: persona_id.to_i)
-          raise DiscourseAi::AiBot::Bot::BOT_NOT_FOUND if persona.nil?
-        end
-
-        if !persona && persona_name = post.topic.custom_fields["ai_persona"]
-          persona =
-            DiscourseAi::AiBot::Personas::Persona.find_by(user: post.user, name: persona_name)
-          raise DiscourseAi::AiBot::Bot::BOT_NOT_FOUND if persona.nil?
-        end
-
-        persona ||= DiscourseAi::AiBot::Personas::General
+        persona = DiscourseAi::AiBot::Personas::Persona.find_by(user: post.user, id: persona_id)
+        raise DiscourseAi::AiBot::Bot::BOT_NOT_FOUND if persona.nil?
 
         bot = DiscourseAi::AiBot::Bot.as(bot_user, persona: persona.new)
 

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -86,6 +86,7 @@ class AiPersona < ActiveRecord::Base
     allowed_group_ids = self.allowed_group_ids
     id = self.id
     system = self.system
+    user_id = self.user_id
 
     persona_class = DiscourseAi::AiBot::Personas::Persona.system_personas_by_id[self.id]
     if persona_class
@@ -142,6 +143,10 @@ class AiPersona < ActiveRecord::Base
 
       define_singleton_method :name do
         name
+      end
+
+      define_singleton_method :user_id do
+        user_id
       end
 
       define_singleton_method :description do

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -197,7 +197,7 @@ class AiPersona < ActiveRecord::Base
   end
 
   def create_user!
-    raise "User already exists" if user_id
+    raise "User already exists" if user_id && User.exists?(user_id)
 
     # note .invalid is a reserved TLD which will route nowhere
     user =

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -64,9 +64,15 @@ class AiPersona < ActiveRecord::Base
       .where(mentionable: true)
       .where(enabled: true)
       .joins(:user)
-      .pluck("users.username, allowed_group_ids")
-      .map do |username, allowed_group_ids|
-        { username: username, allowed_group_ids: allowed_group_ids }
+      .pluck("ai_personas.id, users.id, lower(users.username), allowed_group_ids, default_llm")
+      .map do |id, user_id, username, allowed_group_ids, default_llm|
+        {
+          id: id,
+          user_id: user_id,
+          username: username,
+          allowed_group_ids: allowed_group_ids,
+          default_llm: default_llm,
+        }
       end
   end
 

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -65,7 +65,7 @@ class AiPersona < ActiveRecord::Base
       .where(mentionable: true)
       .where(enabled: true)
       .joins(:user)
-      .pluck("ai_personas.id, users.id, lower(users.username), allowed_group_ids, default_llm")
+      .pluck("ai_personas.id, users.id, users.username_lower, allowed_group_ids, default_llm")
       .map do |id, user_id, username, allowed_group_ids, default_llm|
         {
           id: id,

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -199,15 +199,14 @@ class AiPersona < ActiveRecord::Base
   def create_user!
     raise "User already exists" if user_id
 
+    # note .invalid is a reserved TLD which will route nowhere
     user =
       User.new(
-        email: "no_email_#{name}",
+        email: "no_email_#{name}@does-not-exist.invalid",
         name: name.titleize,
-        username: UserNameSuggester.suggest(name),
+        username: UserNameSuggester.suggest(name + "_bot"),
         active: true,
         approved: true,
-        admin: true,
-        moderator: true,
         trust_level: TrustLevel[4],
       )
     user.save!(validate: false)

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -238,7 +238,7 @@ class AiPersona < ActiveRecord::Base
     # note .invalid is a reserved TLD which will route nowhere
     user =
       User.new(
-        email: "no_email_#{name}@does-not-exist.invalid",
+        email: "#{SecureRandom.hex}@does-not-exist.invalid",
         name: name.titleize,
         username: UserNameSuggester.suggest(name + "_bot"),
         active: true,

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -8,6 +8,7 @@ class AiPersona < ActiveRecord::Base
   validates :description, presence: true, length: { maximum: 2000 }
   validates :system_prompt, presence: true, length: { maximum: 10_000_000 }
   validate :system_persona_unchangeable, on: :update, if: :system
+  validates :max_context_posts, numericality: { greater_than: 0 }, allow_nil: true
 
   belongs_to :created_by, class_name: "User"
   belongs_to :user
@@ -87,6 +88,9 @@ class AiPersona < ActiveRecord::Base
     id = self.id
     system = self.system
     user_id = self.user_id
+    mentionable = self.mentionable
+    default_llm = self.default_llm
+    max_context_posts = self.max_context_posts
 
     persona_class = DiscourseAi::AiBot::Personas::Persona.system_personas_by_id[self.id]
     if persona_class
@@ -100,6 +104,22 @@ class AiPersona < ActiveRecord::Base
 
       persona_class.define_singleton_method :system do
         system
+      end
+
+      persona_class.define_singleton_method :user_id do
+        user_id
+      end
+
+      persona_class.define_singleton_method :mentionable do
+        mentionable
+      end
+
+      persona_class.define_singleton_method :default_llm do
+        default_llm
+      end
+
+      persona_class.define_singleton_method :max_context_posts do
+        max_context_posts
       end
 
       return persona_class
@@ -159,6 +179,22 @@ class AiPersona < ActiveRecord::Base
 
       define_singleton_method :allowed_group_ids do
         allowed_group_ids
+      end
+
+      define_singleton_method :user_id do
+        user_id
+      end
+
+      define_singleton_method :mentionable do
+        mentionable
+      end
+
+      define_singleton_method :default_llm do
+        default_llm
+      end
+
+      define_singleton_method :max_context_posts do
+        max_context_posts
       end
 
       define_singleton_method :to_s do
@@ -236,23 +272,26 @@ end
 #
 # Table name: ai_personas
 #
-#  id                :bigint           not null, primary key
-#  name              :string(100)      not null
-#  description       :string(2000)     not null
-#  commands          :json             not null
-#  system_prompt     :string(10000000) not null
-#  allowed_group_ids :integer          default([]), not null, is an Array
-#  created_by_id     :integer
-#  enabled           :boolean          default(TRUE), not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  system            :boolean          default(FALSE), not null
-#  priority          :boolean          default(FALSE), not null
-#  temperature       :float
-#  top_p             :float
-#  user_id           :integer
-#  mentionable       :boolean          default(FALSE), not null
-#  default_llm       :text
+#  id                      :bigint           not null, primary key
+#  name                    :string(100)      not null
+#  description             :string(2000)     not null
+#  commands                :json             not null
+#  system_prompt           :string(10000000) not null
+#  allowed_group_ids       :integer          default([]), not null, is an Array
+#  created_by_id           :integer
+#  enabled                 :boolean          default(TRUE), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  system                  :boolean          default(FALSE), not null
+#  priority                :boolean          default(FALSE), not null
+#  temperature             :float
+#  top_p                   :float
+#  user_id                 :integer
+#  mentionable             :boolean          default(FALSE), not null
+#  default_llm             :text
+#  max_context_posts       :integer
+#  max_post_context_tokens :integer
+#  max_context_tokens      :integer
 #
 # Indexes
 #

--- a/app/serializers/localized_ai_persona_serializer.rb
+++ b/app/serializers/localized_ai_persona_serializer.rb
@@ -13,7 +13,12 @@ class LocalizedAiPersonaSerializer < ApplicationSerializer
              :system_prompt,
              :allowed_group_ids,
              :temperature,
-             :top_p
+             :top_p,
+             :mentionable,
+             :default_llm,
+             :user_id
+
+  has_one :user, serializer: BasicUserSerializer, embed: :object
 
   def name
     object.class_instance.name

--- a/app/serializers/localized_ai_persona_serializer.rb
+++ b/app/serializers/localized_ai_persona_serializer.rb
@@ -16,7 +16,8 @@ class LocalizedAiPersonaSerializer < ApplicationSerializer
              :top_p,
              :mentionable,
              :default_llm,
-             :user_id
+             :user_id,
+             :max_context_posts
 
   has_one :user, serializer: BasicUserSerializer, embed: :object
 

--- a/assets/javascripts/discourse/admin-discourse-ai-personas-route-map.js
+++ b/assets/javascripts/discourse/admin-discourse-ai-personas-route-map.js
@@ -5,7 +5,7 @@ export default {
 
   map() {
     this.route("discourse-ai", function () {
-      this.route("ai-personas", { path: "ai_personas" }, function () {
+      this.route("ai-personas", function () {
         this.route("new");
         this.route("show", { path: "/:id" });
       });

--- a/assets/javascripts/discourse/admin/adapters/ai-persona.js
+++ b/assets/javascripts/discourse/admin/adapters/ai-persona.js
@@ -7,8 +7,12 @@ export default class Adapter extends RestAdapter {
     return "/admin/plugins/discourse-ai/";
   }
 
-  pathFor() {
-    return super.pathFor(...arguments) + ".json";
+  pathFor(store, type, findArgs) {
+    // removes underscores which are implemented in base
+    let path =
+      this.basePath(store, type, findArgs) +
+      store.pluralize(this.apiNameFor(type));
+    return this.appendQueryParams(path, findArgs);
   }
 
   apiNameFor() {

--- a/assets/javascripts/discourse/admin/models/ai-persona.js
+++ b/assets/javascripts/discourse/admin/models/ai-persona.js
@@ -58,9 +58,9 @@ export default class AiPersona extends RestModel {
         type: "POST",
       }
     );
-    this.user = result["user"];
-    this.user_id = result["user"]["id"];
-    return result["user"];
+    this.user = result.user;
+    this.user_id = this.user.id;
+    return this.user;
   }
 
   getCommandOption(commandId, optionId) {

--- a/assets/javascripts/discourse/admin/models/ai-persona.js
+++ b/assets/javascripts/discourse/admin/models/ai-persona.js
@@ -53,7 +53,7 @@ export default class AiPersona extends RestModel {
 
   async createUser() {
     const result = await ajax(
-      `/admin/plugins/discourse-ai/ai-personas/${this.id}/create_user.json`,
+      `/admin/plugins/discourse-ai/ai-personas/${this.id}/create-user.json`,
       {
         type: "POST",
       }

--- a/assets/javascripts/discourse/admin/models/ai-persona.js
+++ b/assets/javascripts/discourse/admin/models/ai-persona.js
@@ -17,6 +17,7 @@ const ATTRIBUTES = [
   "mentionable",
   "default_llm",
   "user",
+  "max_context_posts",
 ];
 
 class CommandOption {

--- a/assets/javascripts/discourse/admin/models/ai-persona.js
+++ b/assets/javascripts/discourse/admin/models/ai-persona.js
@@ -1,4 +1,5 @@
 import { tracked } from "@glimmer/tracking";
+import { ajax } from "discourse/lib/ajax";
 import RestModel from "discourse/models/rest";
 
 const ATTRIBUTES = [
@@ -12,6 +13,10 @@ const ATTRIBUTES = [
   "priority",
   "top_p",
   "temperature",
+  "user_id",
+  "mentionable",
+  "default_llm",
+  "user",
 ];
 
 class CommandOption {
@@ -43,6 +48,18 @@ export default class AiPersona extends RestModel {
     }
     super.init(properties);
     this.commands = properties.commands;
+  }
+
+  async createUser() {
+    const result = await ajax(
+      `/admin/plugins/discourse-ai/ai-personas/${this.id}/create_user.json`,
+      {
+        type: "POST",
+      }
+    );
+    this.user = result["user"];
+    this.user_id = result["user"]["id"];
+    return result["user"];
   }
 
   getCommandOption(commandId, optionId) {

--- a/assets/javascripts/discourse/components/ai-llm-selector.js
+++ b/assets/javascripts/discourse/components/ai-llm-selector.js
@@ -1,0 +1,22 @@
+import { computed, observer } from "@ember/object";
+import I18n from "discourse-i18n";
+import ComboBox from "select-kit/components/combo-box";
+
+export default ComboBox.extend({
+  _modelDisabledChanged: observer("attrs.disabled", function () {
+    this.selectKit.options.set("disabled", this.get("attrs.disabled.value"));
+  }),
+
+  content: computed(function () {
+    return [
+      {
+        id: "blank",
+        name: I18n.t("discourse_ai.ai_persona.no_llm_selected"),
+      },
+    ].concat(this.llms);
+  }),
+
+  selectKitOptions: {
+    filterable: true,
+  },
+});

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -123,17 +123,17 @@ export default class PersonaEditor extends Component {
 
   @action
   async toggleEnabled() {
-    this.toggleField("enabled");
+    await this.toggleField("enabled");
   }
 
   @action
   async togglePriority() {
-    this.toggleField("priority", true);
+    await this.toggleField("priority", true);
   }
 
   @action
   async toggleMentionable() {
-    this.toggleField("mentionable");
+    await this.toggleField("mentionable");
   }
 
   @action

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -306,6 +306,18 @@ export default class PersonaEditor extends Component {
           disabled={{this.editingModel.system}}
         />
       </div>
+      <div class="control-group">
+        <label>{{I18n.t "discourse_ai.ai_persona.max_context_posts"}}</label>
+        <Input
+          @type="number"
+          class="ai-persona-editor__max_context_posts"
+          @value={{this.editingModel.max_context_posts}}
+        />
+        <DTooltip
+          @icon="question-circle"
+          @content={{I18n.t "discourse_ai.ai_persona.max_context_posts_help"}}
+        />
+      </div>
       {{#if this.showTemperature}}
         <div class="control-group">
           <label>{{I18n.t "discourse_ai.ai_persona.temperature"}}</label>

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -149,7 +149,7 @@ export default class PersonaEditor extends Component {
 
   async toggleField(field, sortPersonas) {
     this.args.model.set(field, !this.args.model[field]);
-    this.editingModel.set("field", this.args.model[field]);
+    this.editingModel.set(field, this.args.model[field]);
     if (!this.args.model.isNew) {
       try {
         const args = {};

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -138,8 +138,13 @@ export default class PersonaEditor extends Component {
 
   @action
   async createUser() {
-    let user = await this.args.model.createUser();
-    this.editingModel.set("user", user);
+    try {
+      let user = await this.args.model.createUser();
+      this.editingModel.set("user", user);
+      this.editingModel.set("user_id", user.id);
+    } catch (e) {
+      popupAjaxError(e);
+    }
   }
 
   async toggleField(field, sortPersonas) {

--- a/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
@@ -31,6 +31,10 @@
 }
 
 .ai-persona-editor {
+  .fk-d-tooltip__icon {
+    padding-left: 0.25em;
+    color: var(--primary-medium);
+  }
   label {
     display: block;
   }
@@ -53,10 +57,9 @@
   &__priority {
     display: flex;
     align-items: center;
-
-    .fk-d-tooltip__icon {
-      padding-left: 0.25em;
-      color: var(--primary-medium);
-    }
+  }
+  &__mentionable {
+    display: flex;
+    align-items: center;
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -109,6 +109,8 @@ en:
         name: Name
         description: Description
         no_llm_selected: "No language model selected"
+        max_context_posts: "Max Context Posts"
+        max_context_posts_help: "The maximum number of posts to use as context for the AI when responding to a user. (empty for default)"
         mentionable: Mentionable
         mentionable_help: If enabled, users in allowed groups can mention this user in posts and messages, the AI will respond as this persona.
         user: User

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -108,6 +108,14 @@ en:
       ai_persona:
         name: Name
         description: Description
+        no_llm_selected: "No language model selected"
+        mentionable: Mentionable
+        mentionable_help: If enabled, users in allowed groups can mention this user in posts and messages, the AI will respond as this persona.
+        user: User
+        create_user: Create User
+        create_user_help: You can optionally attach a user to this persona. If you do, the AI will use this user to respond to requests.
+        default_llm: Default Language Model
+        default_llm_help: The default language model to use for this persona. Required if you wish to mention persona on public posts.
         system_prompt: System Prompt
         save: Save
         saved: AI Persona Saved

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -172,6 +172,7 @@ en:
             name: "Base Search Query"
             description: "Base query to use when searching. Example: '#urgent' will prepend '#urgent' to the search query and only include topics with the urgent category or tag."
       command_summary:
+        random_picker: "Random Picker"
         categories: "List categories"
         search: "Search"
         tags: "List tags"
@@ -185,6 +186,7 @@ en:
         search_settings: "Searching site settings"
         dall_e: "Generate image"
       command_help:
+        random_picker: "Pick a random number or a random element of a list"
         categories: "List all publicly visible categories on the forum"
         search: "Search all public topics on the forum"
         tags: "List all tags on the forum"
@@ -198,6 +200,7 @@ en:
         search_settings: "Search site settings"
         dall_e: "Generate image using DALL-E 3"
       command_description:
+        random_picker: "Picking from %{options}, picked: %{result}"
         read: "Reading: <a href='%{url}'>%{title}</a>"
         time: "Time in %{timezone} is %{time}"
         summarize: "Summarized <a href='%{url}'>%{title}</a>"
@@ -258,6 +261,6 @@ en:
         disable_embeddings: "You have to disable 'ai embeddings enabled' first."
         choose_model: "Set 'ai embeddings model' first."
         model_unreachable: "We failed to generate a test embedding with this model. Check your settings are correct."
-        hint: 
+        hint:
           one: "Make sure the `%{settings}` setting was configured."
           other: "Make sure the settings of the provider you want were configured. Options are: %{settings}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,10 +27,11 @@ Discourse::Application.routes.draw do
       :constraints => StaffConstraint.new
 
   scope "/admin/plugins/discourse-ai", constraints: AdminConstraint.new do
-    get "/", to: redirect("/admin/plugins/discourse-ai/ai_personas")
+    get "/", to: redirect("/admin/plugins/discourse-ai/ai-personas")
 
     resources :ai_personas,
               only: %i[index create show update destroy],
+              path: "ai-personas",
               controller: "discourse_ai/admin/ai_personas"
 
     post "/ai-personas/:id/create-user", to: "discourse_ai/admin/ai_personas#create_user"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,11 @@ Discourse::Application.routes.draw do
 
   scope "/admin/plugins/discourse-ai", constraints: AdminConstraint.new do
     get "/", to: redirect("/admin/plugins/discourse-ai/ai_personas")
+
     resources :ai_personas,
               only: %i[index create show update destroy],
               controller: "discourse_ai/admin/ai_personas"
+
+    post "/ai-personas/:id/create_user", to: "discourse_ai/admin/ai_personas#create_user"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,6 @@ Discourse::Application.routes.draw do
               only: %i[index create show update destroy],
               controller: "discourse_ai/admin/ai_personas"
 
-    post "/ai-personas/:id/create_user", to: "discourse_ai/admin/ai_personas#create_user"
+    post "/ai-personas/:id/create-user", to: "discourse_ai/admin/ai_personas#create_user"
   end
 end

--- a/db/migrate/20240209044519_add_user_id_mentionable_default_llm_to_ai_personas.rb
+++ b/db/migrate/20240209044519_add_user_id_mentionable_default_llm_to_ai_personas.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+#
+class AddUserIdMentionableDefaultLlmToAiPersonas < ActiveRecord::Migration[7.0]
+  def change
+    change_table :ai_personas do |t|
+      t.integer :user_id, null: true
+      t.boolean :mentionable, default: false, null: false
+      t.text :default_llm, null: true, length: 250
+    end
+  end
+end

--- a/db/migrate/20240213051213_add_limits_to_ai_persona.rb
+++ b/db/migrate/20240213051213_add_limits_to_ai_persona.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddLimitsToAiPersona < ActiveRecord::Migration[7.0]
+  def change
+    change_table :ai_personas do |t|
+      t.integer :max_context_posts, null: true
+    end
+  end
+end

--- a/lib/ai_bot/bot.rb
+++ b/lib/ai_bot/bot.rb
@@ -16,6 +16,7 @@ module DiscourseAi
       end
 
       attr_reader :bot_user
+      attr_accessor :persona
 
       def get_updated_title(conversation_context, post_user)
         system_insts = <<~TEXT.strip
@@ -110,8 +111,6 @@ module DiscourseAi
 
         raw_context
       end
-
-      attr_reader :persona
 
       private
 

--- a/lib/ai_bot/personas/persona.rb
+++ b/lib/ai_bot/personas/persona.rb
@@ -61,6 +61,7 @@ module DiscourseAi
               Tools::SearchSettings,
               Tools::Summarize,
               Tools::SettingContext,
+              Tools::RandomPicker,
             ]
 
             tools << Tools::ListTags if SiteSetting.tagging_enabled

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -193,7 +193,7 @@ module DiscourseAi
 
         # we need to ensure persona user is allowed to reply to the pm
         if post.topic.private_message?
-          if !post.topic.topic_allowed_users.where(user_id: reply_user.id).exists?
+          if !post.topic.topic_allowed_users.exists?(user_id: reply_user.id)
             post.topic.topic_allowed_users.create!(user_id: reply_user.id)
           end
         end

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -90,7 +90,10 @@ module DiscourseAi
         # We want to inject the last post as context because they are translated differently.
 
         # also setting default to 40, allowing huge contexts costs lots of tokens
-        max_posts = bot.persona.class.max_context_posts || 40
+        max_posts = 40
+        if bot.persona.class.respond_to?(:max_context_posts)
+          max_posts = bot.persona.class.max_context_posts || 40
+        end
 
         post_types = [Post.types[:regular]]
         post_types << Post.types[:whisper] if post.post_type == Post.types[:whisper]

--- a/lib/ai_bot/site_settings_extension.rb
+++ b/lib/ai_bot/site_settings_extension.rb
@@ -4,11 +4,11 @@ module DiscourseAi::AiBot::SiteSettingsExtension
   def self.enable_or_disable_ai_bots
     enabled_bots = SiteSetting.ai_bot_enabled_chat_bots_map
     enabled_bots = [] if !SiteSetting.ai_bot_enabled
+
     DiscourseAi::AiBot::EntryPoint::BOTS.each do |id, bot_name, name|
       if id == DiscourseAi::AiBot::EntryPoint::FAKE_ID
         next if Rails.env.production?
       end
-
       active = enabled_bots.include?(name)
       user = User.find_by(id: id)
 

--- a/lib/ai_bot/tools/random_picker.rb
+++ b/lib/ai_bot/tools/random_picker.rb
@@ -33,7 +33,7 @@ module DiscourseAi
         def invoke(_bot_user, _llm)
           result = nil
           # can be a naive list of strings
-          if options.all? { |option| !option.match?(/\A\d+-\d+\z/) && !option.include?(",") }
+          if options.none? { |option| option.match?(/\A\d+-\d+\z/) || option.include?(",") }
             result = options.sample
           else
             result =

--- a/lib/ai_bot/tools/random_picker.rb
+++ b/lib/ai_bot/tools/random_picker.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module AiBot
+    module Tools
+      class RandomPicker < Tool
+        def self.signature
+          {
+            name: name,
+            description:
+              "Handles a variety of random decisions based on the format of each input element",
+            parameters: [
+              {
+                name: "options",
+                description:
+                  "An array where each element is either a range (e.g., '1-6') or a comma-separated list of options (e.g., 'sam,jane,joe')",
+                type: "array",
+                item_type: "string",
+                required: true,
+              },
+            ],
+          }
+        end
+
+        def self.name
+          "random_picker"
+        end
+
+        def options
+          parameters[:options]
+        end
+
+        def invoke(_bot_user, _llm)
+          result = nil
+          # can be a naive list of strings
+          if options.all? { |option| !option.match?(/\A\d+-\d+\z/) && !option.include?(",") }
+            result = options.sample
+          else
+            result =
+              options.map do |option|
+                case option
+                when /\A\d+-\d+\z/ # Range format, e.g., "1-6"
+                  random_range(option)
+                when /,/ # Comma-separated values, e.g., "sam,jane,joe"
+                  pick_list(option)
+                else
+                  "Invalid format: #{option}"
+                end
+              end
+          end
+
+          @last_result = result
+          { options: options, result: result }
+        end
+
+        private
+
+        def random_range(range_str)
+          low, high = range_str.split("-").map(&:to_i)
+          rand(low..high)
+        end
+
+        def pick_list(list_str)
+          list_str.split(",").map(&:strip).sample
+        end
+
+        def description_args
+          { options: options, result: @last_result }
+        end
+      end
+    end
+  end
+end

--- a/lib/completions/llm.rb
+++ b/lib/completions/llm.rb
@@ -21,28 +21,39 @@ module DiscourseAi
         def models_by_provider
           # ChatGPT models are listed under open_ai but they are actually available through OpenAI and Azure.
           # However, since they use the same URL/key settings, there's no reason to duplicate them.
-          {
-            aws_bedrock: %w[claude-instant-1 claude-2],
-            anthropic: %w[claude-instant-1 claude-2],
-            vllm: %w[
-              mistralai/Mixtral-8x7B-Instruct-v0.1
-              mistralai/Mistral-7B-Instruct-v0.2
-              StableBeluga2
-              Upstage-Llama-2-*-instruct-v2
-              Llama2-*-chat-hf
-              Llama2-chat-hf
-            ],
-            hugging_face: %w[
-              mistralai/Mixtral-8x7B-Instruct-v0.1
-              mistralai/Mistral-7B-Instruct-v0.2
-              StableBeluga2
-              Upstage-Llama-2-*-instruct-v2
-              Llama2-*-chat-hf
-              Llama2-chat-hf
-            ],
-            open_ai: %w[gpt-3.5-turbo gpt-4 gpt-3.5-turbo-16k gpt-4-32k gpt-4-turbo],
-            google: %w[gemini-pro],
-          }.tap { |h| h[:fake] = ["fake"] if Rails.env.test? || Rails.env.development? }
+          @models_by_provider ||=
+            {
+              aws_bedrock: %w[claude-instant-1 claude-2],
+              anthropic: %w[claude-instant-1 claude-2],
+              vllm: %w[
+                mistralai/Mixtral-8x7B-Instruct-v0.1
+                mistralai/Mistral-7B-Instruct-v0.2
+                StableBeluga2
+                Upstage-Llama-2-*-instruct-v2
+                Llama2-*-chat-hf
+                Llama2-chat-hf
+              ],
+              hugging_face: %w[
+                mistralai/Mixtral-8x7B-Instruct-v0.1
+                mistralai/Mistral-7B-Instruct-v0.2
+                StableBeluga2
+                Upstage-Llama-2-*-instruct-v2
+                Llama2-*-chat-hf
+                Llama2-chat-hf
+              ],
+              open_ai: %w[gpt-3.5-turbo gpt-4 gpt-3.5-turbo-16k gpt-4-32k gpt-4-turbo],
+              google: %w[gemini-pro],
+            }.tap { |h| h[:fake] = ["fake"] if Rails.env.test? || Rails.env.development? }
+        end
+
+        def valid_provider_models
+          return @valid_provider_models if defined?(@valid_provider_models)
+
+          valid_provider_models = []
+          models_by_provider.each do |provider, models|
+            valid_provider_models.concat(models.map { |model| "#{provider}:#{model}" })
+          end
+          @valid_provider_models = Set.new(valid_provider_models)
         end
 
         def with_prepared_responses(responses)

--- a/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
+++ b/spec/lib/modules/ai_bot/jobs/regular/create_ai_reply_spec.rb
@@ -14,10 +14,12 @@ RSpec.describe Jobs::CreateAiReply do
     before { SiteSetting.min_personal_message_post_length = 5 }
 
     it "adds a reply from the bot" do
+      persona_id = AiPersona.find_by(name: "Forum Helper").id
       DiscourseAi::Completions::Llm.with_prepared_responses([expected_response]) do
         subject.execute(
           post_id: topic.first_post.id,
           bot_user_id: DiscourseAi::AiBot::EntryPoint::GPT3_5_TURBO_ID,
+          persona_id: persona_id,
         )
       end
 

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe DiscourseAi::AiBot::Playground do
     before { Jobs.run_immediately! }
 
     it "allows mentioning a persona" do
+      SiteSetting.ai_bot_allowed_groups = "#{Group::AUTO_GROUPS[:trust_level_0]}"
+
       persona =
         AiPersona.create!(
           name: "Test Persona",
@@ -52,7 +54,7 @@ RSpec.describe DiscourseAi::AiBot::Playground do
         )
 
       persona.create_user!
-      persona.update!(default_llm: "test", mentionable: true)
+      persona.update!(default_llm: "claude-2", mentionable: true)
 
       post = nil
       DiscourseAi::Completions::Llm.with_prepared_responses(["Yes I can"]) do

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -102,6 +102,9 @@ RSpec.describe DiscourseAi::AiBot::Playground do
       last_post = post.topic.posts.order(:post_number).last
       expect(last_post.raw).to eq("Yes I can")
       expect(last_post.user_id).to eq(persona.user_id)
+
+      last_post.topic.reload
+      expect(last_post.topic.allowed_users.pluck(:user_id)).to include(persona.user_id)
     end
   end
 

--- a/spec/lib/modules/ai_bot/tools/random_picker_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/random_picker_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DiscourseAi::AiBot::Tools::RandomPicker do
+  describe "#invoke" do
+    subject { described_class.new({ options: options }).invoke(nil, nil) }
+
+    context "with options as simple list of strings" do
+      let(:options) { %w[apple banana cherry] }
+
+      it "returns one of the options" do
+        expect(options).to include(subject[:result])
+      end
+    end
+
+    context "with options as ranges" do
+      let(:options) { %w[1-3 10-20] }
+
+      it "returns a number within one of the provided ranges" do
+        results = subject[:result]
+        expect(results).to all(
+          satisfy { |result| (1..3).include?(result) || (10..20).include?(result) },
+        )
+      end
+    end
+
+    context "with options as comma-separated values" do
+      let(:options) { %w[red,green,blue mon,tue,wed] }
+
+      it "returns one value from each comma-separated list" do
+        results = subject[:result]
+        expect(results).to include(a_kind_of(String))
+        results.each { |result| expect(result.split(",")).to include(result) }
+      end
+    end
+
+    context "with mixed options (list, range, and comma-separated)" do
+      let(:options) { %w[apple 1-3 mon,tue,wed] }
+
+      it "handles each option appropriately" do
+        results = subject[:result]
+        expect(results.size).to eq(options.size)
+        # Verifying each type of option is respected needs a more elaborate setup,
+        # potentially mocking or specific expectations for each type.
+      end
+    end
+
+    context "with an invalid format in options" do
+      let(:options) { ["invalid_format"] }
+
+      it "returns an error message for invalid formats" do
+        expect(subject[:result]).to include("invalid_format")
+      end
+    end
+  end
+end

--- a/spec/models/ai_persona_spec.rb
+++ b/spec/models/ai_persona_spec.rb
@@ -24,6 +24,23 @@ RSpec.describe AiPersona do
     expect(persona.valid?).to eq(true)
   end
 
+  it "allows creation of user" do
+    persona =
+      AiPersona.create!(
+        name: "test",
+        description: "test",
+        system_prompt: "test",
+        commands: [],
+        allowed_group_ids: [],
+      )
+
+    user = persona.create_user!
+    expect(user.username).to eq("test_bot")
+    expect(user.name).to eq("Test")
+    expect(user.bot?).to be(true)
+    expect(user.id).to be <= AiPersona::FIRST_PERSONA_USER_ID
+  end
+
   it "defines singleton methods on system persona classes" do
     forum_helper = AiPersona.find_by(name: "Forum Helper")
     forum_helper.update!(

--- a/spec/models/ai_persona_spec.rb
+++ b/spec/models/ai_persona_spec.rb
@@ -1,6 +1,75 @@
 # frozen_string_literal: true
 
 RSpec.describe AiPersona do
+  it "validates context settings" do
+    persona =
+      AiPersona.new(
+        name: "test",
+        description: "test",
+        system_prompt: "test",
+        commands: [],
+        allowed_group_ids: [],
+      )
+
+    expect(persona.valid?).to eq(true)
+
+    persona.max_context_posts = 0
+    expect(persona.valid?).to eq(false)
+    expect(persona.errors[:max_context_posts]).to eq(["must be greater than 0"])
+
+    persona.max_context_posts = 1
+    expect(persona.valid?).to eq(true)
+
+    persona.max_context_posts = nil
+    expect(persona.valid?).to eq(true)
+  end
+
+  it "defines singleton methods on system persona classes" do
+    forum_helper = AiPersona.find_by(name: "Forum Helper")
+    forum_helper.update!(
+      user_id: 1,
+      mentionable: true,
+      default_llm: "anthropic:claude-2",
+      max_context_posts: 3,
+    )
+
+    klass = forum_helper.class_instance
+
+    expect(klass.id).to eq(forum_helper.id)
+    expect(klass.system).to eq(true)
+    # tl 0 by default
+    expect(klass.allowed_group_ids).to eq([10])
+    expect(klass.user_id).to eq(1)
+    expect(klass.mentionable).to eq(true)
+    expect(klass.default_llm).to eq("anthropic:claude-2")
+    expect(klass.max_context_posts).to eq(3)
+  end
+
+  it "defines singleton methods non persona classes" do
+    persona =
+      AiPersona.create!(
+        name: "test",
+        description: "test",
+        system_prompt: "test",
+        commands: [],
+        allowed_group_ids: [],
+        default_llm: "anthropic:claude-2",
+        max_context_posts: 3,
+        mentionable: true,
+        user_id: 1,
+      )
+
+    klass = persona.class_instance
+
+    expect(klass.id).to eq(persona.id)
+    expect(klass.system).to eq(false)
+    expect(klass.allowed_group_ids).to eq([])
+    expect(klass.user_id).to eq(1)
+    expect(klass.mentionable).to eq(true)
+    expect(klass.default_llm).to eq("anthropic:claude-2")
+    expect(klass.max_context_posts).to eq(3)
+  end
+
   it "does not leak caches between sites" do
     AiPersona.create!(
       name: "pun_bot",

--- a/spec/requests/admin/ai_personas_controller_spec.rb
+++ b/spec/requests/admin/ai_personas_controller_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
 
   describe "POST #create_user" do
     it "creates a user for the persona" do
-      post "/admin/plugins/discourse-ai/ai-personas/#{ai_persona.id}/create_user.json"
+      post "/admin/plugins/discourse-ai/ai-personas/#{ai_persona.id}/create-user.json"
       ai_persona.reload
 
       expect(response).to be_successful

--- a/spec/requests/admin/ai_personas_controller_spec.rb
+++ b/spec/requests/admin/ai_personas_controller_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
       expect(response).to be_successful
 
       expect(response.parsed_body["meta"]["llms"]).to eq(
-        JSON.parse(DiscourseAi::Configuration::LlmEnumerator.values.to_json),
+        DiscourseAi::Configuration::LlmEnumerator.values.map do |hash|
+          { "id" => hash[:value], "name" => hash[:name] }
+        end,
       )
     end
 

--- a/spec/requests/admin/ai_personas_controller_spec.rb
+++ b/spec/requests/admin/ai_personas_controller_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
       )
     end
 
+    it "sideloads llms" do
+      get "/admin/plugins/discourse-ai/ai_personas.json"
+      expect(response).to be_successful
+
+      expect(response.parsed_body["meta"]["llms"]).to eq(
+        JSON.parse(DiscourseAi::Configuration::LlmEnumerator.values.to_json),
+      )
+    end
+
     it "returns commands options with each command" do
       persona1 = Fabricate(:ai_persona, name: "search1", commands: ["SearchCommand"])
       persona2 =

--- a/spec/requests/admin/ai_personas_controller_spec.rb
+++ b/spec/requests/admin/ai_personas_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
 
   describe "GET #index" do
     it "returns a success response" do
-      get "/admin/plugins/discourse-ai/ai_personas.json"
+      get "/admin/plugins/discourse-ai/ai-personas.json"
       expect(response).to be_successful
 
       expect(response.parsed_body["ai_personas"].length).to eq(AiPersona.count)
@@ -18,7 +18,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
     end
 
     it "sideloads llms" do
-      get "/admin/plugins/discourse-ai/ai_personas.json"
+      get "/admin/plugins/discourse-ai/ai-personas.json"
       expect(response).to be_successful
 
       expect(response.parsed_body["meta"]["llms"]).to eq(
@@ -40,7 +40,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
         )
       persona2.create_user!
 
-      get "/admin/plugins/discourse-ai/ai_personas.json"
+      get "/admin/plugins/discourse-ai/ai-personas.json"
       expect(response).to be_successful
 
       serializer_persona1 = response.parsed_body["ai_personas"].find { |p| p["id"] == persona1.id }
@@ -105,7 +105,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
       end
 
       it "returns localized persona names and descriptions" do
-        get "/admin/plugins/discourse-ai/ai_personas.json"
+        get "/admin/plugins/discourse-ai/ai-personas.json"
 
         id =
           DiscourseAi::AiBot::Personas::Persona.system_personas[
@@ -121,7 +121,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
 
   describe "GET #show" do
     it "returns a success response" do
-      get "/admin/plugins/discourse-ai/ai_personas/#{ai_persona.id}.json"
+      get "/admin/plugins/discourse-ai/ai-personas/#{ai_persona.id}.json"
       expect(response).to be_successful
       expect(response.parsed_body["ai_persona"]["name"]).to eq(ai_persona.name)
     end
@@ -144,7 +144,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
 
       it "creates a new AiPersona" do
         expect {
-          post "/admin/plugins/discourse-ai/ai_personas.json",
+          post "/admin/plugins/discourse-ai/ai-personas.json",
                params: { ai_persona: valid_attributes }.to_json,
                headers: {
                  "CONTENT_TYPE" => "application/json",
@@ -169,7 +169,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
 
     context "with invalid params" do
       it "renders a JSON response with errors for the new ai_persona" do
-        post "/admin/plugins/discourse-ai/ai_personas.json", params: { ai_persona: { foo: "" } } # invalid attribute
+        post "/admin/plugins/discourse-ai/ai-personas.json", params: { ai_persona: { foo: "" } } # invalid attribute
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to include("application/json")
       end
@@ -189,7 +189,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
   describe "PUT #update" do
     it "allows us to trivially clear top_p and temperature" do
       persona = Fabricate(:ai_persona, name: "test_bot2", top_p: 0.5, temperature: 0.1)
-      put "/admin/plugins/discourse-ai/ai_personas/#{persona.id}.json",
+      put "/admin/plugins/discourse-ai/ai-personas/#{persona.id}.json",
           params: {
             ai_persona: {
               top_p: "",
@@ -205,7 +205,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
     end
 
     it "does not allow temperature and top p changes on stock personas" do
-      put "/admin/plugins/discourse-ai/ai_personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json",
+      put "/admin/plugins/discourse-ai/ai-personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json",
           params: {
             ai_persona: {
               top_p: 0.5,
@@ -218,7 +218,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
 
     context "with valid params" do
       it "updates the requested ai_persona" do
-        put "/admin/plugins/discourse-ai/ai_personas/#{ai_persona.id}.json",
+        put "/admin/plugins/discourse-ai/ai-personas/#{ai_persona.id}.json",
             params: {
               ai_persona: {
                 name: "SuperBot",
@@ -239,7 +239,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
 
     context "with system personas" do
       it "does not allow editing of system prompts" do
-        put "/admin/plugins/discourse-ai/ai_personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json",
+        put "/admin/plugins/discourse-ai/ai-personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json",
             params: {
               ai_persona: {
                 system_prompt: "you are not a helpful bot",
@@ -252,7 +252,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
       end
 
       it "does not allow editing of commands" do
-        put "/admin/plugins/discourse-ai/ai_personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json",
+        put "/admin/plugins/discourse-ai/ai-personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json",
             params: {
               ai_persona: {
                 commands: %w[SearchCommand ImageCommand],
@@ -265,7 +265,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
       end
 
       it "does not allow editing of name and description cause it is localized" do
-        put "/admin/plugins/discourse-ai/ai_personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json",
+        put "/admin/plugins/discourse-ai/ai-personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json",
             params: {
               ai_persona: {
                 name: "bob",
@@ -279,7 +279,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
       end
 
       it "does allow some actions" do
-        put "/admin/plugins/discourse-ai/ai_personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json",
+        put "/admin/plugins/discourse-ai/ai-personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json",
             params: {
               ai_persona: {
                 allowed_group_ids: [Group::AUTO_GROUPS[:trust_level_1]],
@@ -294,7 +294,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
 
     context "with invalid params" do
       it "renders a JSON response with errors for the ai_persona" do
-        put "/admin/plugins/discourse-ai/ai_personas/#{ai_persona.id}.json",
+        put "/admin/plugins/discourse-ai/ai-personas/#{ai_persona.id}.json",
             params: {
               ai_persona: {
                 name: "",
@@ -309,7 +309,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
   describe "DELETE #destroy" do
     it "destroys the requested ai_persona" do
       expect {
-        delete "/admin/plugins/discourse-ai/ai_personas/#{ai_persona.id}.json"
+        delete "/admin/plugins/discourse-ai/ai-personas/#{ai_persona.id}.json"
 
         expect(response).to have_http_status(:no_content)
       }.to change(AiPersona, :count).by(-1)
@@ -317,7 +317,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
 
     it "is not allowed to delete system personas" do
       expect {
-        delete "/admin/plugins/discourse-ai/ai_personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json"
+        delete "/admin/plugins/discourse-ai/ai-personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}.json"
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"].join).not_to be_blank
         # let's make sure this is translated

--- a/spec/system/ai_bot/persona_spec.rb
+++ b/spec/system/ai_bot/persona_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "AI personas", type: :system, js: true do
   end
 
   it "allows creation of a persona" do
-    visit "/admin/plugins/discourse-ai/ai_personas"
+    visit "/admin/plugins/discourse-ai/ai-personas"
     find(".ai-persona-list-editor__header .btn-primary").click()
     find(".ai-persona-editor__name").set("Test Persona")
     find(".ai-persona-editor__description").fill_in(with: "I am a test persona")
@@ -42,7 +42,7 @@ RSpec.describe "AI personas", type: :system, js: true do
 
     find(".ai-persona-editor__save").click()
 
-    expect(page).not_to have_current_path("/admin/plugins/discourse-ai/ai_personas/new")
+    expect(page).not_to have_current_path("/admin/plugins/discourse-ai/ai-personas/new")
 
     persona_id = page.current_path.split("/").last.to_i
 
@@ -54,7 +54,7 @@ RSpec.describe "AI personas", type: :system, js: true do
   end
 
   it "will not allow deletion or editing of system personas" do
-    visit "/admin/plugins/discourse-ai/ai_personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}"
+    visit "/admin/plugins/discourse-ai/ai-personas/#{DiscourseAi::AiBot::Personas::Persona.system_personas.values.first}"
     expect(page).not_to have_selector(".ai-persona-editor__delete")
     expect(find(".ai-persona-editor__system_prompt")).to be_disabled
   end
@@ -62,7 +62,7 @@ RSpec.describe "AI personas", type: :system, js: true do
   it "will enable persona right away when you click on enable but does not save side effects" do
     persona = Fabricate(:ai_persona, enabled: false)
 
-    visit "/admin/plugins/discourse-ai/ai_personas/#{persona.id}"
+    visit "/admin/plugins/discourse-ai/ai-personas/#{persona.id}"
 
     find(".ai-persona-editor__name").set("Test Persona 1")
     PageObjects::Components::DToggleSwitch.new(".ai-persona-editor__enabled").toggle

--- a/test/javascripts/unit/models/ai-persona-test.js
+++ b/test/javascripts/unit/models/ai-persona-test.js
@@ -41,6 +41,10 @@ module("Discourse AI | Unit | Model | ai-persona", function () {
       description: "Description",
       top_p: 0.8,
       temperature: 0.7,
+      mentionable: false,
+      default_llm: "Default LLM",
+      user: null,
+      user_id: null,
     };
 
     const aiPersona = AiPersona.create({ ...properties });
@@ -67,6 +71,10 @@ module("Discourse AI | Unit | Model | ai-persona", function () {
       description: "Description",
       top_p: 0.8,
       temperature: 0.7,
+      user: null,
+      user_id: null,
+      default_llm: "Default LLM",
+      mentionable: false,
     };
 
     const aiPersona = AiPersona.create({ ...properties });

--- a/test/javascripts/unit/models/ai-persona-test.js
+++ b/test/javascripts/unit/models/ai-persona-test.js
@@ -45,6 +45,7 @@ module("Discourse AI | Unit | Model | ai-persona", function () {
       default_llm: "Default LLM",
       user: null,
       user_id: null,
+      max_context_posts: 5,
     };
 
     const aiPersona = AiPersona.create({ ...properties });
@@ -75,6 +76,7 @@ module("Discourse AI | Unit | Model | ai-persona", function () {
       user_id: null,
       default_llm: "Default LLM",
       mentionable: false,
+      max_context_posts: 5,
     };
 
     const aiPersona = AiPersona.create({ ...properties });


### PR DESCRIPTION
This rather large PR adds support for the following: 

![image](https://github.com/discourse/discourse-ai/assets/5213/4cb688d0-47b0-4e1f-97dd-6847387ac473)

![image](https://github.com/discourse/discourse-ai/assets/5213/aa1f02d7-698c-4fc0-9d79-dfa03f21eb2d)

1. Personas are now **optionally** mentionable, meaning that you can mention them either from public topics or PMs
    1. Mentioning from PMs helps "switch" persona mid conversation, meaning if you want to look up sites setting you can invoke the site setting bot, or if you want to generate an image you can invoke dall e
    2. Mentioning outside of PMs allows you to inject a bot reply in a topic trivially
2. We also add the support for max_context_posts this allow you to limit the amount of context you feed in, which can help control costs
 


