### PR TITLE
FIX: ai-image-caption should not crash on checking currentUser can_use_assistant

### DIFF
--- a/assets/javascripts/initializers/ai-image-caption.js
+++ b/assets/javascripts/initializers/ai-image-caption.js
@@ -14,7 +14,7 @@ export default apiInitializer("1.25.0", (api) => {
 
   if (
     !settings.ai_helper_enabled_features.includes("image_caption") ||
-    !currentUser.can_use_assistant
+    !currentUser?.can_use_assistant
   ) {
     return;
   }


### PR DESCRIPTION
This happens when attempting to view sites with this plugin while logged out.

<img width="692" alt="Screenshot 2024-03-12 at 4 04 05 PM" src="https://github.com/discourse/discourse-ai/assets/133760061/c71bd969-6378-48e8-b03e-19bc4f4a2608">
