### PR TITLE
FIX: Ask AI highlight fixes

### DIFF
--- a/assets/javascripts/discourse/connectors/post-text-buttons/ai-helper-options-menu.gjs
+++ b/assets/javascripts/discourse/connectors/post-text-buttons/ai-helper-options-menu.gjs
@@ -100,8 +100,13 @@ export default class AIHelperOptionsMenu extends Component {
     );
 
     const textNodes = [];
-    while (walker.nextNode()) {
+
+    if (walker.currentNode?.nodeType === Node.TEXT_NODE) {
       textNodes.push(walker.currentNode);
+    } else {
+      while (walker.nextNode()) {
+        textNodes.push(walker.currentNode);
+      }
     }
 
     for (let textNode of textNodes) {

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -142,7 +142,7 @@
 }
 
 .ai-helper-highlighted-selection {
-  background-color: var(--highlight-low);
+  background-color: var(--highlight-low-or-medium);
 }
 
 // AI Typing indicator (taken from: https://github.com/nzbin/three-dots)


### PR DESCRIPTION
This PR applies two fixes related to the Ask AI highlight feature:
1. Uses `var(--highlight-low-or-medium);` for the highlight color so that it is more clear on dark modes.
2. Fixes an issue where the highlight would not apply if it was simply a single text node.