### PR TITLE
FEATURE: Cohere Command R support

### DIFF
--- a/app/models/ai_api_audit_log.rb
+++ b/app/models/ai_api_audit_log.rb
@@ -7,6 +7,7 @@ class AiApiAuditLog < ActiveRecord::Base
     HuggingFaceTextGeneration = 3
     Gemini = 4
     Vllm = 5
+    Cohere = 6
   end
 end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -266,6 +266,7 @@ en:
           claude-3-opus: "Claude 3 Opus"
           claude-3-sonnet: "Claude 3 Sonnet"
           claude-3-haiku: "Claude 3 Haiku"
+          cohere-command-r-plus: "Cohere Command R Plus"
           gpt-4: "GPT-4"
           gpt-4-turbo: "GPT-4 Turbo"
           gpt-3:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -50,6 +50,7 @@ en:
     ai_openai_embeddings_url: "Custom URL used for the OpenAI embeddings API. (in the case of Azure it can be: https://COMPANY.openai.azure.com/openai/deployments/DEPLOYMENT/embeddings?api-version=2023-05-15)"
     ai_openai_api_key: "API key for OpenAI API"
     ai_anthropic_api_key: "API key for Anthropic API"
+    ai_cohere_api_key: "API key for Cohere API"
     ai_hugging_face_api_url: "Custom URL used for OpenSource LLM inference. Compatible with https://github.com/huggingface/text-generation-inference"
     ai_hugging_face_api_key: API key for Hugging Face API
     ai_hugging_face_token_limit: Max tokens Hugging Face API can use per request

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -110,6 +110,9 @@ discourse_ai:
   ai_anthropic_api_key:
     default: ""
     secret: true
+  ai_cohere_api_key:
+    default: ""
+    secret: true
   ai_stability_api_key:
     default: ""
     secret: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -338,6 +338,7 @@ discourse_ai:
       - claude-3-opus
       - claude-3-sonnet
       - claude-3-haiku
+      - cohere-command-r-plus
   ai_bot_add_to_header:
     default: true
     client: true

--- a/lib/ai_bot/bot.rb
+++ b/lib/ai_bot/bot.rb
@@ -180,6 +180,8 @@ module DiscourseAi
         when DiscourseAi::AiBot::EntryPoint::CLAUDE_3_OPUS_ID
           # no bedrock support yet 18-03
           "anthropic:claude-3-opus"
