### PR TITLE
FIX: Avoid replying to the reply user for llm_triage automation

### DIFF
--- a/discourse_automation/llm_triage.rb
+++ b/discourse_automation/llm_triage.rb
@@ -36,6 +36,13 @@ if defined?(DiscourseAutomation)
 
     script do |context, fields|
       post = context["post"]
+      canned_reply = fields.dig("canned_reply", "value")
+      canned_reply_user = fields.dig("canned_reply_user", "value")
+
+      # nothing to do if we already replied
+      next if post.user.username == canned_reply_user
+      next if post.raw.strip == canned_reply.to_s.strip
+
       system_prompt = fields["system_prompt"]["value"]
       search_for_text = fields["search_for_text"]["value"]
       model = fields["model"]["value"]
@@ -49,15 +56,6 @@ if defined?(DiscourseAutomation)
       tags = fields.dig("tags", "value")
       hide_topic = fields.dig("hide_topic", "value")
       flag_post = fields.dig("flag_post", "value")
-      canned_reply = fields.dig("canned_reply", "value")
-      canned_reply_user = fields.dig("canned_reply_user", "value")
-
-      next if post.user.username == canned_reply_user
-
-      if post.raw.strip == canned_reply.to_s.strip
-        # nothing to do if we already replied
-        next
-      end
 
       begin
         DiscourseAi::Automation::LlmTriage.handle(

--- a/discourse_automation/llm_triage.rb
+++ b/discourse_automation/llm_triage.rb
@@ -34,7 +34,7 @@ if defined?(DiscourseAutomation)
     field :canned_reply, component: :message
     field :canned_reply_user, component: :user
 
-    script do |context, fields, automation|
+    script do |context, fields|
       post = context["post"]
       system_prompt = fields["system_prompt"]["value"]
       search_for_text = fields["search_for_text"]["value"]
@@ -51,6 +51,10 @@ if defined?(DiscourseAutomation)
       flag_post = fields.dig("flag_post", "value")
       canned_reply = fields.dig("canned_reply", "value")
       canned_reply_user = fields.dig("canned_reply_user", "value")
+
+      if post.user.username == canned_reply_user
+        next
+      end
 
       if post.raw.strip == canned_reply.to_s.strip
         # nothing to do if we already replied

--- a/discourse_automation/llm_triage.rb
+++ b/discourse_automation/llm_triage.rb
@@ -52,9 +52,7 @@ if defined?(DiscourseAutomation)
       canned_reply = fields.dig("canned_reply", "value")
       canned_reply_user = fields.dig("canned_reply_user", "value")
 
-      if post.user.username == canned_reply_user
-        next
-      end
+      next if post.user.username == canned_reply_user
 
       if post.raw.strip == canned_reply.to_s.strip
         # nothing to do if we already replied


### PR DESCRIPTION
The "Triage posts using AI" automation allows admins to set a "Reply User" to represent the generated response.

When the "Reply User" is not a bot and creates a reply, the automation will be triggered again. This causes an infinite conversation from the reply_user to the reply_user.

This PR ignores posts from the "Reply User"

Here's an idea of what the full automation looks like (no change):
<img width="339" alt="Screenshot 2024-03-22 at 12 09 47 PM" src="https://github.com/discourse/discourse-ai/assets/1555215/d602c8ca-94a2-4340-8288-8a61a0584fc8">
