### PR TITLE
FEATURE: AI Bot RAG support.

### DIFF
--- a/admin/assets/javascripts/discourse/routes/admin-plugins-show-discourse-ai-ai-personas-new.js
+++ b/admin/assets/javascripts/discourse/routes/admin-plugins-show-discourse-ai-ai-personas-new.js
@@ -5,6 +5,7 @@ export default DiscourseRoute.extend({
   async model() {
     const record = this.store.createRecord("ai-persona");
     record.set("allowed_group_ids", [AUTO_GROUPS.trust_level_0.id]);
+    record.set("rag_uploads", []);
     return record;
   },
 

--- a/app/controllers/discourse_ai/admin/ai_personas_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_personas_controller.rb
@@ -30,8 +30,10 @@ module DiscourseAi
       end
 
       def create
-        ai_persona = AiPersona.new(ai_persona_params)
+        ai_persona = AiPersona.new(ai_persona_params.except(:rag_uploads))
         if ai_persona.save
+          RagDocumentFragment.link_persona_and_uploads(ai_persona, attached_upload_ids)
+
           render json: { ai_persona: ai_persona }, status: :created
         else
           render_json_error ai_persona
@@ -44,7 +46,9 @@ module DiscourseAi
       end
 
       def update
-        if @ai_persona.update(ai_persona_params)
+        if @ai_persona.update(ai_persona_params.except(:rag_uploads))
+          RagDocumentFragment.update_persona_uploads(@ai_persona, attached_upload_ids)
+
           render json: @ai_persona
         else
           render_json_error @ai_persona
@@ -59,10 +63,41 @@ module DiscourseAi
         end
       end
 
+      def upload_file
+        file = params[:file] || params[:files].first
+        filename = params[:file].original_filename
+
+        if !SiteSetting.ai_embeddings_enabled?
+          raise Discourse::InvalidAccess.new("Embeddings not enabled")
+        end
+
+        # Validate size.
+
+        hijack do
+          upload =
+            UploadCreator.new(
+              file.tempfile,
+              file.original_filename,
+              type: "discourse_ai_rag_upload",
+              skip_validations: true,
+            ).create_for(current_user.id)
+
+          if upload.persisted?
+            render json: UploadSerializer.new(upload)
+          else
+            render json: failed_json.merge(errors: upload.errors.full_messages), status: 422
+          end
+        end
+      end
+
       private
 
       def find_ai_persona
         @ai_persona = AiPersona.find(params[:id])
+      end
+
+      def attached_upload_ids
+        ai_persona_params[:rag_uploads].to_a.map { |h| h[:id] }
       end
 
       def ai_persona_params
@@ -82,6 +117,7 @@ module DiscourseAi
             :vision_enabled,
             :vision_max_pixels,
             allowed_group_ids: [],
+            rag_uploads: [:id],
           )
 
         if commands = params.dig(:ai_persona, :commands)

--- a/app/jobs/regular/digest_rag_upload.rb
+++ b/app/jobs/regular/digest_rag_upload.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module ::Jobs
+  class DigestRagUpload < ::Jobs::Base
+    # TODO(roman): Add a way to automatically recover from errors, resulting in unindexed uploads.
+    def execute(args)
+      return if (upload = Upload.find_by(id: args[:upload_id])).nil?
+      return if (ai_persona = AiPersona.find_by(id: args[:ai_persona_id])).nil?
+
+      fragment_ids = RagDocumentFragment.where(ai_persona: ai_persona, upload: upload).pluck(:id)
+
+      # Check if this is the first time we process this upload.
+      if fragment_ids.empty?
+        document = get_uploaded_file(upload)
+        return if document.nil?
+
+        chunk_size = 1024
+        chunk_overlap = 64
+        chunks = []
+        overlap = ""
+
+        splitter =
+          Baran::RecursiveCharacterTextSplitter.new(
+            chunk_size: chunk_size,
+            chunk_overlap: chunk_overlap,
+            separators: ["\n\n", "\n", " ", ""],
+          )
+
+        while raw_text = document.read(2048)
+          splitter.chunks(overlap + raw_text).each { |chunk| chunks << chunk[:text] }
+
+          overlap = chunks.last[-chunk_overlap..-1] || chunks.last
+        end
+
+        ActiveRecord::Base.transaction do
+          fragment_ids =
+            chunks.each_with_index.map do |fragment_text, idx|
+              RagDocumentFragment.create!(
+                ai_persona: ai_persona,
+                fragment: Encodings.to_utf8(fragment_text),
+                fragment_number: idx + 1,
+                upload: upload,
+              ).id
+            end
+        end
+      end
+
+      fragment_ids.each_slice(50) do |slice|
+        Jobs.enqueue(:generate_rag_embeddings, fragment_ids: slice)
+      end
+    end
+
+    private
+
+    def get_uploaded_file(upload)
+      store = Discourse.store
+      @file ||=
+        if store.external?
+          # Upload#filesize could be approximate.
+          # add two extra Mbs to make sure that we'll be able to download the upload.
+          max_filesize = upload.filesize + 2.megabytes
+          store.download(upload, max_file_size_kb: max_filesize)
+        else
+          File.open(store.path_for(upload))
+        end
+    end
+  end
+end

--- a/app/jobs/regular/generate_rag_embeddings.rb
+++ b/app/jobs/regular/generate_rag_embeddings.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ::Jobs
+  class GenerateRagEmbeddings < ::Jobs::Base
+    def execute(args)
+      return if (fragments = RagDocumentFragment.where(id: args[:fragment_ids].to_a)).empty?
+
+      truncation = DiscourseAi::Embeddings::Strategies::Truncation.new
+      vector_rep =
+        DiscourseAi::Embeddings::VectorRepresentations::Base.current_representation(truncation)
+
+      # generate_representation_from checks compares the digest value to make sure
+      # the embedding is only generated once per fragment unless something changes.
+      fragments.map { |fragment| vector_rep.generate_representation_from(fragment) }
+    end
+  end
+end

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -264,6 +264,10 @@ class AiPersona < ActiveRecord::Base
       define_method :system_prompt do
         @ai_persona&.system_prompt || "You are a helpful bot."
       end
+
+      define_method :uploads do
+        @ai_persona&.uploads || []
+      end
     end
   end
 

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -16,6 +16,13 @@ class AiPersona < ActiveRecord::Base
   belongs_to :created_by, class_name: "User"
   belongs_to :user
 
+  has_many :upload_references, as: :target, dependent: :destroy
+  has_many :uploads, through: :upload_references
+
+  has_many :rag_document_fragment, dependent: :destroy
+
+  has_many :rag_document_fragments, through: :ai_persona_rag_document_fragments
+
   before_destroy :ensure_not_system
 
   class MultisiteHash

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -266,7 +266,7 @@ class AiPersona < ActiveRecord::Base
       end
 
       define_method :uploads do
-        @ai_persona&.uploads || []
+        @ai_persona&.uploads
       end
     end
   end

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -335,26 +335,26 @@ end
 #
 # Table name: ai_personas
 #
-#  id                      :bigint           not null, primary key
-#  name                    :string(100)      not null
-#  description             :string(2000)     not null
-#  commands                :json             not null
-#  system_prompt           :string(10000000) not null
-#  allowed_group_ids       :integer          default([]), not null, is an Array
-#  created_by_id           :integer
-#  enabled                 :boolean          default(TRUE), not null
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  system                  :boolean          default(FALSE), not null
-#  priority                :boolean          default(FALSE), not null
-#  temperature             :float
-#  top_p                   :float
-#  user_id                 :integer
-#  mentionable             :boolean          default(FALSE), not null
-#  default_llm             :text
-#  max_context_posts       :integer
-#  max_post_context_tokens :integer
-#  max_context_tokens      :integer
+#  id                :bigint           not null, primary key
+#  name              :string(100)      not null
+#  description       :string(2000)     not null
+#  commands          :json             not null
+#  system_prompt     :string(10000000) not null
+#  allowed_group_ids :integer          default([]), not null, is an Array
+#  created_by_id     :integer
+#  enabled           :boolean          default(TRUE), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  system            :boolean          default(FALSE), not null
+#  priority          :boolean          default(FALSE), not null
+#  temperature       :float
+#  top_p             :float
+#  user_id           :integer
+#  mentionable       :boolean          default(FALSE), not null
+#  default_llm       :text
+#  max_context_posts :integer
+#  vision_enabled    :boolean          default(FALSE), not null
+#  vision_max_pixels :integer          default(1048576), not null
 #
 # Indexes
 #

--- a/app/models/ai_persona.rb
+++ b/app/models/ai_persona.rb
@@ -245,6 +245,10 @@ class AiPersona < ActiveRecord::Base
         super(*args, **kwargs)
       end
 
+      define_method :persona_id do
+        @ai_persona&.id
+      end
+
       define_method :tools do
         tools
       end

--- a/app/models/post_custom_prompt.rb
+++ b/app/models/post_custom_prompt.rb
@@ -7,3 +7,18 @@ end
 class ::Post
   has_one :post_custom_prompt, dependent: :destroy
 end
+
+# == Schema Information
+#
+# Table name: post_custom_prompts
+#
+#  id            :bigint           not null, primary key
+#  post_id       :integer          not null
+#  custom_prompt :json             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_post_custom_prompts_on_post_id  (post_id) UNIQUE
+#

--- a/app/models/rag_document_fragment.rb
+++ b/app/models/rag_document_fragment.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class RagDocumentFragment < ActiveRecord::Base
+  belongs_to :upload
+  belongs_to :ai_persona
+
+  class << self
+    def link_persona_and_uploads(persona, upload_ids)
+      return if persona.blank?
+      return if upload_ids.blank?
+      return if !SiteSetting.ai_embeddings_enabled?
+
+      UploadReference.ensure_exist!(upload_ids: upload_ids, target: persona)
+
+      upload_ids.each do |upload_id|
+        Jobs.enqueue(:digest_rag_upload, ai_persona_id: persona.id, upload_id: upload_id)
+      end
+    end
+
+    def update_persona_uploads(persona, upload_ids)
+      return if persona.blank?
+      return if !SiteSetting.ai_embeddings_enabled?
+
+      if upload_ids.blank?
+        RagDocumentFragment.where(ai_persona: persona).destroy_all
+        UploadReference.where(target: persona).destroy_all
+      else
+        RagDocumentFragment.where(ai_persona: persona).where.not(upload_id: upload_ids).destroy_all
+        link_persona_and_uploads(persona, upload_ids)
+      end
+    end
+  end
+end

--- a/app/models/rag_document_fragment.rb
+++ b/app/models/rag_document_fragment.rb
@@ -31,3 +31,16 @@ class RagDocumentFragment < ActiveRecord::Base
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: rag_document_fragments
+#
+#  id              :bigint           not null, primary key
+#  fragment        :text             not null
+#  ai_persona_id   :integer          not null
+#  upload_id       :integer          not null
+#  fragment_number :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#

--- a/app/serializers/localized_ai_persona_serializer.rb
+++ b/app/serializers/localized_ai_persona_serializer.rb
@@ -22,6 +22,11 @@ class LocalizedAiPersonaSerializer < ApplicationSerializer
              :vision_max_pixels
 
   has_one :user, serializer: BasicUserSerializer, embed: :object
+  has_many :rag_uploads, serializer: UploadSerializer, embed: :object
+
+  def rag_uploads
+    object.uploads
+  end
 
   def name
     object.class_instance.name

--- a/assets/javascripts/discourse/admin/models/ai-persona.js
+++ b/assets/javascripts/discourse/admin/models/ai-persona.js
@@ -20,6 +20,7 @@ const ATTRIBUTES = [
   "max_context_posts",
   "vision_enabled",
   "vision_max_pixels",
+  "rag_uploads",
 ];
 
 const SYSTEM_ATTRIBUTES = [
@@ -34,6 +35,7 @@ const SYSTEM_ATTRIBUTES = [
   "max_context_posts",
   "vision_enabled",
   "vision_max_pixels",
+  "rag_uploads",
 ];
 
 class CommandOption {

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -15,6 +15,7 @@ import DToggleSwitch from "discourse/components/d-toggle-switch";
 import Avatar from "discourse/helpers/bound-avatar-template";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import Group from "discourse/models/group";
+import { bind } from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 import AdminUser from "admin/models/admin-user";
 import ComboBox from "select-kit/components/combo-box";
@@ -24,7 +25,6 @@ import AiCommandSelector from "./ai-command-selector";
 import AiLlmSelector from "./ai-llm-selector";
 import AiPersonaCommandOptions from "./ai-persona-command-options";
 import PersonaRagUploader from "./persona-rag-uploader";
-import { bind } from "discourse-common/utils/decorators";
 
 export default class PersonaEditor extends Component {
   @service router;
@@ -44,20 +44,31 @@ export default class PersonaEditor extends Component {
 =======
   constructor() {
     super(...arguments);
-    this.messageBus.subscribe("/discourse-ai/ai-bot/uploads", this.onUploadUpdate);
+    this.messageBus.subscribe(
+      "/discourse-ai/ai-bot/uploads",
+      this.onUploadUpdate
+    );
   }
 
   willDestroy() {
     super.willDestroy(...arguments);
-    this.messageBus.unsubscribe("/discourse-ai/ai-bot/uploads", this.onUploadUpdate);
+    this.messageBus.unsubscribe(
+      "/discourse-ai/ai-bot/uploads",
+      this.onUploadUpdate
+    );
   }
 
   @bind
-  onUploadUpdate(data) { 
-    const upload = this.editingModel.rag_uploads.findBy("upload_id", data.upload_id);
+  onUploadUpdate(data) {
+    const upload = this.editingModel.rag_uploads.findBy(
+      "upload_id",
+      data.upload_id
+    );
 
     upload.status = data.status;
-    upload.statusText = I18n.t(`discourse_ai.ai_persona.uploads.processing.${data.status}`);
+    upload.statusText = I18n.t(
+      `discourse_ai.ai_persona.uploads.processing.${data.status}`
+    );
   }
 >>>>>>> 8ae5131 (FEATURE: RAG embeddings for the AI Bot)
 
@@ -463,7 +474,11 @@ export default class PersonaEditor extends Component {
       </div>
       {{#if this.siteSettings.ai_embeddings_enabled}}
         <div class="control-group">
-          <PersonaRagUploader @ragUploads={{this.editingModel.rag_uploads}} @onAdd={{this.addUpload}} @onRemove={{this.removeUpload}}/>
+          <PersonaRagUploader
+            @ragUploads={{this.editingModel.rag_uploads}}
+            @onAdd={{this.addUpload}}
+            @onRemove={{this.removeUpload}}
+          />
         </div>
       {{/if}}
       <div class="control-group ai-persona-editor__action_panel">

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -15,7 +15,6 @@ import DToggleSwitch from "discourse/components/d-toggle-switch";
 import Avatar from "discourse/helpers/bound-avatar-template";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import Group from "discourse/models/group";
-import { bind } from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 import AdminUser from "admin/models/admin-user";
 import ComboBox from "select-kit/components/combo-box";
@@ -31,17 +30,14 @@ export default class PersonaEditor extends Component {
   @service store;
   @service dialog;
   @service toasts;
-  @service messageBus;
   @service siteSettings;
 
   @tracked allGroups = [];
   @tracked isSaving = false;
   @tracked editingModel = null;
   @tracked showDelete = false;
-
-<<<<<<< HEAD
   @tracked maxPixelsValue = null;
-=======
+
   constructor() {
     super(...arguments);
     this.messageBus.subscribe(
@@ -72,6 +68,8 @@ export default class PersonaEditor extends Component {
   }
 >>>>>>> 8ae5131 (FEATURE: RAG embeddings for the AI Bot)
 
+=======
+>>>>>>> 9593f80 (Uploads filter, css adjustments and file validations)
   @action
   updateModel() {
     this.editingModel = this.args.model.workingCopy();
@@ -236,6 +234,7 @@ export default class PersonaEditor extends Component {
   @action
   removeUpload(upload) {
     this.editingModel.rag_uploads.removeObject(upload);
+    this.save();
   }
 
   async toggleField(field, sortPersonas) {

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -38,38 +38,6 @@ export default class PersonaEditor extends Component {
   @tracked showDelete = false;
   @tracked maxPixelsValue = null;
 
-  constructor() {
-    super(...arguments);
-    this.messageBus.subscribe(
-      "/discourse-ai/ai-bot/uploads",
-      this.onUploadUpdate
-    );
-  }
-
-  willDestroy() {
-    super.willDestroy(...arguments);
-    this.messageBus.unsubscribe(
-      "/discourse-ai/ai-bot/uploads",
-      this.onUploadUpdate
-    );
-  }
-
-  @bind
-  onUploadUpdate(data) {
-    const upload = this.editingModel.rag_uploads.findBy(
-      "upload_id",
-      data.upload_id
-    );
-
-    upload.status = data.status;
-    upload.statusText = I18n.t(
-      `discourse_ai.ai_persona.uploads.processing.${data.status}`
-    );
-  }
->>>>>>> 8ae5131 (FEATURE: RAG embeddings for the AI Bot)
-
-=======
->>>>>>> 9593f80 (Uploads filter, css adjustments and file validations)
   @action
   updateModel() {
     this.editingModel = this.args.model.workingCopy();

--- a/assets/javascripts/discourse/components/persona-rag-uploader.gjs
+++ b/assets/javascripts/discourse/components/persona-rag-uploader.gjs
@@ -72,6 +72,7 @@ export default class PersonaRagUploader extends Component.extend(
     <div class="persona-rag-uploader">
       <h3>{{I18n.t "discourse_ai.ai_persona.uploads.title"}}</h3>
       <p>{{I18n.t "discourse_ai.ai_persona.uploads.description"}}</p>
+      <p>{{I18n.t "discourse_ai.ai_persona.uploads.hint"}}</p>
 
       <div class="persona-rag-uploader__search-input-container">
         <div class="persona-rag-uploader__search-input">

--- a/assets/javascripts/discourse/components/persona-rag-uploader.gjs
+++ b/assets/javascripts/discourse/components/persona-rag-uploader.gjs
@@ -1,12 +1,11 @@
 import Component from "@ember/component";
-import { action, computed } from "@ember/object";
-import { tracked } from "@glimmer/tracking";
-import UppyUploadMixin from "discourse/mixins/uppy-upload";
-import i18n from "discourse-common/helpers/i18n";
-import icon from "discourse-common/helpers/d-icon";
-import DButton from "discourse/components/d-button";
 import { fn } from "@ember/helper";
+import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import UppyUploadMixin from "discourse/mixins/uppy-upload";
+import icon from "discourse-common/helpers/d-icon";
+import I18n from "discourse-i18n";
 
 export default class PersonaRagUploader extends Component.extend(
   UppyUploadMixin
@@ -19,7 +18,8 @@ export default class PersonaRagUploader extends Component.extend(
   preventDirectS3Uploads = true;
 
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs();
+    super.didReceiveAttrs(...arguments);
     if (this.inProgressUploads?.length > 0) {
       this._uppyInstance?.cancelAll();
     }
@@ -46,27 +46,43 @@ export default class PersonaRagUploader extends Component.extend(
     <p>{{I18n.t "discourse_ai.ai_persona.uploads.description"}}</p>
 
     <table class="rag-uploads">
-      {{#each @ragUploads as |upload|}}
-        <tr>
-          <td><span class="rag-file-icon">{{icon "file"}}</span> {{upload.original_filename}}</td>
-          <td class="upload-status {{upload.status}}">{{icon "check"}} {{upload.statusText}}</td>
-          <td>
-            <DButton @icon="times" @title="discourse_ai.ai_persona.uploads.remove" @action={{fn @onRemove upload}} @class="btn-flat" />
-          </td>
-        </tr>
-      {{/each}}
-      {{#each this.inProgressUploads as |upload|}}
-        <tr>
-          <td><span class="rag-file-icon">{{icon "file"}}</span> {{upload.original_filename}}</td>
-          <td class="upload-status">
-            <div class="spinner small"></div>
-            <span>{{I18n.t "discourse_ai.ai_persona.uploads.uploading"}} {{upload.uploadProgress}}%</span>
-          </td>
-          <td>
-            <DButton @icon="times" @title="discourse_ai.ai_persona.uploads.remove" @action={{fn this.cancelUploading upload}} @class="btn-flat" />
-          </td>
-        </tr>
-      {{/each}}
+      <tbody>
+        {{#each @ragUploads as |upload|}}
+          <tr>
+            <td><span class="rag-file-icon">{{icon "file"}}</span>
+              {{upload.original_filename}}</td>
+            <td class="upload-status {{upload.status}}">{{icon "check"}}
+              {{upload.statusText}}</td>
+            <td>
+              <DButton
+                @icon="times"
+                @title="discourse_ai.ai_persona.uploads.remove"
+                @action={{fn @onRemove upload}}
+                @class="btn-flat"
+              />
+            </td>
+          </tr>
+        {{/each}}
+        {{#each this.inProgressUploads as |upload|}}
+          <tr>
+            <td><span class="rag-file-icon">{{icon "file"}}</span>
+              {{upload.original_filename}}</td>
+            <td class="upload-status">
+              <div class="spinner small"></div>
+              <span>{{I18n.t "discourse_ai.ai_persona.uploads.uploading"}}
+                {{upload.uploadProgress}}%</span>
+            </td>
+            <td>
+              <DButton
+                @icon="times"
+                @title="discourse_ai.ai_persona.uploads.remove"
+                @action={{fn this.cancelUploading upload}}
+                @class="btn-flat"
+              />
+            </td>
+          </tr>
+        {{/each}}
+      </tbody>
     </table>
 
     <input
@@ -78,7 +94,7 @@ export default class PersonaRagUploader extends Component.extend(
     />
     <DButton
       @label="discourse_ai.ai_persona.uploads.button"
-      @icon="plus"  
+      @icon="plus"
       @title="discourse_ai.ai_persona.uploads.button"
       @action={{this.submitFiles}}
       class="btn-default"

--- a/assets/javascripts/discourse/components/persona-rag-uploader.gjs
+++ b/assets/javascripts/discourse/components/persona-rag-uploader.gjs
@@ -1,0 +1,87 @@
+import Component from "@ember/component";
+import { action, computed } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
+import UppyUploadMixin from "discourse/mixins/uppy-upload";
+import i18n from "discourse-common/helpers/i18n";
+import icon from "discourse-common/helpers/d-icon";
+import DButton from "discourse/components/d-button";
+import { fn } from "@ember/helper";
+import { inject as service } from "@ember/service";
+
+export default class PersonaRagUploader extends Component.extend(
+  UppyUploadMixin
+) {
+  @service appEvents;
+
+  id = "discourse-ai-persona-rag-uploader";
+  maxFiles = 20;
+  uploadUrl = "/admin/plugins/discourse-ai/ai-personas/files/upload";
+  preventDirectS3Uploads = true;
+
+  didReceiveAttrs() {
+    this._super(...arguments);
+    if (this.inProgressUploads?.length > 0) {
+      this._uppyInstance?.cancelAll();
+    }
+  }
+
+  uploadDone(uploadedFile) {
+    this.onAdd(uploadedFile.upload);
+  }
+
+  @action
+  submitFiles() {
+    this.fileInputEl.click();
+  }
+
+  @action
+  cancelUploading(upload) {
+    this.appEvents.trigger(`upload-mixin:${this.id}:cancel-upload`, {
+      fileId: upload.id,
+    });
+  }
+
+  <template>
+    <label>{{I18n.t "discourse_ai.ai_persona.uploads.title"}}</label>
+    <p>{{I18n.t "discourse_ai.ai_persona.uploads.description"}}</p>
+
+    <table class="rag-uploads">
+      {{#each @ragUploads as |upload|}}
+        <tr>
+          <td><span class="rag-file-icon">{{icon "file"}}</span> {{upload.original_filename}}</td>
+          <td class="upload-status {{upload.status}}">{{icon "check"}} {{upload.statusText}}</td>
+          <td>
+            <DButton @icon="times" @title="discourse_ai.ai_persona.uploads.remove" @action={{fn @onRemove upload}} @class="btn-flat" />
+          </td>
+        </tr>
+      {{/each}}
+      {{#each this.inProgressUploads as |upload|}}
+        <tr>
+          <td><span class="rag-file-icon">{{icon "file"}}</span> {{upload.original_filename}}</td>
+          <td class="upload-status">
+            <div class="spinner small"></div>
+            <span>{{I18n.t "discourse_ai.ai_persona.uploads.uploading"}} {{upload.uploadProgress}}%</span>
+          </td>
+          <td>
+            <DButton @icon="times" @title="discourse_ai.ai_persona.uploads.remove" @action={{fn this.cancelUploading upload}} @class="btn-flat" />
+          </td>
+        </tr>
+      {{/each}}
+    </table>
+
+    <input
+      class="hidden-upload-field"
+      disabled={{this.uploading}}
+      type="file"
+      multiple="multiple"
+      accept=".txt"
+    />
+    <DButton
+      @label="discourse_ai.ai_persona.uploads.button"
+      @icon="plus"  
+      @title="discourse_ai.ai_persona.uploads.button"
+      @action={{this.submitFiles}}
+      class="btn-default"
+    />
+  </template>
+}

--- a/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
@@ -85,7 +85,7 @@
       padding-right: 0;
 
       &.succesful {
-        color: var(--success);  
+        color: var(--success);
       }
     }
 
@@ -93,9 +93,9 @@
       text-align: right;
       padding-left: 0;
     }
-    
+
     .rag-file-icon {
       margin-right: 5px;
-    }  
+    }
   }
 }

--- a/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
@@ -76,4 +76,26 @@
     display: flex;
     align-items: center;
   }
+
+  .rag-uploads {
+    margin-bottom: 20px;
+
+    .upload-status {
+      text-align: right;
+      padding-right: 0;
+
+      &.succesful {
+        color: var(--success);  
+      }
+    }
+
+    .remove-upload {
+      text-align: right;
+      padding-left: 0;
+    }
+    
+    .rag-file-icon {
+      margin-right: 5px;
+    }  
+  }
 }

--- a/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
@@ -77,24 +77,67 @@
     align-items: center;
   }
 
-  .rag-uploads {
-    margin-bottom: 20px;
+  .persona-rag-uploader {
+    width: 500px;
 
-    .upload-status {
-      text-align: right;
-      padding-right: 0;
+    &__search-input {
+      display: flex;
+      align-items: center;
+      border: 1px solid var(--primary-400);
+      width: 100%;
+      box-sizing: border-box;
+      height: 35px;
+      padding: 0 0.5rem;
 
-      &.succesful {
-        color: var(--success);
+      &:focus,
+      &:focus-within {
+        @include default-focus();
+      }
+
+      &-container {
+        display: flex;
+        flex-grow: 1;
+      }
+
+      &__search-icon {
+        background: none !important;
+        color: var(--primary-medium);
+      }
+
+      &__input {
+        width: 100% !important;
+      }
+
+      &__input,
+      &__input:focus {
+        margin: 0 !important;
+        border: 0 !important;
+        appearance: none !important;
+        outline: none !important;
+        background: none !important;
       }
     }
 
-    .remove-upload {
+    &__uploads-list {
+      margin-bottom: 20px;
+
+      tbody {
+        border-top: none;
+      }
+    }
+
+    &__upload-status {
+      text-align: right;
+      padding-right: 0;
+      color: var(--success);
+    }
+
+    &__remove-file {
       text-align: right;
       padding-left: 0;
     }
 
-    .rag-file-icon {
+    &__rag-file-icon {
       margin-right: 5px;
     }
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -169,10 +169,8 @@ en:
           title: "Uploads"
           description: "Your AI persona will be able to search and reference the content of included files. Uploaded files must be formatted as plaintext (.txt)"
           button: "Add Files"
-          uploaded: "Uploaded"
-          processing: "Processing..."
-          indexing: "Indexing..."
-          completed: "Complete"
+          filter: "Filter uploads"
+          complete: "Complete"
 
       related_topics:
         title: "Related Topics"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -168,6 +168,7 @@ en:
         uploads:
           title: "Uploads"
           description: "Your AI persona will be able to search and reference the content of included files. Uploaded files must be formatted as plaintext (.txt)"
+          hint: "To control where the file's content gets placed within the system prompt, include the {uploads} placeholder in the system prompt above."
           button: "Add Files"
           filter: "Filter uploads"
           complete: "Complete"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -164,6 +164,15 @@ en:
           #### Group-Specific Access to AI Personas
 
           Moreover, you can set it up so that certain user groups have access to specific personas. This means you can have different AI behaviors for different sections of your forum, further enhancing the diversity and richness of your community's interactions.
+        
+        uploads:
+          title: "Uploads"
+          description: "Your AI persona will be able to search and reference the content of included files. Uploaded files must be formatted as plaintext (.txt)"
+          button: "Add Files"
+          uploaded: "Uploaded"
+          processing: "Processing..."
+          indexing: "Indexing..."
+          completed: "Complete"
 
       related_topics:
         title: "Related Topics"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,5 +41,7 @@ Discourse::Application.routes.draw do
               controller: "discourse_ai/admin/ai_personas"
 
     post "/ai-personas/:id/create-user", to: "discourse_ai/admin/ai_personas#create_user"
+    post "/ai-personas/files/upload", to: "discourse_ai/admin/ai_personas#upload_file"
+    put "/ai-personas/:id/files/remove", to: "discourse_ai/admin/ai_personas#remove_file"
   end
 end

--- a/db/migrate/20240309034752_create_rag_document_fragment_table.rb
+++ b/db/migrate/20240309034752_create_rag_document_fragment_table.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateRagDocumentFragmentTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :rag_document_fragments do |t|
+      t.text :fragment, null: false
+      t.integer :upload_id, null: false
+      t.integer :ai_persona_id, null: false
+      t.integer :fragment_number, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240313165121_embedding_tables_for_rag_uploads.rb
+++ b/db/migrate/20240313165121_embedding_tables_for_rag_uploads.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+class EmbeddingTablesForRagUploads < ActiveRecord::Migration[7.0]
+  def change
+    create_table :ai_document_fragment_embeddings_1_1, id: false do |t|
+      t.integer :rag_document_fragment_id, null: false
+      t.integer :model_version, null: false
+      t.integer :strategy_version, null: false
+      t.text :digest, null: false
+      t.column :embeddings, "vector(768)", null: false
+      t.timestamps
+
+      t.index :rag_document_fragment_id,
+              unique: true,
+              name: "rag_document_fragment_id_embeddings_1_1"
+    end
+
+    create_table :ai_document_fragment_embeddings_2_1, id: false do |t|
+      t.integer :rag_document_fragment_id, null: false
+      t.integer :model_version, null: false
+      t.integer :strategy_version, null: false
+      t.text :digest, null: false
+      t.column :embeddings, "vector(1536)", null: false
+      t.timestamps
+
+      t.index :rag_document_fragment_id,
+              unique: true,
+              name: "rag_document_fragment_id_embeddings_2_1"
+    end
+
+    create_table :ai_document_fragment_embeddings_3_1, id: false do |t|
+      t.integer :rag_document_fragment_id, null: false
+      t.integer :model_version, null: false
+      t.integer :strategy_version, null: false
+      t.text :digest, null: false
+      t.column :embeddings, "vector(1024)", null: false
+      t.timestamps
+
+      t.index :rag_document_fragment_id,
+              unique: true,
+              name: "rag_document_fragment_id_embeddings_3_1"
+    end
+
+    create_table :ai_document_fragment_embeddings_4_1, id: false do |t|
+      t.integer :rag_document_fragment_id, null: false
+      t.integer :model_version, null: false
+      t.integer :strategy_version, null: false
+      t.text :digest, null: false
+      t.column :embeddings, "vector(1024)", null: false
+      t.timestamps
+
+      t.index :rag_document_fragment_id,
+              unique: true,
+              name: "rag_document_fragment_id_embeddings_4_1"
+    end
+
+    create_table :ai_document_fragment_embeddings_5_1, id: false do |t|
+      t.integer :rag_document_fragment_id, null: false
+      t.integer :model_version, null: false
+      t.integer :strategy_version, null: false
+      t.text :digest, null: false
+      t.column :embeddings, "vector(768)", null: false
+      t.timestamps
+
+      t.index :rag_document_fragment_id,
+              unique: true,
+              name: "rag_document_fragment_id_embeddings_5_1"
+    end
+
+    create_table :ai_document_fragment_embeddings_6_1, id: false do |t|
+      t.integer :rag_document_fragment_id, null: false
+      t.integer :model_version, null: false
+      t.integer :strategy_version, null: false
+      t.text :digest, null: false
+      t.column :embeddings, "vector(1536)", null: false
+      t.timestamps
+
+      t.index :rag_document_fragment_id,
+              unique: true,
+              name: "rag_document_fragment_id_embeddings_6_1"
+    end
+
+    create_table :ai_document_fragment_embeddings_7_1, id: false do |t|
+      t.integer :rag_document_fragment_id, null: false
+      t.integer :model_version, null: false
+      t.integer :strategy_version, null: false
+      t.text :digest, null: false
+      t.column :embeddings, "vector(2000)", null: false
+      t.timestamps
+
+      t.index :rag_document_fragment_id,
+              unique: true,
+              name: "rag_document_fragment_id_embeddings_7_1"
+    end
+  end
+end

--- a/lib/ai_bot/personas/persona.rb
+++ b/lib/ai_bot/personas/persona.rb
@@ -93,7 +93,7 @@ module DiscourseAi
         end
 
         def id
-          self.class.system_personas[self.class]
+          @ai_persona&.id || self.class.system_personas[self.class]
         end
 
         def tools
@@ -127,13 +127,24 @@ module DiscourseAi
               found.nil? ? match : found.to_s
             end
 
+          prompt_insts = <<~TEXT.strip
+          #{system_insts}
+          #{available_tools.map(&:custom_system_message).compact_blank.join("\n")}
+          TEXT
+
+          fragments_guidance = rag_fragments_prompt(context[:conversation_context].to_a)&.strip
+
+          if fragments_guidance.present?
+            if system_insts.include?("{uploads}")
+              prompt_insts = prompt_insts.gsub("{uploads}", fragments_guidance)
+            else
+              prompt_insts << fragments_guidance
+            end
+          end
+
           prompt =
             DiscourseAi::Completions::Prompt.new(
-              <<~TEXT.strip,
-            #{system_insts}
-            #{available_tools.map(&:custom_system_message).compact_blank.join("\n")}
-            #{rag_fragments_prompt(context[:conversation_context].to_a)}
-          TEXT
+              prompt_insts,
               messages: context[:conversation_context].to_a,
               topic_id: context[:topic_id],
               post_id: context[:post_id],
@@ -203,6 +214,7 @@ module DiscourseAi
           strategy = DiscourseAi::Embeddings::Strategies::Truncation.new
           vector_rep =
             DiscourseAi::Embeddings::VectorRepresentations::Base.current_representation(strategy)
+          reranker = DiscourseAi::Inference::HuggingFaceTextEmbeddings
 
           interactions_vector = vector_rep.vector_from(latest_interactions)
 
@@ -210,7 +222,7 @@ module DiscourseAi
             vector_rep.asymmetric_rag_fragment_similarity_search(
               interactions_vector,
               persona_id: id,
-              limit: 50,
+              limit: reranker.reranker_configured? ? 50 : 10,
               offset: 0,
             )
 
@@ -219,7 +231,7 @@ module DiscourseAi
               :fragment,
             )
 
-          if DiscourseAi::Inference::HuggingFaceTextEmbeddings.reranker_configured?
+          if reranker.reranker_configured?
             ranks =
               DiscourseAi::Inference::HuggingFaceTextEmbeddings
                 .rerank(conversation_context.last[:content], guidance)
@@ -232,19 +244,18 @@ module DiscourseAi
             else
               guidance = ranks.map { |idx| guidance[idx] }
             end
-          else
-            guidance = guidance.take(10)
           end
 
           <<~TEXT
+          <guidance>
           The following texts will give you additional guidance to elaborate a response.
           We included them because we believe they are relevant to this conversation topic.
           Take them into account to elaborate a response.
 
           Texts:
 
-          #{guidance}
-
+          #{guidance.join("\n")}
+          </guidance>
           TEXT
         end
       end

--- a/lib/embeddings/strategies/truncation.rb
+++ b/lib/embeddings/strategies/truncation.rb
@@ -18,6 +18,8 @@ module DiscourseAi
             topic_truncation(target, tokenizer, max_length)
           when Post
             post_truncation(target, tokenizer, max_length)
+          when RagDocumentFragment
+            tokenizer.truncate(target.fragment, max_length)
           else
             raise ArgumentError, "Invalid target type"
           end

--- a/lib/embeddings/vector_representations/base.rb
+++ b/lib/embeddings/vector_representations/base.rb
@@ -260,6 +260,37 @@ module DiscourseAi
           raise MissingEmbeddingError
         end
 
+        def asymmetric_rag_fragment_similarity_search(
+          raw_vector,
+          limit:,
+          offset:,
+          return_distance: false
+        )
+          results = DB.query(<<~SQL, query_embedding: raw_vector, limit: limit, offset: offset)
+            #{probes_sql(post_table_name)}
+            SELECT
+              rag_document_fragment_id,
+              embeddings #{pg_function} '[:query_embedding]' AS distance
+            FROM
+              #{rag_fragments_table_name}
+            INNER JOIN
+              rag_document_fragments AS rdf ON rdf.id = rag_document_fragment_id
+            ORDER BY
+              embeddings #{pg_function} '[:query_embedding]'
+            LIMIT :limit
+            OFFSET :offset
+          SQL
+
+          if return_distance
+            results.map { |r| [r.rag_document_fragment_id, r.distance] }
+          else
+            results.map(&:rag_document_fragment_id)
+          end
+        rescue PG::Error => e
+          Rails.logger.error("Error #{e} querying embeddings for model #{name}")
+          raise MissingEmbeddingError
+        end
+
         def symmetric_topics_similarity_search(topic)
           DB.query(<<~SQL, topic_id: topic.id).map(&:topic_id)
             #{probes_sql(topic_table_name)}

--- a/lib/inference/hugging_face_text_embeddings.rb
+++ b/lib/inference/hugging_face_text_embeddings.rb
@@ -56,6 +56,11 @@ module ::DiscourseAi
           JSON.parse(response.body, symbolize_names: true)
         end
 
+        def reranker_configured?
+          SiteSetting.ai_hugging_face_tei_reranker_endpoint.present? ||
+            SiteSetting.ai_hugging_face_tei_reranker_endpoint_srv.present?
+        end
+
         def configured?
           SiteSetting.ai_hugging_face_tei_endpoint.present? ||
             SiteSetting.ai_hugging_face_tei_endpoint_srv.present?

--- a/plugin.rb
+++ b/plugin.rb
@@ -10,6 +10,7 @@
 
 gem "tokenizers", "0.4.3"
 gem "tiktoken_ruby", "0.0.7"
+gem "baran", "0.1.10"
 
 enabled_site_setting :discourse_ai_enabled
 

--- a/spec/fabricators/rag_document_fragment_fabricator.rb
+++ b/spec/fabricators/rag_document_fragment_fabricator.rb
@@ -3,6 +3,5 @@
 Fabricator(:rag_document_fragment) do
   fragment { sequence(:fragment) { |n| "Document fragment #{n}" } }
   upload
-  ai_persona
   fragment_number { sequence(:fragment_number) { |n| n + 1 } }
 end

--- a/spec/fabricators/rag_document_fragment_fabricator.rb
+++ b/spec/fabricators/rag_document_fragment_fabricator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Fabricator(:rag_document_fragment) do
+  fragment { sequence(:fragment) { |n| "Document fragment #{n}" } }
+  upload
+  ai_persona
+  fragment_number { sequence(:fragment_number) { |n| n + 1 } }
+end

--- a/spec/jobs/regular/digest_rag_upload_spec.rb
+++ b/spec/jobs/regular/digest_rag_upload_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Jobs::DigestRagUpload do
   fab!(:persona) { Fabricate(:ai_persona) }
-  fab!(:upload) { Fabricate(:upload) }
+  fab!(:upload)
 
   let(:document_file) { StringIO.new("some text" * 200) }
 
@@ -24,7 +24,7 @@ RSpec.describe Jobs::DigestRagUpload do
   end
 
   describe "#execute" do
-    context "Processing an upload for the first time" do
+    context "when processing an upload for the first time" do
       before { File.expects(:open).returns(document_file) }
 
       it "splits an upload into chunks" do

--- a/spec/jobs/regular/digest_rag_upload_spec.rb
+++ b/spec/jobs/regular/digest_rag_upload_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::DigestRagUpload do
+  fab!(:persona) { Fabricate(:ai_persona) }
+  fab!(:upload) { Fabricate(:upload) }
+
+  let(:document_file) { StringIO.new("some text" * 200) }
+
+  let(:truncation) { DiscourseAi::Embeddings::Strategies::Truncation.new }
+  let(:vector_rep) do
+    DiscourseAi::Embeddings::VectorRepresentations::Base.current_representation(truncation)
+  end
+
+  let(:expected_embedding) { [0.0038493] * vector_rep.dimensions }
+
+  before do
+    SiteSetting.ai_embeddings_enabled = true
+    SiteSetting.ai_embeddings_discourse_service_api_endpoint = "http://test.com"
+
+    WebMock.stub_request(
+      :post,
+      "#{SiteSetting.ai_embeddings_discourse_service_api_endpoint}/api/v1/classify",
+    ).to_return(status: 200, body: JSON.dump(expected_embedding))
+  end
+
+  describe "#execute" do
+    context "Processing an upload for the first time" do
+      before { File.expects(:open).returns(document_file) }
+
+      it "splits an upload into chunks" do
+        subject.execute(upload_id: upload.id, ai_persona_id: persona.id)
+
+        created_fragment = RagDocumentFragment.last
+
+        expect(created_fragment).to be_present
+        expect(created_fragment.fragment).to be_present
+        expect(created_fragment.fragment_number).to eq(2)
+      end
+
+      it "queue jobs to generate embeddings for each fragment" do
+        expect { subject.execute(upload_id: upload.id, ai_persona_id: persona.id) }.to change(
+          Jobs::GenerateRagEmbeddings.jobs,
+          :size,
+        ).by(1)
+      end
+    end
+
+    it "doesn't generate new fragments if we already processed the upload" do
+      Fabricate(:rag_document_fragment, upload: upload, ai_persona: persona)
+      previous_count = RagDocumentFragment.where(upload: upload, ai_persona: persona).count
+
+      subject.execute(upload_id: upload.id, ai_persona_id: persona.id)
+      updated_count = RagDocumentFragment.where(upload: upload, ai_persona: persona).count
+
+      expect(updated_count).to eq(previous_count)
+    end
+  end
+end

--- a/spec/jobs/regular/generate_rag_embeddings_spec.rb
+++ b/spec/jobs/regular/generate_rag_embeddings_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::GenerateRagEmbeddings do
+  describe "#execute" do
+    let(:truncation) { DiscourseAi::Embeddings::Strategies::Truncation.new }
+    let(:vector_rep) do
+      DiscourseAi::Embeddings::VectorRepresentations::Base.current_representation(truncation)
+    end
+
+    let(:expected_embedding) { [0.0038493] * vector_rep.dimensions }
+
+    fab!(:ai_persona)
+
+    fab!(:rag_document_fragment_1) { Fabricate(:rag_document_fragment, ai_persona: ai_persona) }
+    fab!(:rag_document_fragment_2) { Fabricate(:rag_document_fragment, ai_persona: ai_persona) }
+
+    before do
+      SiteSetting.ai_embeddings_enabled = true
+      SiteSetting.ai_embeddings_discourse_service_api_endpoint = "http://test.com"
+
+      WebMock.stub_request(
+        :post,
+        "#{SiteSetting.ai_embeddings_discourse_service_api_endpoint}/api/v1/classify",
+      ).to_return(status: 200, body: JSON.dump(expected_embedding))
+    end
+
+    it "generates a new vector for each fragment" do
+      expected_embeddings = 2
+
+      subject.execute(fragment_ids: [rag_document_fragment_1.id, rag_document_fragment_2.id])
+
+      embeddings_count =
+        DB.query_single("SELECT COUNT(*) from #{vector_rep.rag_fragments_table_name}").first
+
+      expect(embeddings_count).to eq(expected_embeddings)
+    end
+  end
+end

--- a/spec/models/rag_document_fragment_spec.rb
+++ b/spec/models/rag_document_fragment_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe RagDocumentFragment do
   fab!(:upload_1) { Fabricate(:upload) }
   fab!(:upload_2) { Fabricate(:upload) }
 
+  before do
+    SiteSetting.ai_embeddings_enabled = true
+    SiteSetting.ai_embeddings_discourse_service_api_endpoint = "http://test.com"
+  end
+
   describe ".link_uploads_and_persona" do
     it "does nothing if there is no persona" do
       expect { described_class.link_persona_and_uploads(nil, [upload_1.id]) }.not_to change(

--- a/spec/models/rag_document_fragment_spec.rb
+++ b/spec/models/rag_document_fragment_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe RagDocumentFragment do
+  fab!(:persona) { Fabricate(:ai_persona) }
+  fab!(:upload_1) { Fabricate(:upload) }
+  fab!(:upload_2) { Fabricate(:upload) }
+
+  describe ".link_uploads_and_persona" do
+    it "does nothing if there is no persona" do
+      expect { described_class.link_persona_and_uploads(nil, [upload_1.id]) }.not_to change(
+        Jobs::DigestRagUpload.jobs,
+        :size,
+      )
+    end
+
+    it "does nothing if there are no uploads" do
+      expect { described_class.link_persona_and_uploads(persona, []) }.not_to change(
+        Jobs::DigestRagUpload.jobs,
+        :size,
+      )
+    end
+
+    it "queues a job for each upload to generate fragments" do
+      expect {
+        described_class.link_persona_and_uploads(persona, [upload_1.id, upload_2.id])
+      }.to change(Jobs::DigestRagUpload.jobs, :size).by(2)
+    end
+
+    it "creates references between the persona an each upload" do
+      described_class.link_persona_and_uploads(persona, [upload_1.id, upload_2.id])
+
+      refs = UploadReference.where(target: persona).pluck(:upload_id)
+
+      expect(refs).to contain_exactly(upload_1.id, upload_2.id)
+    end
+  end
+
+  describe ".update_persona_uploads" do
+    it "does nothing if there is no persona" do
+      expect { described_class.update_persona_uploads(nil, [upload_1.id]) }.not_to change(
+        Jobs::DigestRagUpload.jobs,
+        :size,
+      )
+    end
+
+    it "deletes the fragment if its not present in the uploads list" do
+      fragment = Fabricate(:rag_document_fragment, ai_persona: persona)
+
+      described_class.update_persona_uploads(persona, [])
+
+      expect { fragment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "delete references between the upload and the persona" do
+      described_class.link_persona_and_uploads(persona, [upload_1.id, upload_2.id])
+
+      described_class.update_persona_uploads(persona, [upload_2.id])
+
+      refs = UploadReference.where(target: persona).pluck(:upload_id)
+
+      expect(refs).to contain_exactly(upload_2.id)
+    end
+
+    it "queues jobs to generate new fragments" do
+      expect { described_class.update_persona_uploads(persona, [upload_1.id]) }.to change(
+        Jobs::DigestRagUpload.jobs,
+        :size,
+      ).by(1)
+    end
+  end
+end

--- a/spec/requests/admin/ai_personas_controller_spec.rb
+++ b/spec/requests/admin/ai_personas_controller_spec.rb
@@ -125,6 +125,21 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
       expect(response).to be_successful
       expect(response.parsed_body["ai_persona"]["name"]).to eq(ai_persona.name)
     end
+
+    it "includes rag uploads for each persona" do
+      upload = Fabricate(:upload)
+      RagDocumentFragment.link_persona_and_uploads(ai_persona, [upload.id])
+
+      get "/admin/plugins/discourse-ai/ai-personas/#{ai_persona.id}.json"
+      expect(response).to be_successful
+
+      serialized_persona = response.parsed_body["ai_persona"]
+
+      expect(serialized_persona.dig("rag_uploads", 0, "id")).to eq(upload.id)
+      expect(serialized_persona.dig("rag_uploads", 0, "original_filename")).to eq(
+        upload.original_filename,
+      )
+    end
   end
 
   describe "POST #create" do
@@ -320,6 +335,17 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to include("application/json")
       end
+    end
+  end
+
+  describe "POST #upload_file" do
+    it "works" do
+      post "/admin/plugins/discourse-ai/ai-personas/files/upload.json",
+           params: {
+             file: Rack::Test::UploadedFile.new(file_from_fixtures("spec.txt", "md")),
+           }
+
+      expect(response.status).to eq(200)
     end
   end
 

--- a/spec/requests/admin/ai_personas_controller_spec.rb
+++ b/spec/requests/admin/ai_personas_controller_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
   fab!(:admin)
   fab!(:ai_persona)
 
-  before { sign_in(admin) }
+  before do
+    sign_in(admin)
+
+    SiteSetting.ai_embeddings_enabled = true
+    SiteSetting.ai_embeddings_discourse_service_api_endpoint = "http://test.com"
+  end
 
   describe "GET #index" do
     it "returns a success response" do

--- a/test/javascripts/unit/models/ai-persona-test.js
+++ b/test/javascripts/unit/models/ai-persona-test.js
@@ -48,6 +48,7 @@ module("Discourse AI | Unit | Model | ai-persona", function () {
       max_context_posts: 5,
       vision_enabled: true,
       vision_max_pixels: 100,
+      rag_uploads: [],
     };
 
     const aiPersona = AiPersona.create({ ...properties });
@@ -81,6 +82,7 @@ module("Discourse AI | Unit | Model | ai-persona", function () {
       max_context_posts: 5,
       vision_enabled: true,
       vision_max_pixels: 100,
+      rag_uploads: [],
     };
 
     const aiPersona = AiPersona.create({ ...properties });


### PR DESCRIPTION
This PR lets you associate uploads to an AI persona, which we'll split and generate embeddings from. When building the system prompt to get a bot reply, we'll do a similarity search followed by a re-ranking (if available). This will let us find the most relevant fragments from the body of knowledge you associated with the persona, resulting in better, more informed responses.

For now, we'll only allow plain-text files, but this will change in the future.