+        when DiscourseAi::AiBot::EntryPoint::COHERE_COMMAND_R_PLUS
+          "cohere:command-r-plus"
         when DiscourseAi::AiBot::EntryPoint::CLAUDE_3_SONNET_ID
           if DiscourseAi::Completions::Endpoints::AwsBedrock.correctly_configured?(
                "claude-3-sonnet",

--- a/lib/ai_bot/entry_point.rb
+++ b/lib/ai_bot/entry_point.rb
@@ -17,6 +17,7 @@ module DiscourseAi
       CLAUDE_3_OPUS_ID = -117
       CLAUDE_3_SONNET_ID = -118
       CLAUDE_3_HAIKU_ID = -119
+      COHERE_COMMAND_R_PLUS = -120
 
       BOTS = [
         [GPT4_ID, "gpt4_bot", "gpt-4"],
@@ -29,6 +30,7 @@ module DiscourseAi
         [CLAUDE_3_OPUS_ID, "claude_3_opus_bot", "claude-3-opus"],
         [CLAUDE_3_SONNET_ID, "claude_3_sonnet_bot", "claude-3-sonnet"],
         [CLAUDE_3_HAIKU_ID, "claude_3_haiku_bot", "claude-3-haiku"],
+        [COHERE_COMMAND_R_PLUS, "cohere_command_bot", "cohere-command-r-plus"],
       ]
 
       BOT_USER_IDS = BOTS.map(&:first)
@@ -67,6 +69,8 @@ module DiscourseAi
           CLAUDE_3_SONNET_ID
         in "claude-3-haiku"
           CLAUDE_3_HAIKU_ID
+        in "cohere-command-r-plus"
+          COHERE_COMMAND_R_PLUS
         else
           nil
         end

--- a/lib/completions/dialects/command.rb
+++ b/lib/completions/dialects/command.rb
@@ -57,7 +57,12 @@ module DiscourseAi
 
           tools_prompt = build_tools_prompt
           prompt[:preamble] = +"#{system_message}"
-          prompt[:preamble] << "\n#{tools_prompt}" if tools_prompt.present?
+          if tools_prompt.present?
+            prompt[:preamble] << "\n#{tools_prompt}"
+            prompt[
+              :preamble
+            ] << "\nNEVER attempt to run tools using JSON, always use XML. Lives depend on it."
+          end
 
           prompt[:chat_history] = chat_history if chat_history.present?
 

--- a/lib/completions/dialects/command.rb
+++ b/lib/completions/dialects/command.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# see: https://docs.cohere.com/reference/chat
+#
+module DiscourseAi
+  module Completions
+    module Dialects
+      class Command < Dialect
+        class << self
+          def can_translate?(model_name)
+            %w[command-light command command-r command-r-plus].include?(model_name)
+          end
+
+          def tokenizer
+            DiscourseAi::Tokenizer::OpenAiTokenizer
+          end
+        end
+
+        VALID_ID_REGEX = /\A[a-zA-Z0-9_]+\z/
+
+        def translate
+          messages = prompt.messages
+
+          # ChatGPT doesn't use an assistant msg to improve long-context responses.
+          if messages.last[:type] == :model
+            messages = messages.dup
+            messages.pop
+          end
+
+          trimmed_messages = trim_messages(messages)
+
+          chat_history = []
+          system_message = nil
+
+          prompt = {}
+
+          trimmed_messages.each do |msg|
+            if msg[:type] == :system
+              if system_message
+                chat_history << { role: "SYSTEM", message: msg[:content] }
+              else
+                system_message = msg
+              end
+            elsif msg[:type] == :model
+              chat_history << { role: "CHATBOT", message: msg[:content] }
+            elsif msg[:type] == :tool_call
+              call_details = JSON.parse(msg[:content], symbolize_names: true)
+              call_details[:arguments] = call_details[:arguments].to_json
+              call_details[:name] = msg[:name]
+
+              {
+                role: "assistant",
+                content: nil,
+                tool_calls: [{ type: "function", function: call_details, id: msg[:id] }],
+              }
+            elsif msg[:type] == :tool
+              { role: "tool", tool_call_id: msg[:id], content: msg[:content], name: msg[:name] }
+            else
+              user_message = { role: "USER", message: msg[:content] }
+              user_message[:message] = "#{msg[:id]}: #{msg[:content]}" if msg[:id]
+              chat_history << user_message
+            end
+          end
+
+          prompt[:preamble] = system_message[:content] if system_message
+
+          prompt[:chat_history] = chat_history if chat_history.present?
+
+          chat_history.reverse_each do |msg|
+            if msg[:role] == "USER"
+              prompt[:message] = msg[:message]
+              chat_history.delete(msg)
+              break
+            end
+          end
+
+          prompt
+        end
+
+        def tools
+          prompt.tools.map do |t|
+            tool = t.dup
+
+            tool[:parameters] = t[:parameters]
+              .to_a
+              .reduce({ type: "object", properties: {}, required: [] }) do |memo, p|
+                name = p[:name]
+                memo[:required] << name if p[:required]
+
+                memo[:properties][name] = p.except(:name, :required, :item_type)
+
+                memo[:properties][name][:items] = { type: p[:item_type] } if p[:item_type]
+                memo
+              end
+
+            { type: "function", function: tool }
+          end
+        end
+
+        def max_prompt_tokens
+          # provide a buffer of 120 tokens - our function counting is not
+          # 100% accurate and getting numbers to align exactly is very hard
+          buffer = (opts[:max_tokens] || 2500) + 50
+
+          if tools.present?
+            # note this is about 100 tokens over, OpenAI have a more optimal representation
+            @function_size ||= self.class.tokenizer.size(tools.to_json.to_s)
+            buffer += @function_size
+          end
+
+          model_max_tokens - buffer
+        end
+
+        private
+
+        def per_message_overhead
+          # open ai defines about 4 tokens per message of overhead
+          4
+        end
+
+        def calculate_message_token(context)
+          self.class.tokenizer.size(context[:content].to_s + context[:name].to_s)
+        end
+
+        def model_max_tokens
+          case model_name
+          when "command-light"
+            4096
+          when "command"
+            8192
+          when "command-r"
+            131_072
+          when "command-r-plus"
+            131_072
+          else
+            8192
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/completions/dialects/dialect.rb
+++ b/lib/completions/dialects/dialect.rb
@@ -17,6 +17,7 @@ module DiscourseAi
               DiscourseAi::Completions::Dialects::Gemini,
               DiscourseAi::Completions::Dialects::Mixtral,
               DiscourseAi::Completions::Dialects::Claude,
+              DiscourseAi::Completions::Dialects::Command,
             ]
 
             if Rails.env.test? || Rails.env.development?

