### PR TITLE
UX: Improve Post AI Helper positioning

### DIFF
--- a/assets/javascripts/discourse/connectors/post-text-buttons/ai-helper-options-menu.gjs
+++ b/assets/javascripts/discourse/connectors/post-text-buttons/ai-helper-options-menu.gjs
@@ -54,7 +54,6 @@ export default class AIHelperOptionsMenu extends Component {
   async showAIHelperOptions() {
     this.showMainButtons = false;
     this.menuState = this.MENU_STATES.options;
-    this.menu.activeMenu.options.placement = "bottom";
   }
 
   @bind
@@ -82,6 +81,7 @@ export default class AIHelperOptionsMenu extends Component {
 
     if (option.name === "explain") {
       this.menuState = this.MENU_STATES.result;
+      this.menu.activeMenu.options.placement = "bottom";
 
       const fetchUrl = `/discourse-ai/ai-helper/explain`;
       this._activeAIRequest = ajax(fetchUrl, {


### PR DESCRIPTION
This PR improves the post AI helper's positioning. Previously, we updated the positioning to be a `"bottom"` placement for the menu so that it improves the way the streaming menu grows (https://github.com/discourse/discourse-ai/pull/378). However, that made it applied for the entire menu, so when you select a large passage of text, the menu is moved to the bottom and isn't intuitive. The PR updates the logic so the bottom placement is only added after the Explain feature is triggered.