### PR TITLE
FEATURE: AI helper support in non English languages

### DIFF
--- a/db/fixtures/ai_helper/603_completion_prompts.rb
+++ b/db/fixtures/ai_helper/603_completion_prompts.rb
@@ -9,19 +9,16 @@ CompletionPrompt.seed do |cp|
   cp.temperature = 0.2
   cp.messages = {
     insts: <<~TEXT,
-      I want you to act as an English translator, spelling corrector and improver. I will write to you
+      I want you to act as an %LANGUAGE% translator, spelling corrector and improver. I will write to you
       in any language and you will detect the language, translate it and answer in the corrected and
-      improved version of my text, in English. I want you to replace my simplified A0-level words and
+      improved version of my text, in %LANGUAGE%. I want you to replace my simplified A0-level words and
       sentences with more beautiful and elegant, upper level English words and sentences.
       Keep the meaning same, but make them more literary. I want you to only reply the correction,
       the improvements and nothing else, do not write explanations.
       You will find the text between <input></input> XML tags.
       Include your translation between <output></output> XML tags.
     TEXT
-    examples: [
-      ["<input>Hello world</input>", "<output>Hello world</output>"],
-      ["<input>Bonjour le monde</input>", "<output>Hello world</output>"],
-    ],
+    examples: [["<input>Hello</input>", "<output>...%LANGUAGE% translation...</output>"]],
   }
 end
 

--- a/db/fixtures/ai_helper/603_completion_prompts.rb
+++ b/db/fixtures/ai_helper/603_completion_prompts.rb
@@ -12,7 +12,7 @@ CompletionPrompt.seed do |cp|
       I want you to act as an %LANGUAGE% translator, spelling corrector and improver. I will write to you
       in any language and you will detect the language, translate it and answer in the corrected and
       improved version of my text, in %LANGUAGE%. I want you to replace my simplified A0-level words and
-      sentences with more beautiful and elegant, upper level English words and sentences.
+      sentences with more beautiful and elegant, upper level %LANGUAGE% words and sentences.
       Keep the meaning same, but make them more literary. I want you to only reply the correction,
       the improvements and nothing else, do not write explanations.
       You will find the text between <input></input> XML tags.

--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -144,7 +144,12 @@ module DiscourseAi
                 {
                   type: :user,
                   content: [
-                    { type: "text", text: "Describe this image in a single sentence" },
+                    {
+                      type: "text",
+                      text:
+                        "Describe this image in a single sentence" +
+                          custom_locale_instructions(user),
+                    },
                     { type: "image_url", image_url: image_url },
                   ],
                 },


### PR DESCRIPTION
This attempts some prompt engineering to coerce AI helper to answer
in the appropriate language.

Note mileage will vary, in testing GPT-4 produces the best results
GPT-3.5 can return OKish results.