--- a/lib/completions/endpoints/base.rb
+++ b/lib/completions/endpoints/base.rb
@@ -16,6 +16,7 @@ module DiscourseAi
               DiscourseAi::Completions::Endpoints::Gemini,
               DiscourseAi::Completions::Endpoints::Vllm,
               DiscourseAi::Completions::Endpoints::Anthropic,
+              DiscourseAi::Completions::Endpoints::Cohere,
             ]
 
             if Rails.env.test? || Rails.env.development?

--- a/lib/completions/endpoints/cohere.rb
+++ b/lib/completions/endpoints/cohere.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Completions
+    module Endpoints
+      class Cohere < Base
+        class << self
+          def can_contact?(endpoint_name, model_name)
+            return false unless endpoint_name == "cohere"
+
+            %w[command-light command command-r command-r-plus].include?(model_name)
+          end
+
+          def dependant_setting_names
+            %w[ai_cohere_api_key]
+          end
+
+          def correctly_configured?(model_name)
+            SiteSetting.ai_cohere_api_key.present?
+          end
+
+          def endpoint_name(model_name)
+            "Cohere - #{model_name}"
+          end
+        end
+
+        def normalize_model_params(model_params)
+          model_params = model_params.dup
+
+          # max_tokens, temperature are already supported
+          if model_params[:stop_sequences]
+            model_params[:stop] = model_params.delete(:stop_sequences)
+          end
+
+          model_params
+        end
+
+        def default_options
+          { model: "command-r-plus" }
+        end
+
+        def provider_id
+          AiApiAuditLog::Provider::Cohere
+        end
+
+        private
+
+        def model_uri
+          URI("https://api.cohere.ai/v1/chat")
+        end
+
+        def prepare_payload(prompt, model_params, dialect)
+          payload = default_options.merge(model_params).merge(prompt)
+
+          payload[:stream] = true if @streaming_mode
+          payload[:tools] = dialect.tools if dialect.tools.present?
+
+          payload
+        end
+
+        def prepare_request(payload)
+          headers = {
+            "Content-Type" => "application/json",
+            "Authorization" => "Bearer #{SiteSetting.ai_cohere_api_key}",
+          }
+
+          Net::HTTP::Post.new(model_uri, headers).tap { |r| r.body = payload }
+        end
+
+        def extract_completion_from(response_raw)
+          parsed = JSON.parse(response_raw, symbolize_names: true)
+
+          if @streaming_mode
+            raise "not implemented"
+          else
+            @input_tokens = parsed.dig(:meta, :billed_units, :input_tokens)
+            @output_tokent = parsed.dig(:meta, :billed_units, :output_tokens)
+            parsed[:text]
+          end
+
+          #@has_function_call ||= response_h.dig(:tool_calls).present?
+          #@has_function_call ? response_h.dig(:tool_calls, 0) : response_h.dig(:content)
+        end
+
+        def final_log_update(log)
+          log.request_tokens = @input_tokens if @input_tokens
+          log.response_tokens = @output_tokens if @output_tokens
+        end
+
+        def partials_from(decoded_chunk)
+          decoded_chunk
+            .split("\n")
+            .map do |line|
+              data = line.split("data: ", 2)[1]
+              data == "[DONE]" ? nil : data
+            end
+            .compact
+        end
+
+        def extract_prompt_for_tokenizer(prompt)
+          text = +""
+          if prompt[:chat_history]
+            text << prompt[:chat_history]
+              .map { |message| message[:content] || message["content"] || "" }
+              .join("\n")
+          end
+
+          text << prompt[:message] if prompt[:message]
+          text << prompt[:preamble] if prompt[:preamble]
+
+          text
+        end
+
+        def has_tool?(_response_data)
+          @has_function_call
+        end
+
+        def maybe_has_tool?(_partial_raw)
+          # we always get a full partial
+          false
+        end
+
+        def add_to_function_buffer(function_buffer, partial: nil, payload: nil)
+          if @streaming_mode
+            return function_buffer if !partial
+          else
+            partial = payload
+          end
+
+          @args_buffer ||= +""
+
+          f_name = partial.dig(:function, :name)
+
+          @current_function ||= function_buffer.at("invoke")
+
+          if f_name
+            current_name = function_buffer.at("tool_name").content
+
+            if current_name.blank?
+              # first call
+            else
+              # we have a previous function, so we need to add a noop
+              @args_buffer = +""
+              @current_function =
+                function_buffer.at("function_calls").add_child(
+                  Nokogiri::HTML5::DocumentFragment.parse(noop_function_call_text + "\n"),
+                )
+            end
+          end
+
+          @current_function.at("tool_name").content = f_name if f_name
+          @current_function.at("tool_id").content = partial[:id] if partial[:id]
+
+          args = partial.dig(:function, :arguments)
+
+          # allow for SPACE within arguments
+          if args && args != ""
+            @args_buffer << args
+
+            begin
+              json_args = JSON.parse(@args_buffer, symbolize_names: true)
+
+              argument_fragments =
+                json_args.reduce(+"") do |memo, (arg_name, value)|
+                  memo << "\n<#{arg_name}>#{value}</#{arg_name}>"
+                end
+              argument_fragments << "\n"
+
+              @current_function.at("parameters").children =
+                Nokogiri::HTML5::DocumentFragment.parse(argument_fragments)
+            rescue JSON::ParserError
+              return function_buffer
+            end
+          end
+
+          function_buffer
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/completions/endpoints/cohere_spec.rb
+++ b/spec/lib/completions/endpoints/cohere_spec.rb
@@ -18,6 +18,59 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Cohere do
 
   before { SiteSetting.ai_cohere_api_key = "ABC" }
 
