### PR TITLE
FEATURE: Add GitHub Helper AI Bot persona and tools

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -96,6 +96,7 @@ en:
     ai_bot_allowed_groups: "When the GPT Bot has access to the PM, it will reply to members of these groups."
     ai_bot_enabled_chat_bots: "Available models to act as an AI Bot"
     ai_bot_add_to_header: "Display a button in the header to start a PM with a AI Bot"
+    ai_bot_github_access_token: "GitHub access token for use with GitHub AI tools (required for search support)"
 
     ai_stability_api_key: "API key for the stability.ai API"
     ai_stability_engine: "Image generation engine to use for the stability.ai API"
@@ -193,6 +194,7 @@ en:
             name: "Base Search Query"
             description: "Base query to use when searching. Example: '#urgent' will prepend '#urgent' to the search query and only include topics with the urgent category or tag."
       command_summary:
+        github_search_code: "GitHub code search"
         github_file_content: "GitHub file content"
         github_pull_request_diff: "GitHub pull request diff"
         random_picker: "Random Picker"
@@ -210,6 +212,7 @@ en:
         dall_e: "Generate image"
         search_meta_discourse: "Search Meta Discourse"
       command_help:
+        github_search_code: "Search for code in a GitHub repository"
         github_file_content: "Retrieve content of files from a GitHub repository"
         github_pull_request_diff: "Retrieve a GitHub pull request diff"
         random_picker: "Pick a random number or a random element of a list"
@@ -227,6 +230,7 @@ en:
         dall_e: "Generate image using DALL-E 3"
         search_meta_discourse: "Search Meta Discourse"
       command_description:
+        github_search_code: "Searched for '%{query}' in %{repo}"
         github_pull_request_diff: "<a href='%{url}'>%{repo} %{pull_id}</a>"
         github_file_content: "Retrieved content of %{file_paths} from %{repo_name}@%{branch}"
         random_picker: "Picking from %{options}, picked: %{result}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -154,6 +154,9 @@ en:
       personas:
         cannot_delete_system_persona: "System personas cannot be deleted, please disable it instead"
         cannot_edit_system_persona: "System personas can only be renamed, you may not edit commands or system prompt, instead disable and make a copy"
+        github_helper:
+          name: "GitHub Helper"
+          description: "AI Bot specialized in assisting with GitHub-related tasks and questions"
         general:
           name: Forum Helper
           description: "General purpose AI Bot capable of performing various tasks"
@@ -190,6 +193,7 @@ en:
             name: "Base Search Query"
             description: "Base query to use when searching. Example: '#urgent' will prepend '#urgent' to the search query and only include topics with the urgent category or tag."
       command_summary:
+        github_file_content: "GitHub file content"
         github_pull_request_diff: "GitHub pull request diff"
         random_picker: "Random Picker"
         categories: "List categories"
@@ -206,6 +210,7 @@ en:
         dall_e: "Generate image"
         search_meta_discourse: "Search Meta Discourse"
       command_help:
+        github_file_content: "Retrieve content of files from a GitHub repository"
         github_pull_request_diff: "Retrieve a GitHub pull request diff"
         random_picker: "Pick a random number or a random element of a list"
         categories: "List all publicly visible categories on the forum"
@@ -223,6 +228,7 @@ en:
         search_meta_discourse: "Search Meta Discourse"
       command_description:
         github_pull_request_diff: "<a href='%{url}'>%{repo} %{pull_id}</a>"
+        github_file_content: "Retrieved content of %{file_paths} from %{repo_name}@%{branch}"
         random_picker: "Picking from %{options}, picked: %{result}"
         read: "Reading: <a href='%{url}'>%{title}</a>"
         time: "Time in %{timezone} is %{time}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -190,6 +190,7 @@ en:
             name: "Base Search Query"
             description: "Base query to use when searching. Example: '#urgent' will prepend '#urgent' to the search query and only include topics with the urgent category or tag."
       command_summary:
+        github_pull_request_diff: "GitHub pull request diff"
         random_picker: "Random Picker"
         categories: "List categories"
         search: "Search"
@@ -205,6 +206,7 @@ en:
         dall_e: "Generate image"
         search_meta_discourse: "Search Meta Discourse"
       command_help:
+        github_pull_request_diff: "Retrieve a GitHub pull request diff"
         random_picker: "Pick a random number or a random element of a list"
         categories: "List all publicly visible categories on the forum"
         search: "Search all public topics on the forum"
@@ -220,6 +222,7 @@ en:
         dall_e: "Generate image using DALL-E 3"
         search_meta_discourse: "Search Meta Discourse"
       command_description:
+        github_pull_request_diff: "<a href='%{url}'>%{repo} %{pull_id}</a>"
         random_picker: "Picking from %{options}, picked: %{result}"
         read: "Reading: <a href='%{url}'>%{title}</a>"
         time: "Time in %{timezone} is %{time}"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -318,3 +318,6 @@ discourse_ai:
   ai_bot_add_to_header:
     default: true
     client: true
+  ai_bot_github_access_token:
+    default: ""
+    secret: true

--- a/lib/ai_bot/entry_point.rb
+++ b/lib/ai_bot/entry_point.rb
@@ -2,6 +2,8 @@
 
 module DiscourseAi
   module AiBot
