### PR TITLE
FIX: Secure/unsecure uploads when sharing AI conversations

### DIFF
--- a/app/controllers/discourse_ai/ai_bot/shared_ai_conversations_controller.rb
+++ b/app/controllers/discourse_ai/ai_bot/shared_ai_conversations_controller.rb
@@ -26,7 +26,9 @@ module DiscourseAi
 
       def destroy
         ensure_allowed_destroy!
-        @shared_conversation.destroy
+
+        SharedAiConversation.destroy_conversation(@shared_conversation)
+
         render json:
                  success_json.merge(message: I18n.t("discourse_ai.share_ai.conversation_deleted"))
       end

--- a/app/jobs/regular/shared_conversation_adjust_upload_security.rb
+++ b/app/jobs/regular/shared_conversation_adjust_upload_security.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module ::Jobs
+  class SharedConversationAdjustUploadSecurity < ::Jobs::Base
+    def execute(args)
+      # The conversation context includes post cooked content so this
+      # must be updated when target uploads security changes.
+      update_conversation(args[:conversation_id]) if args[:conversation_id].present?
+
+      # If we deleted the conversation then we just need to update the target's
+      # uploads security, no need to update the conversation.
+      if args[:target_id].present? && args[:target_type].present?
+        update_target(args[:target_id], args[:target_type])
+      end
+    end
+
+    def update_conversation(conversation_id)
+      conversation = SharedAiConversation.find(conversation_id)
+      return if conversation.blank?
+
+      # NOTE: Only Topics are supported for now, in future we will need a more flexible
+      # way of doing this.
+      if conversation.target_type == "Topic"
+        rebaked_posts = TopicUploadSecurityManager.new(conversation.target).run
+
+        if rebaked_posts.any?
+          new_context =
+            conversation.context.map do |context_post|
+              rebaked_post = rebaked_posts.find { |p| p.id == context_post["id"] }
+              context_post[:cooked] = rebaked_post.cooked if rebaked_post
+              context_post
+            end
+
+          conversation.update!(context: new_context)
+        end
+      end
+    end
+
+    def update_target(target_id, target_type)
+      # NOTE: Only Topics are supported for now, in future we will need a more flexible
+      # way of doing this.
+      if target_type == "Topic"
+        topic = target_type.constantize.find_by(id: target_id)
+        return if topic.blank?
+        TopicUploadSecurityManager.new(topic).run
+      end
+    end
+  end
+end

--- a/app/jobs/regular/shared_conversation_adjust_upload_security.rb
+++ b/app/jobs/regular/shared_conversation_adjust_upload_security.rb
@@ -3,19 +3,21 @@
 module ::Jobs
   class SharedConversationAdjustUploadSecurity < ::Jobs::Base
     def execute(args)
-      # The conversation context includes post cooked content so this
-      # must be updated when target uploads security changes.
-      update_conversation(args[:conversation_id]) if args[:conversation_id].present?
-
-      # If we deleted the conversation then we just need to update the target's
-      # uploads security, no need to update the conversation.
-      if args[:target_id].present? && args[:target_type].present?
+      if args[:conversation_id].present?
+        # The conversation context includes post cooked content so this
+        # must be updated when target uploads security changes.
+        update_conversation(args[:conversation_id])
+      elsif args[:target_id].present? && args[:target_type].present?
+        # If we deleted the conversation then we just need to update the target's
+        # uploads security, no need to update the conversation.
         update_target(args[:target_id], args[:target_type])
       end
     end
 
+    private
+
     def update_conversation(conversation_id)
-      conversation = SharedAiConversation.find(conversation_id)
+      conversation = SharedAiConversation.find_by(id: conversation_id)
       return if conversation.blank?
 
       # NOTE: Only Topics are supported for now, in future we will need a more flexible
@@ -27,11 +29,11 @@ module ::Jobs
           new_context =
             conversation.context.map do |context_post|
               rebaked_post = rebaked_posts.find { |p| p.id == context_post["id"] }
-              context_post[:cooked] = rebaked_post.cooked if rebaked_post
+              context_post["cooked"] = rebaked_post.cooked if rebaked_post
               context_post
             end
 