+  it "is able to perform streaming completions" do
+    body = <<~TEXT
+      {"is_finished":false,"event_type":"stream-start","generation_id":"eb889b0f-c27d-45ea-98cf-567bdb7fc8bf"}
+      {"is_finished":false,"event_type":"text-generation","text":"You"}
+      {"is_finished":false,"event_type":"text-generation","text":"'re"}
+      {"is_finished":false,"event_type":"text-generation","text":" welcome"}
+      {"is_finished":false,"event_type":"text-generation","text":"!"}
+      {"is_finished":false,"event_type":"text-generation","text":" Is"}
+      {"is_finished":false,"event_type":"text-generation","text":" there"}
+      {"is_finished":false,"event_type":"text-generation","text":" anything"}|
+      {"is_finished":false,"event_type":"text-generation","text":" else"}
+      {"is_finished":false,"event_type":"text-generation","text":" I"}
+      {"is_finished":false,"event_type":"text-generation","text":" can"}
+      {"is_finished":false,"event_type":"text-generation","text":" help"}|
+      {"is_finished":false,"event_type":"text-generation","text":" you"}
+      {"is_finished":false,"event_type":"text-generation","text":" with"}
+      {"is_finished":false,"event_type":"text-generation","text":"?"}|
+      {"is_finished":true,"event_type":"stream-end","response":{"response_id":"d235db17-8555-493b-8d91-e601f76de3f9","text":"You're welcome! Is there anything else I can help you with?","generation_id":"eb889b0f-c27d-45ea-98cf-567bdb7fc8bf","chat_history":[{"role":"USER","message":"user1: hello"},{"role":"CHATBOT","message":"hi user"},{"role":"USER","message":"user1: thanks"},{"role":"CHATBOT","message":"You're welcome! Is there anything else I can help you with?"}],"token_count":{"prompt_tokens":29,"response_tokens":14,"total_tokens":43,"billed_tokens":28},"meta":{"api_version":{"version":"1"},"billed_units":{"input_tokens":14,"output_tokens":14}}},"finish_reason":"COMPLETE"}
+    TEXT
+
+    parsed_body = nil
+    result = +""
+
+    EndpointMock.with_chunk_array_support do
+      stub_request(:post, "https://api.cohere.ai/v1/chat").with(
+        body:
+          proc do |req_body|
+            parsed_body = JSON.parse(req_body, symbolize_names: true)
+            true
+          end,
+        headers: {
+          "Content-Type" => "application/json",
+          "Authorization" => "Bearer ABC",
+        },
+      ).to_return(status: 200, body: body.split("|"))
+
+      result = llm.generate(prompt, user: user) { |partial, cancel| result << partial }
+    end
+
+    expect(parsed_body[:preamble]).to eq("You are hello bot")
+    expect(parsed_body[:chat_history]).to eq(
+      [{ role: "USER", message: "user1: hello" }, { role: "CHATBOT", message: "hi user" }],
+    )
+    expect(parsed_body[:message]).to eq("user1: thanks")
+
+    expect(result).to eq("You're welcome! Is there anything else I can help you with?")
+    audit = AiApiAuditLog.order("id desc").first
+
+    # billing should be picked
+    expect(audit.request_tokens).to eq(14)
+    expect(audit.response_tokens).to eq(14)
+  end
+
   it "is able to perform non streaming completions" do
     body = {
       response_id: "0a90275b-273d-4690-abce-8018edcec7d0",
@@ -74,7 +127,5 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Cohere do
     # billing should be picked
     expect(audit.request_tokens).to eq(14)
     expect(audit.response_tokens).to eq(11)
-
-    bang
   end
 end

--- a/spec/lib/completions/endpoints/cohere_spec.rb
+++ b/spec/lib/completions/endpoints/cohere_spec.rb
@@ -16,7 +16,155 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Cohere do
     )
   end
 