+    USER_AGENT = "Discourse AI Bot 1.0 (https://www.discourse.org)"
+
     class EntryPoint
       REQUIRE_TITLE_UPDATE = "discourse-ai-title-update"
 

--- a/lib/ai_bot/personas/github_helper.rb
+++ b/lib/ai_bot/personas/github_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module AiBot
+    module Personas
+      class GithubHelper < Persona
+        def tools
+          [Tools::GithubFileContent, Tools::GithubPullRequestDiff]
+        end
+
+        def system_prompt
+          <<~PROMPT
+            You are a helpful GitHub assistant.
+            You _understand_ and **generate** Discourse Flavored Markdown.
+            You live in a Discourse Forum Message.
+
+            Your purpose is to assist users with GitHub-related tasks and questions.
+            When asked about a specific repository, pull request, or file, try to use the available tools to provide accurate and helpful information.
+            If you don't have enough context to answer a question, ask for clarification or additional details.
+          PROMPT
+        end
+      end
+    end
+  end
+end

--- a/lib/ai_bot/personas/github_helper.rb
+++ b/lib/ai_bot/personas/github_helper.rb
@@ -5,7 +5,7 @@ module DiscourseAi
     module Personas
       class GithubHelper < Persona
         def tools
-          [Tools::GithubFileContent, Tools::GithubPullRequestDiff]
+          [Tools::GithubFileContent, Tools::GithubPullRequestDiff, Tools::GithubSearchCode]
         end
 
         def system_prompt
@@ -16,7 +16,6 @@ module DiscourseAi
 
             Your purpose is to assist users with GitHub-related tasks and questions.
             When asked about a specific repository, pull request, or file, try to use the available tools to provide accurate and helpful information.
-            If you don't have enough context to answer a question, ask for clarification or additional details.
           PROMPT
         end
       end

--- a/lib/ai_bot/personas/persona.rb
+++ b/lib/ai_bot/personas/persona.rb
@@ -69,6 +69,8 @@ module DiscourseAi
               Tools::GithubPullRequestDiff,
             ]
 
+            tools << Tools::GithubSearchCode if SiteSetting.ai_bot_github_access_token.present?
+
             tools << Tools::ListTags if SiteSetting.tagging_enabled
             tools << Tools::Image if SiteSetting.ai_stability_api_key.present?
 

--- a/lib/ai_bot/personas/persona.rb
+++ b/lib/ai_bot/personas/persona.rb
@@ -15,6 +15,7 @@ module DiscourseAi
               Personas::Creative => -6,
               Personas::DallE3 => -7,
               Personas::DiscourseHelper => -8,
+              Personas::GithubHelper => -9,
             }
           end
 

--- a/lib/ai_bot/personas/persona.rb
+++ b/lib/ai_bot/personas/persona.rb
@@ -64,6 +64,8 @@ module DiscourseAi
               Tools::SettingContext,
               Tools::RandomPicker,
               Tools::DiscourseMetaSearch,
+              Tools::GithubFileContent,
+              Tools::GithubPullRequestDiff,
             ]
 
             tools << Tools::ListTags if SiteSetting.tagging_enabled

--- a/lib/ai_bot/personas/persona.rb
+++ b/lib/ai_bot/personas/persona.rb
@@ -167,7 +167,7 @@ module DiscourseAi
 
           tool_klass.new(
             arguments,
-            tool_call_id: function_id,
+            tool_call_id: function_id || function_name,
             persona_options: options[tool_klass].to_h,
           )
         end

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -276,6 +276,14 @@ module DiscourseAi
         publish_final_update(reply_post) if stream_reply
       end
 
+      def available_bot_usernames
+        @bot_usernames ||=
+          AiPersona
+            .joins(:user)
+            .pluck(:username)
+            .concat(DiscourseAi::AiBot::EntryPoint::BOTS.map(&:second))
+      end
+
       private
 
       def publish_final_update(reply_post)
@@ -347,10 +355,6 @@ module DiscourseAi
           max_backlog_size: 2,
           max_backlog_age: 60,
         )
-      end
-
-      def available_bot_usernames
-        @bot_usernames ||= DiscourseAi::AiBot::EntryPoint::BOTS.map(&:second)
       end
     end
   end

