### PR TITLE
FIX: Improve AI persona editor inputs and optional GitHub auth

### DIFF
--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -315,6 +315,7 @@ export default class PersonaEditor extends Component {
         <label>{{I18n.t "discourse_ai.ai_persona.max_context_posts"}}</label>
         <Input
           @type="number"
+          lang="en"
           class="ai-persona-editor__max_context_posts"
           @value={{this.editingModel.max_context_posts}}
         />
@@ -329,6 +330,8 @@ export default class PersonaEditor extends Component {
           <Input
             @type="number"
             class="ai-persona-editor__temperature"
+            step="any"
+            lang="en"
             @value={{this.editingModel.temperature}}
             disabled={{this.editingModel.system}}
           />
@@ -343,6 +346,8 @@ export default class PersonaEditor extends Component {
           <label>{{I18n.t "discourse_ai.ai_persona.top_p"}}</label>
           <Input
             @type="number"
+            step="any"
+            lang="en"
             class="ai-persona-editor__top_p"
             @value={{this.editingModel.top_p}}
             disabled={{this.editingModel.system}}

--- a/lib/ai_bot/tools/tool.rb
+++ b/lib/ai_bot/tools/tool.rb
@@ -82,7 +82,7 @@ module DiscourseAi
           request = FinalDestination::HTTP::Get.new(uri)
           request["User-Agent"] = DiscourseAi::AiBot::USER_AGENT
           headers.each { |k, v| request[k] = v }
-          if authenticate_github
+          if authenticate_github && SiteSetting.ai_bot_github_access_token.present?
             request["Authorization"] = "Bearer #{SiteSetting.ai_bot_github_access_token}"
           end
 


### PR DESCRIPTION
1. Fix input fields in AI persona editor and make GitHub tool authentication optional

2. AI persona editor improvements and tool GitHub access token check

This pull request makes a few improvements:

- Adds `lang="en"` to number input fields in the AI persona editor to prevent localization issues 
- Adds `step="any"` to allow fractional values for temperature and top_p settings
- Makes GitHub tool authentication contingent on `ai_bot_github_access_token` site setting being present

see: https://meta.discourse.org/t/ai-bot-personas-don-t-accept-decimals-for-temperature-top-p/298243/7