+  let(:weather_tool) do
+    {
+      name: "weather",
+      description: "lookup weather in a city",
+      parameters: [{ name: "city", type: "string", description: "city name", required: true }],
+    }
+  end
+
+  let(:prompt_with_tools) do
+    prompt =
+      DiscourseAi::Completions::Prompt.new(
+        "You are weather bot",
+        messages: [
+          { type: :user, id: "user1", content: "what is the weather in sydney and melbourne?" },
+        ],
+      )
+
+    prompt.tools = [weather_tool]
+    prompt
+  end
+
   before { SiteSetting.ai_cohere_api_key = "ABC" }
+
+  it "is able to run tools in streaming mode" do
+    body = <<~TEXT
+      {"is_finished":false,"event_type":"stream-start","generation_id":"d8dd0557-b51d-483c-b855-6ce7fcc5b19f"}
+      {"is_finished":false,"event_type":"tool-calls-generation","tool_calls":[{"name":"weather","parameters":{"city":"Sydney"}},{"name":"weather","parameters":{"city":"Melbourne"}}]}
+      {"is_finished":true,"event_type":"stream-end","response":{"response_id":"002516fe-6dc1-48d5-a9a9-031f5132a79f","text":"","generation_id":"d8dd0557-b51d-483c-b855-6ce7fcc5b19f","chat_history":[],"meta":{"api_version":{"version":"1"},"billed_units":{"input_tokens":24,"output_tokens":12},"tokens":{"output_tokens":12}},"tool_calls":[{"name":"weather","parameters":{"city":"Sydney"}},{"name":"weather","parameters":{"city":"Melbourne"}}]},"finish_reason":"COMPLETE"}
+    TEXT
+
+    parsed_body = nil
+
+    stub_request(:post, "https://api.cohere.ai/v1/chat").with(
+      body:
+        proc do |req_body|
+          parsed_body = JSON.parse(req_body, symbolize_names: true)
+          true
+        end,
+      headers: {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer ABC",
+      },
+    ).to_return(status: 200, body: body)
+
+    response = +""
+    llm.generate(prompt_with_tools, user: user) { |partial| response << partial }
+
+    expect(parsed_body[:tools]).to be_present
+
+    expected = <<~XML
+      <function_calls>
+      <invoke>
+      <tool_name>weather</tool_name>
+      <parameters>
+      <city>Sydney</city>
+      </parameters>
+      <tool_id>tool_0</tool_id>
+      </invoke>
+      <invoke>
+      <tool_name>weather</tool_name>
+      <parameters>
+      <city>Melbourne</city>
+      </parameters>
+      <tool_id>tool_1</tool_id>
+      </invoke>
+      </function_calls>
+    XML
+
+    expect(response.strip).to eq(expected.strip)
+  end
+
+  it "is able to run tools" do
+    body = {
+      response_id: "c8542aec-d528-4ed0-92c9-dc863a860685",
+      text: "",
+      generation_id: "e3107038-b9d4-4ae8-a459-23f64ed512ab",
+      chat_history: [],
+      finish_reason: "COMPLETE",
+      meta: {
+        api_version: {
+          version: "1",
+        },
+        billed_units: {
+          input_tokens: 24,
+          output_tokens: 12,
+        },
+        tokens: {
+          output_tokens: 12,
+        },
+      },
+      tool_calls: [
+        { name: "weather", parameters: { city: "Sydney" } },
+        { name: "weather", parameters: { city: "Melbourne" } },
+      ],
+    }
+
+    parsed_body = nil
+
+    stub_request(:post, "https://api.cohere.ai/v1/chat").with(
+      body:
+        proc do |req_body|
+          parsed_body = JSON.parse(req_body, symbolize_names: true)
+          true
+        end,
+      headers: {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer ABC",
+      },
+    ).to_return(status: 200, body: body.to_json)
+
+    result = llm.generate(prompt_with_tools, user: user)
+
+    expect(parsed_body[:tools]).to eq(
+      [
+        {
+          name: "weather",
+          description: "lookup weather in a city",
+          parameter_definitions: {
+            city: {
+              description: "city name",
+              type: "str",
+              required: true,
+            },
+          },
+        },
+      ],
+    )
+
+    expected = <<~XML
+      <function_calls>
+      <invoke>
+      <tool_name>weather</tool_name>
+      <parameters>
+      <city>Sydney</city>
+      </parameters>
+      <tool_id>tool_0</tool_id>
+      </invoke>
+      <invoke>
+      <tool_name>weather</tool_name>
+      <parameters>
+      <city>Melbourne</city>
+      </parameters>
+      <tool_id>tool_1</tool_id>
+      </invoke>
+      </function_calls>
+    XML
+
+    expect(result.strip).to eq(expected.strip)
+  end
 
   it "is able to perform streaming completions" do
     body = <<~TEXT
