### PR TITLE
UX: Update suggestion button radius to accommodate for new default

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -231,12 +231,29 @@
   background: var(--secondary);
   border: 1px solid var(--primary-400);
   border-left: none;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
-.showing-ai-suggestions .title-input {
-  // border on focus should be on top of suggestion button
-  input:focus {
-    z-index: 1;
+.showing-ai-suggestions {
+  .title-input {
+    // border on focus should be on top of suggestion button
+    input:focus {
+      z-index: 1;
+    }
+
+    input {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+
+  .category-chooser,
+  .mini-tag-chooser {
+    .select-kit-header {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
   }
 }
 
@@ -253,6 +270,8 @@
   border: 1px solid var(--primary-400);
   border-left: none;
   background: none;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 .ai-suggestions-menu {


### PR DESCRIPTION
This PR updates the suggestion button radius in the composer to accommodate for the new `2px` default border radius on input fields (https://github.com/discourse/discourse/pull/26560)

## Before
![Before](https://github.com/discourse/discourse-ai/assets/30090424/3ec13b93-6c13-4282-b1f9-47b77fa8ae75)

## After
![After](https://github.com/discourse/discourse-ai/assets/30090424/5c1c5034-6469-47f7-91e1-0529df294844)
