### PR TITLE
UX: Add title suffix to shared AI pages

### DIFF
--- a/app/views/discourse_ai/ai_bot/shared_ai_conversations/show.html.erb
+++ b/app/views/discourse_ai/ai_bot/shared_ai_conversations/show.html.erb
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= @shared_conversation.title %></title>
-    <meta property="og:title" content="<%= @shared_conversation.title %>">
+    <title><%= I18n.t("discourse_ai.share_ai.title", title: @shared_conversation.title, site_name: SiteSetting.title) %></title>
+    <meta property="og:title" content="<%= I18n.t("discourse_ai.share_ai.title", title: @shared_conversation.title, site_name: SiteSetting.title) %>">
     <meta property="og:description" content="<%= @shared_conversation.formatted_excerpt %>">
     <meta property="og:type" content="website">
     <meta property="og:url" content="<%= request.original_url %>">
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="<%= @shared_conversation.title %>">
+    <meta name="twitter:title" content="<%= I18n.t("discourse_ai.share_ai.title", title: @shared_conversation.title, site_name: SiteSetting.title) %>">
     <meta name="twitter:description" content="<%= @shared_conversation.formatted_excerpt %>">
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="<%= ::UrlHelper.local_cdn_url("/plugins/discourse-ai/ai-share/share.css") %>">

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -159,6 +159,7 @@ en:
       read_more: "Read full transcript"
       onebox_title: "AI Conversation with %{llm_name}"
       formatted_excerpt: "AI Conversation with %{llm_name}:\n %{excerpt}"
+      title: "%{title} - AI Conversation - %{site_name}"
       errors:
         not_allowed: "You are not allowed to share this topic"
         other_people_in_pm: "Personal messages with other humans cannot be shared publicly"


### PR DESCRIPTION
Previously, the title of the shared AI page would be the title of the PM. When shared somewhere else (e.g. another Discourse site, or social media platform), this can make it look like an authoritative article published by the forum owner.

This commit adds an `- AI Conversation` suffix to the page title.

This serves a few purposes:

1. Increases awareness of discourse-ai's bot feature

2. Bring external sharing in line with the internal-onebox for this feature, which already has a clear 'AI conversation' label

3. Makes it clearer that these pages are not an authoritative source, and are not necessarily endorsed by the forum owner

This is especially important in situations where the og:description is not displayed (e.g. in Discourse inline oneboxes)