### PR TITLE
FIX: Filter soft-deleted topics when backfilling sentiment

### DIFF
--- a/lib/tasks/modules/sentiment/backfill.rake
+++ b/lib/tasks/modules/sentiment/backfill.rake
@@ -13,6 +13,7 @@ task "ai:sentiment:backfill", [:start_post] => [:environment] do |_, args|
     .where("posts.id >= ?", args[:start_post].to_i || 0)
     .where("category_id IN (?)", public_categories)
     .where(posts: { deleted_at: nil })
+    .where(topics: { deleted_at: nil })
     .order("posts.id ASC")
     .find_each do |post|
       print "."

--- a/spec/tasks/backfill_spec.rb
+++ b/spec/tasks/backfill_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "../support/sentiment_inference_stubs"
+
+RSpec.describe "assets:precompile" do
+  before do
+    Rake::Task.clear
+    Discourse::Application.load_tasks
+  end
+
+  describe "ai:sentiment:backfill" do
+    before { SiteSetting.ai_sentiment_inference_service_api_endpoint = "http://test.com" }
+
+    it "does nothing if the topic is soft-deleted" do
+      target = Fabricate(:post)
+      SentimentInferenceStubs.stub_classification(target)
+      target.topic.trash!
+
+      path = Rake::Task["ai:sentiment:backfill"].invoke
+
+      expect(ClassificationResult.count).to be_zero
+    end
+  end
+end


### PR DESCRIPTION
The query included soft-deleted topics, causing errors when doing `post.topic`. The `Trashable` module default scope wasn't included by default. 