### PR TITLE
FIX: Revert length issue

### DIFF
--- a/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
+++ b/assets/javascripts/discourse/connectors/after-d-editor/ai-helper-context-menu.js
@@ -338,11 +338,11 @@ export default class AiHelperContextMenu extends Component {
   undoAIAction() {
     if (this.capabilities.isFirefox) {
       // execCommand("undo") is no not supported in Firefox so we insert old text at range
-      this._insertAt(
-        this.lastSelectionRange.x,
-        this.lastSelectionRange.y,
-        this.initialValue
-      );
+      // we also need to calculate the length diffrence between the old and new text
+      const lengthDifference =
+        this.selectedText.length - this.initialValue.length;
+      const end = this.lastSelectionRange.y - lengthDifference;
+      this._insertAt(this.lastSelectionRange.x, end, this.initialValue);
     } else {
       document.execCommand("undo", false, null);
     }


### PR DESCRIPTION
This PR fixes an issue with AI composer helper's revert button in Firefox.

Previously, if you proofread text and revert the text, there will be extra chars remaining from the suggested text.

This PR resolves that issue by accommodating for the length difference between the chars.

No spec because this is a Firefox specific issue and difficult to test for this unique case.