--- a/lib/ai_bot/tools/github_file_content.rb
+++ b/lib/ai_bot/tools/github_file_content.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+module DiscourseAi
+  module AiBot
+    module Tools
+      class GithubFileContent < Tool
+        def self.signature
+          {
+            name: name,
+            description: "Retrieves the content of specified GitHub files",
+            parameters: [
+              {
+                name: "repo_name",
+                description: "The name of the GitHub repository (e.g., 'discourse/discourse')",
+                type: "string",
+                required: true,
+              },
+              {
+                name: "file_paths",
+                description: "The paths of the files to retrieve within the repository",
+                type: "array",
+                item_type: "string",
+                required: true,
+              },
+              {
+                name: "branch",
+                description:
+                  "The branch or commit SHA to retrieve the files from (default: 'main')",
+                type: "string",
+                required: false,
+              },
+            ],
+          }
+        end
+
+        def self.name
+          "github_file_content"
+        end
+
+        def repo_name
+          parameters[:repo_name]
+        end
+
+        def file_paths
+          parameters[:file_paths]
+        end
+
+        def branch
+          parameters[:branch] || "main"
+        end
+
+        def invoke(_bot_user, llm)
+          owner, repo = repo_name.split("/")
+          file_contents = {}
+
+          file_paths.each do |file_path|
+            api_url =
+              "https://api.github.com/repos/#{owner}/#{repo}/contents/#{file_path}?ref=#{branch}"
+
+            uri = URI(api_url)
+            response = Net::HTTP.get_response(uri)
+            file_data = JSON.parse(response.body)
+
+            content = Base64.decode64(file_data["content"])
+            file_contents[file_path] = content
+          end
+
+          blob = file_contents.map { |path, content| "File Path: #{path}:\n#{content}" }.join("\n")
+          blob = truncate(blob, max_length: 20_000, percent_length: 0.3, llm: llm)
+
+          { file_contents: blob }
+        end
+      end
+    end
+  end
+end

--- a/lib/ai_bot/tools/github_file_content.rb
+++ b/lib/ai_bot/tools/github_file_content.rb
@@ -61,7 +61,13 @@ module DiscourseAi
               "https://api.github.com/repos/#{owner}/#{repo}/contents/#{file_path}?ref=#{branch}"
 
             response =
-              send_http_request(api_url, headers: { "Accept" => "application/vnd.github.v3+json" })
+              send_http_request(
+                api_url,
+                headers: {
+                  "Accept" => "application/vnd.github.v3+json",
+                },
+                authenticate_github: true,
+              )
 
             if response.code == "200"
               file_data = JSON.parse(response.body)

--- a/lib/ai_bot/tools/github_pull_request_diff.rb
+++ b/lib/ai_bot/tools/github_pull_request_diff.rb
@@ -43,7 +43,7 @@ module DiscourseAi
 
         def invoke(_bot_user, llm)
           api_url = "https://api.github.com/repos/#{repo}/pulls/#{pull_id}"
-          @url = "https://github.com/repos/#{repo}/pulls/#{pull_id}"
+          @url = "https://github.com/#{repo}/pull/#{pull_id}"
 
           response = send_request(api_url)
 

--- a/lib/ai_bot/tools/github_pull_request_diff.rb
+++ b/lib/ai_bot/tools/github_pull_request_diff.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module AiBot
+    module Tools
+      class GithubPullRequestDiff < Tool
+        def self.signature
+          {
+            name: name,
+            description: "Retrieves the diff for a GitHub pull request",
+            parameters: [
+              {
+                name: "repo",
+                description: "The repository name in the format 'owner/repo'",
+                type: "string",
+                required: true,
+              },
+              {
+                name: "pull_id",
+                description: "The ID of the pull request",
+                type: "integer",
+                required: true,
+              },
+            ],
+          }
+        end
+
+        def self.name
+          "github_pull_request_diff"
+        end
+
+        def repo
+          parameters[:repo]
+        end
+
+        def pull_id
+          parameters[:pull_id]
+        end
+
+        def chain_next_response?
+          false
+        end
+
+        def invoke(_bot_user, llm)
+          api_url = "https://api.github.com/repos/#{repo}/pulls/#{pull_id}"
+
+          response = send_request(api_url)
+
+          if response.code == "200"
+            diff = response.body
+            diff = truncate(diff, max_length: 20_000, percent_length: 0.3, llm: llm)
+            { diff: diff }
+          else
+            { error: "Failed to retrieve the diff. Status code: #{response.code}" }
+          end
+        end
+
+        private
+
+        def send_request(api_url)
+          uri = URI(api_url)
+          request = Net::HTTP::Get.new(uri)
+          request["Accept"] = "application/vnd.github.v3.diff"
+          request["User-Agent"] = "Ruby"
+
+          Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+        end
+
+        def description_args
+          { repo: repo, pull_id: pull_id }
+        end
+      end
+    end
+  end
+end

--- a/lib/ai_bot/tools/github_pull_request_diff.rb
+++ b/lib/ai_bot/tools/github_pull_request_diff.rb
@@ -37,12 +37,13 @@ module DiscourseAi
           parameters[:pull_id]
         end
 
-        def chain_next_response?
-          false
+        def url
+          @url
         end
 
         def invoke(_bot_user, llm)
           api_url = "https://api.github.com/repos/#{repo}/pulls/#{pull_id}"
+          @url = "https://github.com/repos/#{repo}/pulls/#{pull_id}"
 
           response = send_request(api_url)
 
@@ -67,7 +68,7 @@ module DiscourseAi
         end
 
         def description_args
-          { repo: repo, pull_id: pull_id }
+          { repo: repo, pull_id: pull_id, url: url }
         end
       end
     end

--- a/lib/ai_bot/tools/github_pull_request_diff.rb
+++ b/lib/ai_bot/tools/github_pull_request_diff.rb
@@ -45,7 +45,8 @@ module DiscourseAi
           api_url = "https://api.github.com/repos/#{repo}/pulls/#{pull_id}"
           @url = "https://github.com/#{repo}/pull/#{pull_id}"
 
