### PR TITLE
FIX: prompt engineering for summary prompt

### DIFF
--- a/lib/automation/report_runner.rb
+++ b/lib/automation/report_runner.rb
@@ -140,10 +140,7 @@ Follow the provided writing composition instructions carefully and precisely ste
         prompt =
           DiscourseAi::Completions::Prompt.new(
             system_prompt,
-            messages: [
-              { type: :user, content: input },
-              { type: :model, content: "Here is the report I generated for you" },
-            ],
+            messages: [{ type: :user, content: input }],
           )
 
         result = +""


### PR DESCRIPTION
Prompt was steering incorrectly into the wrong language.

New prompt attempts to be more concise and clear and provides
better guidance about size of summary and how to format it.
