### PR TITLE
FIX: Correct max_length calculation to prevent potential token overfl…

### DIFF
--- a/lib/tokenizer/basic_tokenizer.rb
+++ b/lib/tokenizer/basic_tokenizer.rb
@@ -17,15 +17,10 @@ module DiscourseAi
         end
 
         def truncate(text, max_length)
-          # Fast track the common case where the text is already short enough.
-          # return text if text.size < max_length
-
           tokenizer.decode(tokenizer.encode(text).ids.take(max_length))
         end
 
         def can_expand_tokens?(text, addition, max_length)
-          # return true if text.size + addition.size < max_length
-
           tokenizer.encode(text).ids.length + tokenizer.encode(addition).ids.length < max_length
         end
       end

--- a/lib/tokenizer/open_ai_tokenizer.rb
+++ b/lib/tokenizer/open_ai_tokenizer.rb
@@ -13,9 +13,6 @@ module DiscourseAi
         end
 
         def truncate(text, max_length)
-          # Fast track the common case where the text is already short enough.
-          # return text if text.size < max_length
-
           tokenizer.decode(tokenize(text).take(max_length))
         rescue Tiktoken::UnicodeError
           max_length = max_length - 1
@@ -23,8 +20,6 @@ module DiscourseAi
         end
 
         def can_expand_tokens?(text, addition, max_length)
-          # return true if text.size + addition.size < max_length
-
           tokenizer.encode(text).length + tokenizer.encode(addition).length < max_length
         end
       end


### PR DESCRIPTION
FIX: Correct max_length calculation to prevent potential token overflow in embeddings model.

The current max_length calculation was too simplistic, potentially causing the actual token count to surpass the embeddings model's maximum limit. This was particularly noticeable in complex Unicode content. The fix addresses this issue by accurately determining the token count, ensuring compatibility with a wide range of text inputs.