-          response = send_request(api_url)
+          response =
+            send_http_request(api_url, headers: { "Accept" => "application/vnd.github.v3.diff" })
 
           if response.code == "200"
             diff = response.body
@@ -54,17 +55,6 @@ module DiscourseAi
           else
             { error: "Failed to retrieve the diff. Status code: #{response.code}" }
           end
-        end
-
-        private
-
-        def send_request(api_url)
-          uri = URI(api_url)
-          request = Net::HTTP::Get.new(uri)
-          request["Accept"] = "application/vnd.github.v3.diff"
-          request["User-Agent"] = "Ruby"
-
-          Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
         end
 
         def description_args

--- a/lib/ai_bot/tools/github_pull_request_diff.rb
+++ b/lib/ai_bot/tools/github_pull_request_diff.rb
@@ -46,7 +46,13 @@ module DiscourseAi
           @url = "https://github.com/#{repo}/pull/#{pull_id}"
 
           response =
-            send_http_request(api_url, headers: { "Accept" => "application/vnd.github.v3.diff" })
+            send_http_request(
+              api_url,
+              headers: {
+                "Accept" => "application/vnd.github.v3.diff",
+              },
+              authenticate_github: true,
+            )
 
           if response.code == "200"
             diff = response.body

--- a/lib/ai_bot/tools/github_search_code.rb
+++ b/lib/ai_bot/tools/github_search_code.rb
@@ -57,7 +57,7 @@ module DiscourseAi
             search_data = JSON.parse(response.body)
             results =
               search_data["items"]
-                .map { |item| "#{item["name"]}:\n#{item["text_matches"][0]["fragment"]}" }
+                .map { |item| "#{item["path"]}:\n#{item["text_matches"][0]["fragment"]}" }
                 .join("\n---\n")
 
             results = truncate(results, max_length: 20_000, percent_length: 0.3, llm: llm)

