### PR TITLE
UX: minor adjustments for image caption size, behavior

### DIFF
--- a/assets/javascripts/discourse/connectors/editor-preview/ai-image-caption-container.gjs
+++ b/assets/javascripts/discourse/connectors/editor-preview/ai-image-caption-container.gjs
@@ -2,6 +2,8 @@ import Component from "@glimmer/component";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { inject as service } from "@ember/service";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import DButton from "discourse/components/d-button";
@@ -36,6 +38,12 @@ export default class AiImageCaptionContainer extends Component {
     this.imageCaptionPopup.showPopup = false;
   }
 
+  @action
+  resizeTextarea(target) {
+    target.style.height = `${target.scrollHeight + 5}px`;
+    target.scrollTop = 0;
+  }
+
   <template>
     {{#if this.imageCaptionPopup.showPopup}}
       <div class="composer-popup education-message ai-caption-popup">
@@ -43,6 +51,8 @@ export default class AiImageCaptionContainer extends Component {
           @condition={{this.imageCaptionPopup.loading}}
         >
           <DTextarea
+            {{didInsert this.resizeTextarea}}
+            {{didUpdate this.resizeTextarea this.imageCaptionPopup.newCaption}}
             @value={{this.imageCaptionPopup.newCaption}}
             {{on "change" this.updateCaption}}
             {{autoFocus}}

--- a/assets/javascripts/discourse/connectors/editor-preview/ai-image-caption-container.gjs
+++ b/assets/javascripts/discourse/connectors/editor-preview/ai-image-caption-container.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";

--- a/assets/javascripts/initializers/ai-image-caption.js
+++ b/assets/javascripts/initializers/ai-image-caption.js
@@ -34,6 +34,8 @@ export default apiInitializer("1.25.0", (api) => {
         imageCaptionPopup.loading = true;
         imageCaptionPopup.showPopup = !imageCaptionPopup.showPopup;
 
+        event.target.classList.add("disabled");
+
         ajax(`/discourse-ai/ai-helper/caption_image`, {
           method: "POST",
           data: {
@@ -41,7 +43,6 @@ export default apiInitializer("1.25.0", (api) => {
           },
         })
           .then(({ caption }) => {
-            event.target.classList.add("disabled");
             imageCaptionPopup.imageSrc = imageSrc;
             imageCaptionPopup.imageIndex = imageIndex;
             imageCaptionPopup.newCaption = caption;

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -488,29 +488,30 @@
     &.disabled {
       pointer-events: none;
       cursor: not-allowed;
-      opacity: 0.8;
-      &:hover,
-      &:focus {
-        background: var(--primary-low);
-        color: var(--primary-high);
-      }
+      opacity: 0.7;
     }
   }
 }
 
 .ai-caption-popup {
+  --ai-caption-popup-min-width: 20rem;
   width: auto;
   right: unset;
   padding: 1em;
   top: unset;
   bottom: 0;
 
+  .loading-container {
+    min-width: var(--ai-caption-popup-min-width);
+  }
+
   textarea {
     width: 100%;
-    max-width: 40vw;
+    max-width: 40dvw;
+    max-height: calc(100dvh - var(--header-offset) - 10em);
     min-height: 3em;
     height: 7em;
-    min-width: 20em;
+    min-width: var(--ai-caption-popup-min-width);
     @include breakpoint(tablet) {
       width: 100%;
       max-width: unset;

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -465,6 +465,7 @@
     color: var(--tertiary);
     box-shadow: var(--shadow-dropdown);
     position: absolute;
+    white-space: nowrap;
     top: -3.15rem;
     left: 0.75rem;
     padding: 0.5em 0.75em;
@@ -506,6 +507,7 @@
   }
 
   textarea {
+    box-sizing: border-box;
     width: 100%;
     max-width: 40dvw;
     max-height: calc(100dvh - var(--header-offset) - 10em);


### PR DESCRIPTION
Making a few adjustments to improve the experience:

* Loading container the same width as textarea to avoid jump when content loads
* Set textarea height based on content, and scroll to top... this avoids situations where someone might have to scroll back up within the caption to see the top of the text. CSS will still cap the max height/width to avoid edge cases. 
* Disable the caption button when the request starts, not after the data has been fetched 
* `pointer-events: none` disables hover and active states, so no need for those in CSS