### PR TITLE
FIX: unable to share conversations with persona user

### DIFF
--- a/assets/javascripts/discourse/lib/copy-conversation.js
+++ b/assets/javascripts/discourse/lib/copy-conversation.js
@@ -56,9 +56,5 @@ async function generateClipboard(topic, fromPostNumber, toPostNumber) {
 
   const text = buffer.join("\n");
 
-  if (window.discourseAiTestClipboard) {
-    window.discourseAiClipboard = text;
-  }
-
   return text;
 }

--- a/assets/javascripts/initializers/ai-bot-replies.js
+++ b/assets/javascripts/initializers/ai-bot-replies.js
@@ -143,6 +143,8 @@ function initializePersonaDecorator(api) {
   );
 }
 
+const MAX_PERSONA_USER_ID = -1200;
+
 function initializeShareButton(api) {
   const currentUser = api.getCurrentUser();
   if (!currentUser || !currentUser.ai_enabled_chat_bots) {
@@ -159,13 +161,20 @@ function initializeShareButton(api) {
   };
 
   api.addPostMenuButton("share", (post) => {
-    // very hacky and ugly, but there is no `.topic` in attrs
+    // for backwards compat so we don't break if topic is undefined
+    if (post.topic?.archetype !== "private_message") {
+      return;
+    }
+
     if (
       !currentUser.ai_enabled_chat_bots.any(
         (bot) => post.username === bot.username
       )
     ) {
-      return;
+      // special handling for personas (larger than -1200 means real user)
+      if (post.user_id > MAX_PERSONA_USER_ID) {
+        return;
+      }
     }
 
     return {

--- a/assets/javascripts/initializers/ai-bot-replies.js
+++ b/assets/javascripts/initializers/ai-bot-replies.js
@@ -171,7 +171,7 @@ function initializeShareButton(api) {
         (bot) => post.username === bot.username
       )
     ) {
-      // special handling for personas (larger than -1200 means real user)
+      // special handling for personas (persona bot users start at ID -1200 and go down)
       if (post.user_id > MAX_PERSONA_USER_ID) {
         return;
       }

--- a/lib/ai_bot/personas/discourse_helper.rb
+++ b/lib/ai_bot/personas/discourse_helper.rb
@@ -15,7 +15,7 @@ module DiscourseAi
             - Discourse Helper Bot understand *markdown* and responds in Discourse **markdown**.
             - Discourse Helper Bot has access to the search function on meta.discourse.org and can help you find answers to your questions.
             - Discourse Helper Bot ALWAYS backs up answers with actual search results from meta.discourse.org, even if the information is in your training set
-            - Discourse Helper Bot does not use the word siscourse in searches, search function is restricted to Discourse Meta and Discourse specific discussions
+            - Discourse Helper Bot does not use the word Discourse in searches, search function is restricted to Discourse Meta and Discourse specific discussions
             - Discourse Helper Bot understands that search is keyword based (terms are joined using AND) and that it is important to simplify search terms to find things.
             - Discourse Helper Bot understands that users often badly phrase and misspell words, it will compensate for that by guessing what user means.
 


### PR DESCRIPTION
Persona users are still bots, but we were not properly accounting
for it and share icon was not showing up.

This depends on a core change that adds .topic to transformed posts