-          conversation.update!(context: new_context)
+          conversation.update(context: new_context)
         end
       end
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -65,11 +65,7 @@ after_initialize do
 
   reloadable_patch { |plugin| Guardian.prepend DiscourseAi::GuardianExtensions }
 
-  register_modifier(:post_with_secure_uploads?) do |_, _, topic|
-    if SharedAiConversation.exists?(target: topic)
-      false
-    else
-      nil
-    end
+  register_modifier(:post_should_secure_uploads?) do |_, _, topic|
+    false if topic.private_message? && SharedAiConversation.exists?(target: topic)
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -64,4 +64,12 @@ after_initialize do
   end
 
   reloadable_patch { |plugin| Guardian.prepend DiscourseAi::GuardianExtensions }
+
+  register_modifier(:post_with_secure_uploads?) do |_, _, topic|
+    if SharedAiConversation.exists?(target: topic)
+      false
+    else
+      nil
+    end
+  end
 end

--- a/spec/jobs/shared_conversation_adjust_upload_security_spec.rb
+++ b/spec/jobs/shared_conversation_adjust_upload_security_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::SharedConversationAdjustUploadSecurity do
+  let(:params) { {} }
+
+  fab!(:bot_user) do
+    SiteSetting.discourse_ai_enabled = true
+    SiteSetting.ai_bot_enabled_chat_bots = "claude-2"
+    SiteSetting.ai_bot_enabled = true
+    SiteSetting.ai_bot_allowed_groups = "10"
+    SiteSetting.ai_bot_public_sharing_allowed_groups = "10"
+    User.find(DiscourseAi::AiBot::EntryPoint::CLAUDE_V2_ID)
+  end
+  fab!(:user)
+  fab!(:topic) { Fabricate(:private_message_topic, user: user, recipient: bot_user) }
+  fab!(:post_1) { Fabricate(:post, topic: topic, user: bot_user) }
+  fab!(:post_2) { Fabricate(:post, topic: topic, user: user) }
+  fab!(:conversation) { SharedAiConversation.share_conversation(user, topic) }
+
+  def run_job
+    described_class.new.execute(params)
+  end
+
+  context "when conversation is created" do
+    let(:params) { { conversation_id: conversation.id } }
+
+    it "does nothing for a conversation that has been deleted before the job ran" do
+      conversation.destroy
+      SharedAiConversation.any_instance.expects(:update).never
+      run_job
+    end
+
+    it "does nothing if there weren't any posts with secure uploads in the topic" do
+      original_context = conversation.context
+      run_job
+      expect(conversation.reload.context).to eq(original_context)
+    end
+
+    context "when topic posts were rebaked because they had secure uploads" do
+      it "updates the conversation cooked post content after rebaking" do
+        post_2.update!(raw: "some new rebaked content")
+        TopicUploadSecurityManager.any_instance.expects(:run).returns([post_2])
+        original_context = conversation.context
+        run_job
+        expect(conversation.reload.context).not_to eq(original_context)
+      end
+    end
+  end
+
+  context "when conversation has been deleted" do
+    let(:params) { { target_id: topic.id, target_type: "Topic" } }
+
+    before { conversation.destroy! }
+
+    it "runs the topic upload security manager but doesn't attempt to update a conversation" do
+      SharedAiConversation.any_instance.expects(:update).never
+      TopicUploadSecurityManager.any_instance.expects(:run).once
+      run_job
+    end
+
+    it "doesn't attempt to run the topic upload security manager if the topic has been deleted" do
+      TopicUploadSecurityManager.any_instance.expects(:run).never
+      topic.trash!
+      run_job
+    end
+  end
+end


### PR DESCRIPTION
This commit uses a new plugin modifier introduced in https://github.com/discourse/discourse/pull/26508
to mark all uploads as _not_ secure in shared PM AI conversations.
This is so images created by the AI bot (or uploaded by the user)
do not end up as broken URLs because of the security requirements
around them.

This relies on the TopicUploadSecurityManager in core as well,
which is fired when an AI conversation is shared or deleted.

**Relies on the core PR mentioned above to be merged first.**
