### PR TITLE
DEV: Make more group-based settings client: false

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -244,12 +244,7 @@ export default class AiHelperContextMenu extends Component {
   }
 
   _showUserCustomPrompts() {
-    const allowedGroups =
-      this.siteSettings?.ai_helper_custom_prompts_allowed_groups
-        .split("|")
-        .map((id) => parseInt(id, 10));
-
-    return this.currentUser?.groups.some((g) => allowedGroups.includes(g.id));
+    return this.currentUser?.can_use_custom_prompts;
   }
 
   handleBoundaries() {

--- a/assets/javascripts/discourse/connectors/post-text-buttons/ai-helper-options-menu.gjs
+++ b/assets/javascripts/discourse/connectors/post-text-buttons/ai-helper-options-menu.gjs
@@ -195,12 +195,7 @@ export default class AIHelperOptionsMenu extends Component {
   }
 
   _showUserCustomPrompts() {
-    const allowedGroups =
-      this.siteSettings?.ai_helper_custom_prompts_allowed_groups
-        .split("|")
-        .map((id) => parseInt(id, 10));
-
-    return this.currentUser?.groups.some((g) => allowedGroups.includes(g.id));
+    return this.currentUser?.can_use_custom_prompts;
   }
 
   @action

--- a/assets/javascripts/discourse/lib/show-ai-helper.js
+++ b/assets/javascripts/discourse/lib/show-ai-helper.js
@@ -1,9 +1,6 @@
 export function showComposerAIHelper(outletArgs, helper, featureType) {
   const enableHelper = _helperEnabled(helper.siteSettings);
-  const enableAssistant = _canUseAssistant(
-    helper.currentUser,
-    _findAllowedGroups(helper.siteSettings.ai_helper_allowed_groups)
-  );
+  const enableAssistant = helper.currentUser.can_use_assistant;
   const canShowInPM = helper.siteSettings.ai_helper_allowed_in_pm;
   const enableFeature =
     helper.siteSettings.ai_helper_enabled_features.includes(featureType);
@@ -18,10 +15,7 @@ export function showComposerAIHelper(outletArgs, helper, featureType) {
 export function showPostAIHelper(outletArgs, helper) {
   return (
     _helperEnabled(helper.siteSettings) &&
-    _canUseAssistant(
-      helper.currentUser,
-      _findAllowedGroups(helper.siteSettings.post_ai_helper_allowed_groups)
-    )
+    helper.currentUser.can_use_assistant_in_post
   );
 }
 
@@ -29,12 +23,4 @@ function _helperEnabled(siteSettings) {
   return (
     siteSettings.discourse_ai_enabled && siteSettings.composer_ai_helper_enabled
   );
-}
-
-function _findAllowedGroups(setting) {
-  return setting.split("|").map((id) => parseInt(id, 10));
-}
-
-function _canUseAssistant(user, allowedGroups) {
-  return user?.groups.some((g) => allowedGroups.includes(g.id));
 }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,7 +46,6 @@ discourse_ai:
     default: 60
     client: false
   ai_toxicity_groups_bypass:
-    client: true
     type: group_list
     list_type: compact
     default: "3" # 3: @staff
@@ -172,7 +171,6 @@ discourse_ai:
     client: true
     validator: "DiscourseAi::Configuration::LlmDependencyValidator"
   ai_helper_allowed_groups:
-    client: true
     type: group_list
     list_type: compact
     default: "3|14" # 3: @staff, 14: @trust_level_4
@@ -188,14 +186,12 @@ discourse_ai:
     enum: "DiscourseAi::Configuration::LlmEnumerator"
     validator: "DiscourseAi::Configuration::LlmValidator"
   ai_helper_custom_prompts_allowed_groups:
-    client: true
     type: group_list
     list_type: compact
     default: "3" # 3: @staff
     allow_any: false
     refresh: true
   post_ai_helper_allowed_groups:
-    client: true
     type: group_list
     list_type: compact
     default: "3|14" # 3: @staff, 14: @trust_level_4

--- a/lib/ai_bot/entry_point.rb
+++ b/lib/ai_bot/entry_point.rb
@@ -98,6 +98,18 @@ module DiscourseAi
           bots
         end
 
+        plugin.add_to_serializer(:current_user, :can_use_assistant) do
+          scope.user.in_any_groups?(SiteSetting.ai_helper_allowed_groups_map)
+        end
+
+        plugin.add_to_serializer(:current_user, :can_use_assistant_in_post) do
+          scope.user.in_any_groups?(SiteSetting.post_ai_helper_allowed_groups_map)
+        end
+
+        plugin.add_to_serializer(:current_user, :can_use_custom_prompts) do
+          scope.user.in_any_groups?(SiteSetting.ai_helper_custom_prompts_allowed_groups_map)
+        end
+
         plugin.register_svg_icon("robot")
 
         plugin.add_to_serializer(


### PR DESCRIPTION
Affects the following settings:

ai_toxicity_groups_bypass
ai_helper_allowed_groups
ai_helper_custom_prompts_allowed_groups
post_ai_helper_allowed_groups

This turns off client: true for these group-based settings, because there is no guarantee that the current user gets all their group memberships serialized to the client. Better to check server-side first.