### PR TITLE
DEV: Auto save caption on mobile view

### DIFF
--- a/assets/javascripts/initializers/ai-image-caption.js
+++ b/assets/javascripts/initializers/ai-image-caption.js
@@ -2,6 +2,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { apiInitializer } from "discourse/lib/api";
 import I18n from "discourse-i18n";
+import { IMAGE_MARKDOWN_REGEX } from "../discourse/lib/utilities";
 
 export default apiInitializer("1.25.0", (api) => {
   const buttonAttrs = {
@@ -11,6 +12,9 @@ export default apiInitializer("1.25.0", (api) => {
   };
   const imageCaptionPopup = api.container.lookup("service:imageCaptionPopup");
   const settings = api.container.lookup("service:site-settings");
+  const composer = api.container.lookup("service:composer");
+  const appEvents = api.container.lookup("service:app-events");
+  const site = api.container.lookup("site:main");
 
   if (!settings.ai_helper_enabled_features.includes("image_caption")) {
     return;
@@ -32,7 +36,10 @@ export default apiInitializer("1.25.0", (api) => {
           .getAttribute("src");
 
         imageCaptionPopup.loading = true;
-        imageCaptionPopup.showPopup = !imageCaptionPopup.showPopup;
+
+        if (!site.mobileView) {
+          imageCaptionPopup.showPopup = !imageCaptionPopup.showPopup;
+        }
 
         event.target.classList.add("disabled");
 
@@ -46,6 +53,18 @@ export default apiInitializer("1.25.0", (api) => {
             imageCaptionPopup.imageSrc = imageSrc;
             imageCaptionPopup.imageIndex = imageIndex;
             imageCaptionPopup.newCaption = caption;
+
+            if (site.mobileView) {
+              // Auto-saves caption on mobile view
+              const matchingPlaceholder =
+                composer.model.reply.match(IMAGE_MARKDOWN_REGEX);
+              const match = matchingPlaceholder[imageIndex];
+              const replacement = match.replace(
+                IMAGE_MARKDOWN_REGEX,
+                `![${imageCaptionPopup.newCaption}|$2$3$4]($5)`
+              );
+              appEvents.trigger("composer:replace-text", match, replacement);
+            }
           })
           .catch(popupAjaxError)
           .finally(() => {


### PR DESCRIPTION
This PR improves the image caption feature for mobile view. 

Previously, image caption on mobile was not functional because the plugin outlet connector used for the `<AiImageCaptionContainer />` was not present in mobile devices. 

This PR updates the logic so that when the site is in `mobileView` the caption will be auto-saved on pressing the "Caption with AI" button.