### PR TITLE
FIX: Image caption feature should respect composer AI helper groups

### DIFF
--- a/assets/javascripts/initializers/ai-image-caption.js
+++ b/assets/javascripts/initializers/ai-image-caption.js
@@ -10,10 +10,15 @@ export default apiInitializer("1.25.0", (api) => {
     class: "generate-caption",
   };
   const settings = api.container.lookup("service:site-settings");
+  const currentUser = api.getCurrentUser();
 
-  if (!settings.ai_helper_enabled_features.includes("image_caption")) {
+  if (
+    !settings.ai_helper_enabled_features.includes("image_caption") ||
+    !currentUser.can_use_assistant
+  ) {
     return;
   }
+
   api.addComposerImageWrapperButton(
     buttonAttrs.label,
     buttonAttrs.class,

--- a/spec/system/page_objects/components/ai_caption_popup.rb
+++ b/spec/system/page_objects/components/ai_caption_popup.rb
@@ -34,6 +34,10 @@ module PageObjects
       def has_no_disabled_generate_button?
         page.has_no_css?("#{GENERATE_CAPTION_SELECTOR}.disabled", visible: false)
       end
+
+      def has_no_generate_caption_button?
+        page.has_no_css?(GENERATE_CAPTION_SELECTOR, visible: false)
+      end
     end
   end
 end


### PR DESCRIPTION
As reported on [Meta](https://meta.discourse.org/t/caption-with-ai-displaying-for-those-without-permission-to-use-it/297422).

The Image caption feature is part of the composer AI helper, therefore it should respect the setting: `ai_helper_allowed_groups`. Previously, the image caption button was still being shown to users outside of the set group and the button would display an error when clicked.