### PR TITLE
DEV: Image caption system specs

### DIFF
--- a/spec/system/ai_helper/ai_image_caption_spec.rb
+++ b/spec/system/ai_helper/ai_image_caption_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe "AI image caption", type: :system, js: true do
+  fab!(:user) { Fabricate(:admin, refresh_auto_groups: true) }
+  let(:composer) { PageObjects::Components::Composer.new }
+  let(:popup) { PageObjects::Components::AiCaptionPopup.new }
+  let(:file_path) { file_from_fixtures("logo.jpg", "images").path }
+  let(:caption) do
+    "The image shows a stylized speech bubble icon with a multicolored border on a black background."
+  end
+  let(:caption_with_attrs) do
+    "#{caption} (#{I18n.t("discourse_ai.ai_helper.image_caption.attribution")})"
+  end
+
+  before do
+    Group.find_by(id: Group::AUTO_GROUPS[:admins]).add(user)
+    SiteSetting.ai_helper_model = "fake:fake"
+    SiteSetting.ai_llava_endpoint = "https://example.com"
+    SiteSetting.ai_helper_enabled_features = "image_caption"
+    sign_in(user)
+
+    stub_request(:post, "https://example.com/predictions").to_return(
+      status: 200,
+      body: { output: caption.gsub(" ", " |").split("|") }.to_json,
+    )
+  end
+
+  context "when triggering caption with AI on desktop" do
+    it "should show an image caption in an input field" do
+      visit("/latest")
+      page.find("#create-topic").click
+      attach_file([file_path]) { composer.click_toolbar_button("upload") }
+      popup.click_generate_caption
+      expect(popup.has_caption_popup_value?(caption_with_attrs)).to eq(true)
+      popup.save_caption
+      wait_for { page.find(".image-wrapper img")["alt"] == caption_with_attrs }
+      expect(page.find(".image-wrapper img")["alt"]).to eq(caption_with_attrs)
+    end
+  end
+
+  context "when triggering caption with AI on mobile", mobile: true do
+    it "should show update the image alt text with the caption" do
+      visit("/latest")
+      page.find("#create-topic").click
+      attach_file([file_path]) { page.find(".mobile-file-upload").click }
+      page.find(".mobile-preview").click
+      popup.click_generate_caption
+      wait_for { page.find(".image-wrapper img")["alt"] == caption_with_attrs }
+      expect(page.find(".image-wrapper img")["alt"]).to eq(caption_with_attrs)
+    end
+  end
+end

--- a/spec/system/page_objects/components/ai_caption_popup.rb
+++ b/spec/system/page_objects/components/ai_caption_popup.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class AiCaptionPopup < PageObjects::Components::Base
+      GENERATE_CAPTION_SELECTOR = ".button-wrapper .generate-caption"
+      CAPTION_POPUP_SELECTOR = ".ai-caption-popup"
+      CAPTION_TEXTAREA_SELECTOR = "#{CAPTION_POPUP_SELECTOR} textarea"
+
+      def click_generate_caption
+        page.find(GENERATE_CAPTION_SELECTOR, visible: false).click
+      end
+
+      def has_caption_popup_value?(value)
+        page.find(CAPTION_TEXTAREA_SELECTOR).value == value
+      end
+
+      def save_caption
+        find("#{CAPTION_POPUP_SELECTOR} .btn-primary").click
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR revisits the recently added image caption feature (https://github.com/discourse/discourse-ai/pull/470) to add system specs.