@@ -113,7 +261,20 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Cohere do
       },
     ).to_return(status: 200, body: body)
 
-    result = llm.generate(prompt, user: user)
+    result =
+      llm.generate(
+        prompt,
+        user: user,
+        temperature: 0.1,
+        top_p: 0.5,
+        max_tokens: 100,
+        stop_sequences: ["stop"],
+      )
+
+    expect(parsed_body[:temperature]).to eq(0.1)
+    expect(parsed_body[:p]).to eq(0.5)
+    expect(parsed_body[:max_tokens]).to eq(100)
+    expect(parsed_body[:stop_sequences]).to eq(["stop"])
 
     expect(parsed_body[:preamble]).to eq("You are hello bot")
     expect(parsed_body[:chat_history]).to eq(

--- a/spec/lib/completions/endpoints/cohere_spec.rb
+++ b/spec/lib/completions/endpoints/cohere_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+require_relative "endpoint_compliance"
+
+RSpec.describe DiscourseAi::Completions::Endpoints::Cohere do
+  let(:llm) { DiscourseAi::Completions::Llm.proxy("cohere:command-r-plus") }
+  fab!(:user)
+
+  let(:prompt) do
+    DiscourseAi::Completions::Prompt.new(
+      "You are hello bot",
+      messages: [
+        { type: :user, id: "user1", content: "hello" },
+        { type: :model, content: "hi user" },
+        { type: :user, id: "user1", content: "thanks" },
+      ],
+    )
+  end
+
+  before { SiteSetting.ai_cohere_api_key = "ABC" }
+
+  it "is able to perform non streaming completions" do
+    body = {
+      response_id: "0a90275b-273d-4690-abce-8018edcec7d0",
+      text: "You're welcome! How can I help you today?",
+      generation_id: "cc2742f7-622c-4e42-8fd4-d95b21012e52",
+      chat_history: [
+        { role: "USER", message: "user1: hello" },
+        { role: "CHATBOT", message: "hi user" },
+        { role: "USER", message: "user1: thanks" },
+        { role: "CHATBOT", message: "You're welcome! How can I help you today?" },
+      ],
+      finish_reason: "COMPLETE",
+      token_count: {
+        prompt_tokens: 29,
+        response_tokens: 11,
+        total_tokens: 40,
+        billed_tokens: 25,
+      },
+      meta: {
+        api_version: {
+          version: "1",
+        },
+        billed_units: {
+          input_tokens: 14,
+          output_tokens: 11,
+        },
+      },
+    }.to_json
+
+    parsed_body = nil
+    stub_request(:post, "https://api.cohere.ai/v1/chat").with(
+      body:
+        proc do |req_body|
+          parsed_body = JSON.parse(req_body, symbolize_names: true)
+          true
+        end,
+      headers: {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer ABC",
+      },
+    ).to_return(status: 200, body: body)
+
+    result = llm.generate(prompt, user: user)
+
+    expect(parsed_body[:preamble]).to eq("You are hello bot")
+    expect(parsed_body[:chat_history]).to eq(
+      [{ role: "USER", message: "user1: hello" }, { role: "CHATBOT", message: "hi user" }],
+    )
+    expect(parsed_body[:message]).to eq("user1: thanks")
+
+    expect(result).to eq("You're welcome! How can I help you today?")
+    audit = AiApiAuditLog.order("id desc").first
+
+    # billing should be picked
+    expect(audit.request_tokens).to eq(14)
+    expect(audit.response_tokens).to eq(11)
+
+    bang
+  end
+end


### PR DESCRIPTION
- Added Cohere Command models (Command, Command Light, Command R, Command R Plus) to the available model list
- Added a new site setting `ai_cohere_api_key` for configuring the Cohere API key
- Implemented a new `DiscourseAi::Completions::Endpoints::Cohere` class to handle interactions with the Cohere API, including:
   - Translating request parameters to the Cohere API format
   - Parsing Cohere API responses 
   - Supporting streaming and non-streaming completions
   - Supporting "tools" which allow the model to call back to discourse to lookup additional information
- Implemented a new `DiscourseAi::Completions::Dialects::Command` class to translate between the generic Discourse AI prompt format and the Cohere Command format
- Added specs covering the new Cohere endpoint and dialect classes
- Updated `DiscourseAi::AiBot::Bot.guess_model` to map the new Cohere model to the appropriate bot user

In summary, this PR adds support for using the Cohere Command family of models with the Discourse AI plugin. It handles configuring API keys, making requests to the Cohere API, and translating between Discourse's generic prompt format and Cohere's specific format. Thorough test coverage was added for the new functionality.