### PR TITLE
FIX: Better AI chat thread titles

### DIFF
--- a/spec/lib/modules/ai_helper/chat_thread_titler_spec.rb
+++ b/spec/lib/modules/ai_helper/chat_thread_titler_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe DiscourseAi::AiHelper::ChatThreadTitler do
 
       expect(result).to eq(expected_title)
     end
-    
+
     it "truncates long titles" do
       titles = "O cavalo trota pelo campo" + " Pocotó" * 100
 

--- a/spec/lib/modules/ai_helper/chat_thread_titler_spec.rb
+++ b/spec/lib/modules/ai_helper/chat_thread_titler_spec.rb
@@ -45,6 +45,23 @@ RSpec.describe DiscourseAi::AiHelper::ChatThreadTitler do
 
       expect(result).to eq(expected_title)
     end
+
+    it "parses the XML" do
+      titles = "Here is your title <title>The solitary horse</title> my friend"
+      expected_title = "The solitary horse"
+
+      result = titler.cleanup(titles)
+
+      expect(result).to eq(expected_title)
+    end
+    
+    it "truncates long titles" do
+      titles = "O cavalo trota pelo campo" + " Pocotó" * 100
+
+      result = titler.cleanup(titles)
+
+      expect(result.size).to be <= 100
+    end
   end
 
   describe "#thread_content" do


### PR DESCRIPTION
- Fix quote removal when multi-line

- Use XML tags for better LLM output parsing

- Use stop_sequences for faster and less wasteful LLM calls

- Adds truncation as the last line of defense