### PR TITLE
FIX: avoid all bot feedback loops

### DIFF
--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -12,12 +12,10 @@ module DiscourseAi
       REQUIRE_TITLE_UPDATE = "discourse-ai-title-update"
 
       def self.is_bot_user_id?(user_id)
-        bot_ids = DiscourseAi::AiBot::EntryPoint::BOT_USER_IDS
-        bot_ids.include?(user_id) ||
-          begin
-            mentionable_ids = AiPersona.mentionables.map { |mentionable| mentionable[:user_id] }
-            mentionable_ids.include?(user_id)
-          end
+        # this will catch everything and avoid any feedback loops
+        # we could get feedback loops between say discobot and ai-bot or third party plugins
+        # and bots
+        user_id.to_i <= 0
       end
 
       def self.schedule_reply(post)

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe DiscourseAi::AiBot::Playground do
     )
   end
 
+  describe "is_bot_user_id?" do
+    it "properly detects ALL bots as bot users" do
+      persona = Fabricate(:ai_persona, enabled: false)
+      persona.create_user!
+
+      expect(DiscourseAi::AiBot::Playground.is_bot_user_id?(persona.user_id)).to eq(true)
+    end
+  end
+
   describe "persona with user support" do
     before do
       Jobs.run_immediately!


### PR DESCRIPTION
We need to ensure that under no circumstances feedback loops between
bots will emerge cause this can eat up a lot of tokens