### PR TITLE
FIX: never mention the word JSON in tool preamble

### DIFF
--- a/spec/lib/completions/dialects/dialect_spec.rb
+++ b/spec/lib/completions/dialects/dialect_spec.rb
@@ -17,6 +17,38 @@ class TestDialect < DiscourseAi::Completions::Dialects::Dialect
 end
 
 RSpec.describe DiscourseAi::Completions::Dialects::Dialect do
+  describe "#build_tools_prompt" do
+    it "can exclude array instructions" do
+      prompt = DiscourseAi::Completions::Prompt.new("12345")
+      prompt.tools = [
+        {
+          name: "weather",
+          description: "lookup weather in a city",
+          parameters: [{ name: "city", type: "string", description: "city name", required: true }],
+        },
+      ]
+
+      dialect = TestDialect.new(prompt, "test")
+
+      expect(dialect.build_tools_prompt).not_to include("array")
+    end
+
+    it "can include array instructions" do
+      prompt = DiscourseAi::Completions::Prompt.new("12345")
+      prompt.tools = [
+        {
+          name: "weather",
+          description: "lookup weather in a city",
+          parameters: [{ name: "city", type: "array", description: "city names", required: true }],
+        },
+      ]
+
+      dialect = TestDialect.new(prompt, "test")
+
+      expect(dialect.build_tools_prompt).to include("array")
+    end
+  end
+
   describe "#trim_messages" do
     it "should trim tool messages if tool_calls are trimmed" do
       prompt = DiscourseAi::Completions::Prompt.new("12345")


### PR DESCRIPTION
Just having the word JSON can confuse models when we expect them
to deal solely in XML

Instead provide an example of how string arrays should be returned

Technically the tool framework supports int arrays and more, but
our current implementation only does string arrays.

Also tune the prompt construction not to give any tips about arrays
if none exist