--- a/lib/ai_bot/tools/github_search_code.rb
+++ b/lib/ai_bot/tools/github_search_code.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module AiBot
+    module Tools
+      class GithubSearchCode < Tool
+        def self.signature
+          {
+            name: name,
+            description: "Searches for code in a GitHub repository",
+            parameters: [
+              {
+                name: "repo",
+                description: "The repository name in the format 'owner/repo'",
+                type: "string",
+                required: true,
+              },
+              {
+                name: "query",
+                description: "The search query (e.g., a function name, variable, or code snippet)",
+                type: "string",
+                required: true,
+              },
+            ],
+          }
+        end
+
+        def self.name
+          "github_search_code"
+        end
+
+        def repo
+          parameters[:repo]
+        end
+
+        def query
+          parameters[:query]
+        end
+
+        def description_args
+          { repo: repo, query: query }
+        end
+
+        def invoke(_bot_user, llm)
+          api_url = "https://api.github.com/search/code?q=#{query}+repo:#{repo}"
+
+          response =
+            send_http_request(
+              api_url,
+              headers: {
+                "Accept" => "application/vnd.github.v3.text-match+json",
+              },
+              authenticate_github: true,
+            )
+
+          if response.code == "200"
+            search_data = JSON.parse(response.body)
+            results =
+              search_data["items"]
+                .map { |item| "#{item["name"]}:\n#{item["text_matches"][0]["fragment"]}" }
+                .join("\n---\n")
+
+            results = truncate(results, max_length: 20_000, percent_length: 0.3, llm: llm)
+            { search_results: results }
+          else
+            { error: "Failed to perform code search. Status code: #{response.code}" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ai_bot/tools/tool.rb
+++ b/lib/ai_bot/tools/tool.rb
@@ -77,6 +77,21 @@ module DiscourseAi
 
         protected
 
+        def truncate(text, llm:, percent_length: nil, max_length: nil)
+          if !percent_length && !max_length
+            raise ArgumentError, "You must provide either percent_length or max_length"
+          end
+
+          target = llm.max_prompt_tokens
+          target = (target * percent_length).to_i if percent_length
+
+          if max_length
+            target = max_length if target > max_length
+          end
+
+          llm.tokenizer.truncate(text, target)
+        end
+
         def accepted_options
           []
         end

--- a/lib/ai_bot/tools/tool.rb
+++ b/lib/ai_bot/tools/tool.rb
@@ -77,6 +77,17 @@ module DiscourseAi
 
         protected
 
+        def send_http_request(url, headers: {})
+          uri = URI(url)
+          request = Net::HTTP::Get.new(uri)
+          request["User-Agent"] = DiscourseAi::AiBot::USER_AGENT
+          headers.each { |k, v| request[k] = v }
+
+          FinalDestination::HTTP.start(uri.hostname, uri.port, use_ssl: uri.port != 80) do |http|
+            http.request(request)
+          end
+        end
+
         def truncate(text, llm:, percent_length: nil, max_length: nil)
           if !percent_length && !max_length
             raise ArgumentError, "You must provide either percent_length or max_length"

--- a/lib/ai_bot/tools/tool.rb
+++ b/lib/ai_bot/tools/tool.rb
@@ -79,7 +79,7 @@ module DiscourseAi
 
         def send_http_request(url, headers: {}, authenticate_github: false)
           uri = URI(url)
-          request = Net::HTTP::Get.new(uri)
+          request = FinalDestination::HTTP::Get.new(uri)
           request["User-Agent"] = DiscourseAi::AiBot::USER_AGENT
           headers.each { |k, v| request[k] = v }
           if authenticate_github

--- a/lib/ai_bot/tools/tool.rb
+++ b/lib/ai_bot/tools/tool.rb
@@ -77,11 +77,14 @@ module DiscourseAi
 
         protected
 
-        def send_http_request(url, headers: {})
+        def send_http_request(url, headers: {}, authenticate_github: false)
           uri = URI(url)
           request = Net::HTTP::Get.new(uri)
           request["User-Agent"] = DiscourseAi::AiBot::USER_AGENT
           headers.each { |k, v| request[k] = v }
+          if authenticate_github
+            request["Authorization"] = "Bearer #{SiteSetting.ai_bot_github_access_token}"
+          end
 
           FinalDestination::HTTP.start(uri.hostname, uri.port, use_ssl: uri.port != 80) do |http|
             http.request(request)

--- a/lib/completions/dialects/dialect.rb
+++ b/lib/completions/dialects/dialect.rb
@@ -36,7 +36,8 @@ module DiscourseAi
           def tool_preamble
             <<~TEXT
               In this environment you have access to a set of tools you can use to answer the user's question.
-              You may call them like this. Only invoke one function at a time and wait for the results before invoking another function:
+              You may call them like this.
+
               <function_calls>
               <invoke>
               <tool_name>$TOOL_NAME</tool_name>
@@ -51,6 +52,7 @@ module DiscourseAi
               [1,"two",3.0]
 
               Always wrap <invoke> calls in <function_calls> tags.
+              You may call multiple function via <invoke> in a single <function_calls> block.
 
               Here are the tools available:
             TEXT

--- a/lib/completions/dialects/dialect.rb
+++ b/lib/completions/dialects/dialect.rb
@@ -47,8 +47,10 @@ module DiscourseAi
               </invoke>
               </function_calls>
 
-              if a parameter type is an array, return a JSON array of values. For example:
+              If a parameter type is an array, return a JSON array of values. For example:
               [1,"two",3.0]
+
+              Always wrap <invoke> calls in <function_calls> tags.
 
               Here are the tools available:
             TEXT

--- a/lib/completions/endpoints/anthropic_messages.rb
+++ b/lib/completions/endpoints/anthropic_messages.rb
@@ -27,8 +27,11 @@ module DiscourseAi
           model_params
         end
 
-        def default_options
-          { model: model + "-20240229", max_tokens: 3_000, stop_sequences: ["</function_calls>"] }
+        def default_options(dialect)
+          options = { model: model + "-20240229", max_tokens: 3_000 }
+
+          options[:stop_sequences] = ["</function_calls>"] if dialect.prompt.has_tools?
+          options
         end
 
         def provider_id
@@ -46,8 +49,8 @@ module DiscourseAi
           @uri ||= URI("https://api.anthropic.com/v1/messages")
         end
 
-        def prepare_payload(prompt, model_params, _dialect)
-          payload = default_options.merge(model_params).merge(messages: prompt.messages)
+        def prepare_payload(prompt, model_params, dialect)
+          payload = default_options(dialect).merge(model_params).merge(messages: prompt.messages)
 
           payload[:system] = prompt.system_prompt if prompt.system_prompt.present?
           payload[:stream] = true if @streaming_mode

--- a/lib/completions/endpoints/gemini.rb
+++ b/lib/completions/endpoints/gemini.rb
@@ -104,11 +104,19 @@ module DiscourseAi
           @has_function_call
         end
 
-        def add_to_buffer(function_buffer, _response_data, partial)
-          if partial[:name].present?
-            function_buffer.at("tool_name").content = partial[:name]
-            function_buffer.at("tool_id").content = partial[:name]
+        def maybe_has_tool?(_partial_raw)
+          # we always get a full partial
+          false
+        end
+
+        def add_to_function_buffer(function_buffer, payload: nil, partial: nil)
+          if @streaming_mode
+            return function_buffer if !partial
+          else
+            partial = payload
           end
+
+          function_buffer.at("tool_name").content = partial[:name] if partial[:name].present?
 
           if partial[:args]
             argument_fragments =

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -163,7 +163,18 @@ module DiscourseAi
           @has_function_call
         end
 
-        def add_to_buffer(function_buffer, _response_data, partial)
+        def maybe_has_tool?(_partial_raw)
+          # we always get a full partial
+          false
+        end
+
+        def add_to_function_buffer(function_buffer, partial: nil, payload: nil)
+          if @streaming_mode
+            return function_buffer if !partial
+          else
+            partial = payload
+          end
+
           @args_buffer ||= +""
 
           f_name = partial.dig(:function, :name)

--- a/lib/completions/prompt.rb
+++ b/lib/completions/prompt.rb
@@ -49,6 +49,10 @@ module DiscourseAi
         messages << new_message
       end
 
+      def has_tools?
+        tools.present?
+      end
+
       private
 
       def validate_message(message)

--- a/spec/lib/completions/endpoints/endpoint_compliance.rb
+++ b/spec/lib/completions/endpoints/endpoint_compliance.rb
@@ -66,11 +66,11 @@ class EndpointMock
       <function_calls>
       <invoke>
       <tool_name>get_weather</tool_name>
-      <tool_id>#{tool_id}</tool_id>
       <parameters>
       <location>Sydney</location>
       <unit>c</unit>
       </parameters>
+      <tool_id>tool_0</tool_id>
       </invoke>
       </function_calls>
     TEXT

--- a/spec/lib/completions/endpoints/gemini_spec.rb
+++ b/spec/lib/completions/endpoints/gemini_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Gemini do
 
   fab!(:user)
 
-  let(:bedrock_mock) { GeminiMock.new(endpoint) }
+  let(:gemini_mock) { GeminiMock.new(endpoint) }
 
   let(:compliance) do
     EndpointsCompliance.new(self, endpoint, DiscourseAi::Completions::Dialects::Gemini, user)
@@ -142,13 +142,13 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Gemini do
     context "when using regular mode" do
       context "with simple prompts" do
         it "completes a trivial prompt and logs the response" do
-          compliance.regular_mode_simple_prompt(bedrock_mock)
+          compliance.regular_mode_simple_prompt(gemini_mock)
         end
       end
 
       context "with tools" do
         it "returns a function invocation" do
-          compliance.regular_mode_tools(bedrock_mock)
+          compliance.regular_mode_tools(gemini_mock)
         end
       end
     end
@@ -156,13 +156,13 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Gemini do
     describe "when using streaming mode" do
       context "with simple prompts" do
         it "completes a trivial prompt and logs the response" do
-          compliance.streaming_mode_simple_prompt(bedrock_mock)
+          compliance.streaming_mode_simple_prompt(gemini_mock)
         end
       end
 
       context "with tools" do
         it "returns a function invocation" do
-          compliance.streaming_mode_tools(bedrock_mock)
+          compliance.streaming_mode_tools(gemini_mock)
         end
       end
     end

--- a/spec/lib/modules/ai_bot/personas/persona_spec.rb
+++ b/spec/lib/modules/ai_bot/personas/persona_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe DiscourseAi::AiBot::Personas::Persona do
           DiscourseAi::AiBot::Personas::Artist,
           DiscourseAi::AiBot::Personas::Creative,
           DiscourseAi::AiBot::Personas::DiscourseHelper,
+          DiscourseAi::AiBot::Personas::GithubHelper,
           DiscourseAi::AiBot::Personas::Researcher,
           DiscourseAi::AiBot::Personas::SettingsExplorer,
           DiscourseAi::AiBot::Personas::SqlHelper,
@@ -169,6 +170,7 @@ RSpec.describe DiscourseAi::AiBot::Personas::Persona do
         DiscourseAi::AiBot::Personas::SettingsExplorer,
         DiscourseAi::AiBot::Personas::Creative,
         DiscourseAi::AiBot::Personas::DiscourseHelper,
+        DiscourseAi::AiBot::Personas::GithubHelper,
       )
 
       AiPersona.find(
@@ -182,6 +184,7 @@ RSpec.describe DiscourseAi::AiBot::Personas::Persona do
         DiscourseAi::AiBot::Personas::SettingsExplorer,
         DiscourseAi::AiBot::Personas::Creative,
         DiscourseAi::AiBot::Personas::DiscourseHelper,
+        DiscourseAi::AiBot::Personas::GithubHelper,
       )
     end
   end

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -337,6 +337,15 @@ RSpec.describe DiscourseAi::AiBot::Playground do
     end
   end
 
