### PR TITLE
FIX: mention suppression was not working right

### DIFF
--- a/lib/automation/report_runner.rb
+++ b/lib/automation/report_runner.rb
@@ -237,6 +237,10 @@ Follow the provided writing composition instructions carefully and precisely ste
         parsed
           .css("a")
           .each do |a|
+            if a["class"] == "mention"
+              a.inner_html = a.inner_html.sub("@", "")
+              next
+            end
             href = a["href"]
             if href.present? && (href.start_with?("#{Discourse.base_url}") || href.start_with?("/"))
               begin
@@ -253,13 +257,6 @@ Follow the provided writing composition instructions carefully and precisely ste
                 # skip
               end
             end
-          end
-
-        parsed
-          .css("span.mention")
-          .each do |mention|
-            no_at_username = mention.text.sub("@", "")
-            mention.replace("<a href='/u/#{no_at_username}' class='mention'>#{no_at_username}</a>")
           end
 
         parsed.to_html

--- a/lib/summarization/models/anthropic.rb
+++ b/lib/summarization/models/anthropic.rb
@@ -9,7 +9,8 @@ module DiscourseAi
         end
 
         def correctly_configured?
-          SiteSetting.ai_anthropic_api_key.present?
+          SiteSetting.ai_anthropic_api_key.present? ||
+          DiscourseAi::Completions::Endpoints::AwsBedrock.correctly_configured?("claude-2")
         end
 
         def configuration_hint

--- a/lib/summarization/models/anthropic.rb
+++ b/lib/summarization/models/anthropic.rb
@@ -10,7 +10,7 @@ module DiscourseAi
 
         def correctly_configured?
           SiteSetting.ai_anthropic_api_key.present? ||
-          DiscourseAi::Completions::Endpoints::AwsBedrock.correctly_configured?("claude-2")
+            DiscourseAi::Completions::Endpoints::AwsBedrock.correctly_configured?("claude-2")
         end
 
         def configuration_hint

--- a/spec/lib/modules/automation/report_runner_spec.rb
+++ b/spec/lib/modules/automation/report_runner_spec.rb
@@ -82,8 +82,10 @@ module DiscourseAi
         end
 
         it "can suppress notifications by remapping content" do
+          user = Fabricate(:user)
+
           markdown = <<~MD
-            @sam is a person
+            @#{user.username} is a person
             [test1](/test) is an internal link
             [test2](/test?1=2) is an internal link
             [test3](https://example.com) is an external link
@@ -117,7 +119,7 @@ module DiscourseAi
 
           # note, magic surprise &amp; is correct HTML 5 representation
           expected = <<~HTML
-            <p><a href="/u/sam" class="mention">sam</a> is a person<br>
+            <p><a class="mention" href="/u/#{user.username}">#{user.username}</a> is a person<br>
             <a href="/test?silent=true">test1</a> is an internal link<br>
             <a href="/test?1=2&amp;silent=true">test2</a> is an internal link<br>
             <a href="https://example.com" rel="noopener nofollow ugc">test3</a> is an external link<br>
@@ -127,7 +129,10 @@ module DiscourseAi
             <a href="//%5B%5Btest?silent=true" rel="noopener nofollow ugc">test7</a> is a link with an invalid URL</p>
           HTML
 
-          expect(report.ordered_posts.first.raw.strip).to eq(expected.strip)
+          post = report.ordered_posts.first
+
+          expect(post.mentions.to_a).to eq([])
+          expect(post.raw.strip).to eq(expected.strip)
         end
 
         it "can exclude tags" do


### PR DESCRIPTION
We were only suppressing non mentions, ones that become spans.

@sam in the test was not resolving to a mention cause the user
did not exist.

depends on: https://github.com/discourse/discourse/pull/26253

For tests to pass.
