### PR TITLE
FIX: support spaces within arguments for Open AI

### DIFF
--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -174,7 +174,7 @@ module DiscourseAi
 
           # allow for SPACE within arguments
           if args && args != ""
-            @args_buffer << partial.dig(:function, :arguments)
+            @args_buffer << args
 
             begin
               json_args = JSON.parse(@args_buffer, symbolize_names: true)

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -136,14 +136,12 @@ module DiscourseAi
 
         def extract_completion_from(response_raw)
           parsed = JSON.parse(response_raw, symbolize_names: true).dig(:choices, 0)
-
           # half a line sent here
           return if !parsed
 
           response_h = @streaming_mode ? parsed.dig(:delta) : parsed.dig(:message)
 
           @has_function_call ||= response_h.dig(:tool_calls).present?
-
           @has_function_call ? response_h.dig(:tool_calls, 0) : response_h.dig(:content)
         end
 
@@ -172,7 +170,10 @@ module DiscourseAi
           function_buffer.at("tool_name").content = f_name if f_name
           function_buffer.at("tool_id").content = partial[:id] if partial[:id]
 
-          if partial.dig(:function, :arguments).present?
+          args = partial.dig(:function, :arguments)
+
+          # allow for SPACE within arguments
+          if args && args != ""
             @args_buffer << partial.dig(:function, :arguments)
 
             begin


### PR DESCRIPTION
Previous to this fix if a tool call ever streamed a SPACE alone,
we would eat it and ignore it, breaking params

Also fixes some tests to ensure they are actually called :)