+  describe "#available_bot_usernames" do
+    it "includes persona users" do
+      persona = Fabricate(:ai_persona)
+      persona.create_user!
+
+      expect(playground.available_bot_usernames).to include(persona.user.username)
+    end
+  end
+
   describe "#conversation_context" do
     context "with limited context" do
       before do

--- a/spec/lib/modules/ai_bot/tools/github_file_content_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/github_file_content_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DiscourseAi::AiBot::Tools::GithubFileContent do
+  let(:tool) do
+    described_class.new(
+      {
+        repo_name: "discourse/discourse-ai",
+        file_paths: %w[lib/database/connection.rb lib/ai_bot/tools/github_pull_request_diff.rb],
+        branch: "8b382d6098fde879d28bbee68d3cbe0a193e4ffc",
+      },
+    )
+  end
+
+  let(:llm) { DiscourseAi::Completions::Llm.proxy("open_ai:gpt-4") }
+
+  describe "#invoke" do
+    before do
+      stub_request(
+        :get,
+        "https://api.github.com/repos/discourse/discourse-ai/contents/lib/database/connection.rb?ref=8b382d6098fde879d28bbee68d3cbe0a193e4ffc",
+      ).to_return(
+        status: 200,
+        body: { content: Base64.encode64("content of connection.rb") }.to_json,
+      )
+
+      stub_request(
+        :get,
+        "https://api.github.com/repos/discourse/discourse-ai/contents/lib/ai_bot/tools/github_pull_request_diff.rb?ref=8b382d6098fde879d28bbee68d3cbe0a193e4ffc",
+      ).to_return(
+        status: 200,
+        body: { content: Base64.encode64("content of github_pull_request_diff.rb") }.to_json,
+      )
+    end
+
+    it "retrieves the content of the specified GitHub files" do
+      result = tool.invoke(nil, llm)
+      expected = {
+        file_contents:
+          "File Path: lib/database/connection.rb:\ncontent of connection.rb\nFile Path: lib/ai_bot/tools/github_pull_request_diff.rb:\ncontent of github_pull_request_diff.rb",
+      }
+
+      expect(result).to eq(expected)
+    end
+  end
+
+  describe ".signature" do
+    it "returns the tool signature" do
+      signature = described_class.signature
+      expect(signature[:name]).to eq("github_file_content")
+      expect(signature[:description]).to eq("Retrieves the content of specified GitHub files")
+      expect(signature[:parameters]).to eq(
+        [
+          {
+            name: "repo_name",
+            description: "The name of the GitHub repository (e.g., 'discourse/discourse')",
+            type: "string",
+            required: true,
+          },
+          {
+            name: "file_paths",
+            description: "The paths of the files to retrieve within the repository",
+            type: "array",
+            item_type: "string",
+            required: true,
+          },
+          {
+            name: "branch",
+            description: "The branch or commit SHA to retrieve the files from (default: 'main')",
+            type: "string",
+            required: false,
+          },
+        ],
+      )
+    end
+  end
+end

