### PR TITLE
FIX: Backspace in composer custom prompt closes menu

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -154,8 +154,11 @@ export default class AiHelperContextMenu extends Component {
     if (event.key === "Escape") {
       return this.closeContextMenu();
     }
-
-    if (event.key === "Backspace" && this.selectedText) {
+    if (
+      event.key === "Backspace" &&
+      this.selectedText &&
+      this.menuState === this.CONTEXT_MENU_STATES.triggers
+    ) {
       return this.closeContextMenu();
     }
   }

--- a/spec/system/ai_helper/ai_composer_helper_spec.rb
+++ b/spec/system/ai_helper/ai_composer_helper_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
       expect(ai_helper_context_menu).to have_no_context_menu
     end
 
+    it "closes the context menu when selected text is deleted" do
+      trigger_context_menu(input)
+      expect(ai_helper_context_menu).to have_context_menu
+      page.send_keys(:backspace)
+      expect(ai_helper_context_menu).to have_no_context_menu
+    end
+
     context "when using custom prompt" do
       let(:mode) { CompletionPrompt::CUSTOM_PROMPT }
 
@@ -97,6 +104,15 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
 
           expect(composer.composer_input.value).to eq(custom_prompt_response)
         end
+      end
+
+      it "should not close the context menu if backspace is pressed" do
+        trigger_context_menu(input)
+        ai_helper_context_menu.click_ai_button
+        expect(ai_helper_context_menu).to have_context_menu
+        ai_helper_context_menu.fill_custom_prompt(custom_prompt_input)
+        page.find(".ai-custom-prompt__input").send_keys(:backspace)
+        expect(ai_helper_context_menu).to have_context_menu
       end
     end
 


### PR DESCRIPTION
This PR fixes a bug that was introduced in https://github.com/discourse/discourse-ai/pull/374 because it was not checking if the menu state was in trigger mode.