### PR TITLE
FIX: Composer service call breaking shared edits

### DIFF
--- a/assets/javascripts/initializers/ai-image-caption.js
+++ b/assets/javascripts/initializers/ai-image-caption.js
@@ -12,7 +12,6 @@ export default apiInitializer("1.25.0", (api) => {
   };
   const imageCaptionPopup = api.container.lookup("service:imageCaptionPopup");
   const settings = api.container.lookup("service:site-settings");
-  const composer = api.container.lookup("service:composer");
   const appEvents = api.container.lookup("service:app-events");
   const site = api.container.lookup("site:main");
 
@@ -56,6 +55,8 @@ export default apiInitializer("1.25.0", (api) => {
 
             if (site.mobileView) {
               // Auto-saves caption on mobile view
+              const composer = api.container.lookup("service:composer");
+
               const matchingPlaceholder =
                 composer.model.reply.match(IMAGE_MARKDOWN_REGEX);
               const match = matchingPlaceholder[imageIndex];


### PR DESCRIPTION
This PR fixes an issue where the call to the composer service for image captions was breaking `discourse-shared-edits`.

This PR moves the service call just before its used on `mobileView` (mobile shared edits is still functional)

**This should provide an immediate fix, however, I will continue to dig into why this was happening and can have a follow up PR with any additional fixes necessary.**