--- a/spec/lib/modules/ai_bot/tools/github_pull_request_diff_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/github_pull_request_diff_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DiscourseAi::AiBot::Tools::GithubPullRequestDiff do
+  let(:tool) { described_class.new({ repo: repo, pull_id: pull_id }) }
+  let(:bot_user) { Fabricate(:user) }
+  let(:llm) { DiscourseAi::Completions::Llm.proxy("open_ai:gpt-4") }
+
+  context "with a valid pull request" do
+    let(:repo) { "discourse/discourse-automation" }
+    let(:pull_id) { 253 }
+
+    it "retrieves the diff for the pull request" do
+      stub_request(:get, "https://api.github.com/repos/#{repo}/pulls/#{pull_id}").with(
+        headers: {
+          "Accept" => "application/vnd.github.v3.diff",
+          "User-Agent" => "Ruby",
+        },
+      ).to_return(status: 200, body: "sample diff")
+
+      result = tool.invoke(bot_user, llm)
+      expect(result[:diff]).to eq("sample diff")
+      expect(result[:error]).to be_nil
+    end
+  end
+
+  context "with an invalid pull request" do
+    let(:repo) { "invalid/repo" }
+    let(:pull_id) { 999 }
+
+    it "returns an error message" do
+      stub_request(:get, "https://api.github.com/repos/#{repo}/pulls/#{pull_id}").with(
+        headers: {
+          "Accept" => "application/vnd.github.v3.diff",
+          "User-Agent" => "Ruby",
+        },
+      ).to_return(status: 404)
+
+      result = tool.invoke(bot_user, nil)
+      expect(result[:diff]).to be_nil
+      expect(result[:error]).to include("Failed to retrieve the diff")
+    end
+  end
+end

--- a/spec/lib/modules/ai_bot/tools/github_pull_request_diff_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/github_pull_request_diff_spec.rb
@@ -15,7 +15,23 @@ RSpec.describe DiscourseAi::AiBot::Tools::GithubPullRequestDiff do
       stub_request(:get, "https://api.github.com/repos/#{repo}/pulls/#{pull_id}").with(
         headers: {
           "Accept" => "application/vnd.github.v3.diff",
-          "User-Agent" => "Discourse AI Bot 1.0 (www.discourse.org)",
+          "User-Agent" => DiscourseAi::AiBot::USER_AGENT,
+        },
+      ).to_return(status: 200, body: "sample diff")
+
+      result = tool.invoke(bot_user, llm)
+      expect(result[:diff]).to eq("sample diff")
+      expect(result[:error]).to be_nil
+    end
+
+    it "uses the github access token if present" do
+      SiteSetting.ai_bot_github_access_token = "ABC"
+
+      stub_request(:get, "https://api.github.com/repos/#{repo}/pulls/#{pull_id}").with(
+        headers: {
+          "Accept" => "application/vnd.github.v3.diff",
+          "User-Agent" => DiscourseAi::AiBot::USER_AGENT,
+          "Authorization" => "Bearer ABC",
         },
       ).to_return(status: 200, body: "sample diff")
 
@@ -33,7 +49,7 @@ RSpec.describe DiscourseAi::AiBot::Tools::GithubPullRequestDiff do
       stub_request(:get, "https://api.github.com/repos/#{repo}/pulls/#{pull_id}").with(
         headers: {
           "Accept" => "application/vnd.github.v3.diff",
-          "User-Agent" => "Ruby",
+          "User-Agent" => DiscourseAi::AiBot::USER_AGENT,
         },
       ).to_return(status: 404)
 

--- a/spec/lib/modules/ai_bot/tools/github_pull_request_diff_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/github_pull_request_diff_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DiscourseAi::AiBot::Tools::GithubPullRequestDiff do
       stub_request(:get, "https://api.github.com/repos/#{repo}/pulls/#{pull_id}").with(
         headers: {
           "Accept" => "application/vnd.github.v3.diff",
-          "User-Agent" => "Ruby",
+          "User-Agent" => "Discourse AI Bot 1.0 (www.discourse.org)",
         },
       ).to_return(status: 200, body: "sample diff")
 

--- a/spec/lib/modules/ai_bot/tools/github_search_code_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/github_search_code_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DiscourseAi::AiBot::Tools::GithubSearchCode do
+  let(:tool) { described_class.new({ repo: repo, query: query }) }
+  let(:bot_user) { Fabricate(:user) }
+  let(:llm) { DiscourseAi::Completions::Llm.proxy("open_ai:gpt-4") }
+
+  context "with valid search results" do
+    let(:repo) { "discourse/discourse" }
+    let(:query) { "def hello" }
+
+    it "searches for code in the repository" do
+      stub_request(
+        :get,
+        "https://api.github.com/search/code?q=def%20hello+repo:discourse/discourse",
+      ).with(
+        headers: {
+          "Accept" => "application/vnd.github.v3.text-match+json",
+          "User-Agent" => DiscourseAi::AiBot::USER_AGENT,
+        },
+      ).to_return(
+        status: 200,
+        body: {
+          total_count: 1,
+          items: [
+            { name: "hello.rb", text_matches: [{ fragment: "def hello\n  puts 'hello'\nend" }] },
+          ],
+        }.to_json,
+      )
+
+      result = tool.invoke(bot_user, llm)
+      expect(result[:search_results]).to include("def hello\n  puts 'hello'\nend")
+      expect(result[:error]).to be_nil
+    end
+  end
+
+  context "with an empty search result" do
+    let(:repo) { "discourse/discourse" }
+    let(:query) { "nonexistent_method" }
+
+    describe "#description_args" do
+      it "returns the repo and query" do
+        expect(tool.description_args).to eq(repo: repo, query: query)
+      end
+    end
+
+    it "returns an empty result" do
+      SiteSetting.ai_bot_github_access_token = "ABC"
+      stub_request(
+        :get,
+        "https://api.github.com/search/code?q=nonexistent_method+repo:discourse/discourse",
+      ).with(
+        headers: {
+          "Accept" => "application/vnd.github.v3.text-match+json",
+          "User-Agent" => DiscourseAi::AiBot::USER_AGENT,
+          "Authorization" => "Bearer ABC",
+        },
+      ).to_return(status: 200, body: { total_count: 0, items: [] }.to_json)
+
+      result = tool.invoke(bot_user, llm)
+      expect(result[:search_results]).to be_empty
+      expect(result[:error]).to be_nil
+    end
+  end
+
+  context "with an error response" do
+    let(:repo) { "discourse/discourse" }
+    let(:query) { "def hello" }
+
+    it "returns an error message" do
+      stub_request(
+        :get,
+        "https://api.github.com/search/code?q=def%20hello+repo:discourse/discourse",
+      ).with(
+        headers: {
+          "Accept" => "application/vnd.github.v3.text-match+json",
+          "User-Agent" => DiscourseAi::AiBot::USER_AGENT,
+        },
+      ).to_return(status: 403)
+
+      result = tool.invoke(bot_user, llm)
+      expect(result[:search_results]).to be_nil
+      expect(result[:error]).to include("Failed to perform code search")
+    end
+  end
+end

--- a/spec/lib/modules/ai_bot/tools/github_search_code_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/github_search_code_spec.rb
@@ -25,13 +25,18 @@ RSpec.describe DiscourseAi::AiBot::Tools::GithubSearchCode do
         body: {
           total_count: 1,
           items: [
-            { name: "hello.rb", text_matches: [{ fragment: "def hello\n  puts 'hello'\nend" }] },
+            {
+              path: "test/hello.rb",
+              name: "hello.rb",
+              text_matches: [{ fragment: "def hello\n  puts 'hello'\nend" }],
+            },
           ],
         }.to_json,
       )
 
       result = tool.invoke(bot_user, llm)
       expect(result[:search_results]).to include("def hello\n  puts 'hello'\nend")
+      expect(result[:search_results]).to include("test/hello.rb")
       expect(result[:error]).to be_nil
     end
   end


### PR DESCRIPTION
This PR introduces a new AI Bot persona called 'GitHub Helper' which is specialized in assisting with GitHub-related tasks and questions. It includes the following key changes:

- Adds translations and settings for the GitHub Helper persona
- Implements the GitHub Helper persona class with its system prompt and available tools
- Adds three new AI Bot tools for GitHub interactions:
  - github_file_content: Retrieves content of files from a GitHub repository 
  - github_pull_request_diff: Retrieves the diff for a GitHub pull request
  - github_search_code: Searches for code in a GitHub repository
- Updates the AI Bot dialects to support the new GitHub tools
- Adds specs to test the new GitHub tools functionality

With these changes, users will be able to interact with an AI assistant that can help them with GitHub-specific tasks by leveraging the newly added tools to fetch repository information, file contents, pull request diffs and perform code searches.

---

- The `github_search_code` tool is only enabled if the access token is present. The other tools will still work without it. Consider if this is the desired behavior or if all tools should require the token.
