### PR TITLE
FEATURE: Enhance AI debugging capabilities and improve interface adjustments

### DIFF
--- a/app/controllers/discourse_ai/ai_bot/bot_controller.rb
+++ b/app/controllers/discourse_ai/ai_bot/bot_controller.rb
@@ -6,6 +6,15 @@ module DiscourseAi
       requires_plugin ::DiscourseAi::PLUGIN_NAME
       requires_login
 
+      def show_debug_info
+        post = Post.find(params[:post_id])
+        guardian.ensure_can_debug_ai_bot_conversation!(post)
+
+        debug_info = AiApiAuditLog.where(post_id: post.id).order(created_at: :desc).first
+
+        render json: debug_info, status: 200
+      end
+
       def stop_streaming_response
         post = Post.find(params[:post_id])
         guardian.ensure_can_see!(post)

--- a/app/controllers/discourse_ai/ai_bot/bot_controller.rb
+++ b/app/controllers/discourse_ai/ai_bot/bot_controller.rb
@@ -10,7 +10,13 @@ module DiscourseAi
         post = Post.find(params[:post_id])
         guardian.ensure_can_debug_ai_bot_conversation!(post)
 
-        debug_info = AiApiAuditLog.where(post_id: post.id).order(created_at: :desc).first
+        posts =
+          Post
+            .where("post_number <= ?", post.post_number)
+            .where(topic_id: post.topic_id)
+            .order("post_number DESC")
+
+        debug_info = AiApiAuditLog.where(post: posts).order(created_at: :desc).first
 
         render json: debug_info, status: 200
       end

--- a/app/models/ai_api_audit_log.rb
+++ b/app/models/ai_api_audit_log.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class AiApiAuditLog < ActiveRecord::Base
+  belongs_to :post
+  belongs_to :topic
+
   module Provider
     OpenAI = 1
     Anthropic = 2

--- a/assets/javascripts/discourse/admin/models/ai-persona.js
+++ b/assets/javascripts/discourse/admin/models/ai-persona.js
@@ -22,14 +22,10 @@ const CREATE_ATTRIBUTES = [
   "vision_enabled",
   "vision_max_pixels",
   "rag_uploads",
-];
-
-// rag params are populated on save, only show it when editing
-const ATTRIBUTES = CREATE_ATTRIBUTES.concat([
   "rag_chunk_tokens",
   "rag_chunk_overlap_tokens",
   "rag_conversation_chunks",
-]);
+];
 
 const SYSTEM_ATTRIBUTES = [
   "id",
@@ -129,7 +125,7 @@ export default class AiPersona extends RestModel {
   updateProperties() {
     let attrs = this.system
       ? this.getProperties(SYSTEM_ATTRIBUTES)
-      : this.getProperties(ATTRIBUTES);
+      : this.getProperties(CREATE_ATTRIBUTES);
     attrs.id = this.id;
     this.populateCommandOptions(attrs);
 
@@ -143,7 +139,7 @@ export default class AiPersona extends RestModel {
   }
 
   workingCopy() {
-    let attrs = this.getProperties(ATTRIBUTES);
+    let attrs = this.getProperties(CREATE_ATTRIBUTES);
     this.populateCommandOptions(attrs);
     return AiPersona.create(attrs);
   }

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -217,7 +217,9 @@ export default class PersonaEditor extends Component {
   @action
   removeUpload(upload) {
     this.editingModel.rag_uploads.removeObject(upload);
-    this.save();
+    if (!this.args.model.isNew) {
+      this.save();
+    }
   }
 
   async toggleField(field, sortPersonas) {

--- a/assets/javascripts/discourse/components/modal/debug-ai-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/debug-ai-modal.gjs
@@ -1,0 +1,136 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { next } from "@ember/runloop";
+import { htmlSafe } from "@ember/template";
+import DButton from "discourse/components/d-button";
+import DModal from "discourse/components/d-modal";
+import { ajax } from "discourse/lib/ajax";
+import { clipboardCopy, escapeExpression } from "discourse/lib/utilities";
+import i18n from "discourse-common/helpers/i18n";
+import discourseLater from "discourse-common/lib/later";
+import I18n from "discourse-i18n";
+
+export default class DebugAiModal extends Component {
+  @tracked info = null;
+  @tracked justCopiedText = "";
+
+  constructor() {
+    super(...arguments);
+    next(() => {
+      this.loadApiRequestInfo();
+    });
+  }
+
+  get htmlContext() {
+    if (!this.info) {
+      return "";
+    }
+
+    let parsed;
+
+    try {
+      parsed = JSON.parse(this.info.raw_request_payload);
+    } catch (e) {
+      return this.info.raw_request_payload;
+    }
+
+    return htmlSafe(this.jsonToHtml(parsed));
+  }
+
+  jsonToHtml(json) {
+    let html = "<ul>";
+    for (let key in json) {
+      if (!json.hasOwnProperty(key)) {
+        continue;
+      }
+      html += "<li>";
+      if (typeof json[key] === "object" && Array.isArray(json[key])) {
+        html += `<strong>${escapeExpression(key)}:</strong> ${this.jsonToHtml(
+          json[key]
+        )}`;
+      } else if (typeof json[key] === "object") {
+        html += `<strong>${escapeExpression(
+          key
+        )}:</strong> <ul><li>${this.jsonToHtml(json[key])}</li></ul>`;
+      } else {
+        let value = json[key];
+        if (typeof value === "string") {
+          value = escapeExpression(value);
+          value = value.replace(/\n/g, "<br>");
+        }
+        html += `<strong>${escapeExpression(key)}:</strong> ${value}`;
+      }
+      html += "</li>";
+    }
+    html += "</ul>";
+    return html;
+  }
+
+  @action
+  copyRequest() {
+    this.copy(this.info.raw_request_payload);
+  }
+
+  @action
+  copyResponse() {
+    this.copy(this.info.raw_response_payload);
+  }
+
+  copy(text) {
+    clipboardCopy(text);
+    this.justCopiedText = I18n.t("discourse_ai.ai_bot.conversation_shared");
+
+    discourseLater(() => {
+      this.justCopiedText = "";
+    }, 2000);
+  }
+
+  loadApiRequestInfo() {
+    ajax(
+      `/discourse-ai/ai-bot/post/${this.args.model.id}/show-debug-info.json`
+    ).then((result) => {
+      this.info = result;
+    });
+  }
+
+  <template>
+    <DModal
+      class="ai-debug-modal"
+      @title={{i18n "discourse_ai.ai_bot.debug_ai_modal.title"}}
+      @closeModal={{@closeModal}}
+    >
+      <:body>
+        <div class="ai-debug-modal__tokens">
+          <span>
+            {{i18n "discourse_ai.ai_bot.debug_ai_modal.request_tokens"}}
+            {{this.info.request_tokens}}
+          </span>
+          <span>
+            {{i18n "discourse_ai.ai_bot.debug_ai_modal.response_tokens"}}
+            {{this.info.response_tokens}}
+          </span>
+        </div>
+        <div class="debug-ai-modal__preview">
+          {{this.htmlContext}}
+        </div>
+      </:body>
+
+      <:footer>
+        <DButton
+          class="btn confirm"
+          @icon="copy"
+          @action={{this.copyRequest}}
+          @label="discourse_ai.ai_bot.debug_ai_modal.copy_request"
+        />
+        <DButton
+          class="btn confirm"
+          @icon="copy"
+          @action={{this.copyResponse}}
+          @label="discourse_ai.ai_bot.debug_ai_modal.copy_response"
+        />
+        <span class="ai-debut-modal__just-copied">{{this.justCopiedText}}</span>
+      </:footer>
+    </DModal>
+  </template>
+}

--- a/assets/javascripts/discourse/components/persona-rag-uploader.gjs
+++ b/assets/javascripts/discourse/components/persona-rag-uploader.gjs
@@ -34,7 +34,7 @@ export default class PersonaRagUploader extends Component.extend(
 
     this.filteredUploads = this.ragUploads || [];
 
-    if (this.ragUploads?.length) {
+    if (this.ragUploads?.length && this.persona?.id) {
       ajax(
         `/admin/plugins/discourse-ai/ai-personas/${this.persona.id}/files/status.json`
       ).then((statuses) => {

--- a/assets/javascripts/initializers/ai-bot-replies.js
+++ b/assets/javascripts/initializers/ai-bot-replies.js
@@ -112,20 +112,8 @@ function initializeDebugButton(api) {
 
   let debugAiResponse = async function ({ post }) {
     const modal = api.container.lookup("service:modal");
-    // message is attached to previous post so look it up...
-    const postStream = post.topic.get("postStream");
 
-    let previousPost;
-
-    for (let i = 0; i < postStream.posts.length; i++) {
-      let p = postStream.posts[i];
-      if (p.id === post.id) {
-        break;
-      }
-      previousPost = p;
-    }
-
-    modal.show(DebugAiModal, { model: previousPost });
+    modal.show(DebugAiModal, { model: post });
   };
 
   api.addPostMenuButton("debugAi", (post) => {

--- a/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
+++ b/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
@@ -141,3 +141,11 @@ details.ai-quote {
 span.onebox-ai-llm-title {
   font-weight: bold;
 }
+
+.d-modal.ai-debug-modal {
+  --modal-max-width: 99%;
+}
+
+.ai-debug-modal__tokens span {
+  display: block;
+}

--- a/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
+++ b/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
@@ -144,6 +144,18 @@ span.onebox-ai-llm-title {
 
 .d-modal.ai-debug-modal {
   --modal-max-width: 99%;
+  ul {
+    padding-left: 1em;
+  }
+
+  li {
+    margin-bottom: 0.2em;
+  }
+
+  li > ul {
+    margin-top: 0.2em;
+    margin-bottom: 0.2em;
+  }
 }
 
 .ai-debug-modal__tokens span {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -258,6 +258,13 @@ en:
         shortcut_title: "Start a PM with an AI bot"
         share: "Share AI conversation"
         conversation_shared: "Conversation copied"
+        debug_ai: "View raw AI request and response"
+        debug_ai_modal:
+          title: "View AI interaction"
+          copy_request: "Copy request"
+          copy_response: "Copy response"
+          request_tokens: "Request tokens:"
+          response_tokens: "Response tokens:"
 
         share_full_topic_modal:
           title: "Share Conversation Publicly"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -160,11 +160,11 @@ en:
         priority: Priority
         priority_help: Priority personas are displayed to users at the top of the persona list. If multiple personas have priority, they will be sorted alphabetically.
         command_options: "Command Options"
-        rag_chunk_tokens: "RAG Chunk Tokens"
+        rag_chunk_tokens: "Upload Chunk Tokens"
         rag_chunk_tokens_help: "The number of tokens to use for each chunk in the RAG model. Increase to increase the amount of context the AI can use. (changing will re-index all uploads)"
-        rag_chunk_overlap_tokens: "RAG Chunk Overlap Tokens"
+        rag_chunk_overlap_tokens: "Upload Chunk Overlap Tokens"
         rag_chunk_overlap_tokens_help: "The number of tokens to overlap between chunks in the RAG model. (changing will re-index all uploads)"
-        rag_conversation_chunks: "RAG Conversation Chunks"
+        rag_conversation_chunks: "Search Conversation Chunks"
         rag_conversation_chunks_help: "The number of chunks to use for the RAG model searches. Increase to increase the amount of context the AI can use."
         what_are_personas: "What are AI Personas?"
         no_persona_selected: |
@@ -187,6 +187,8 @@ en:
           indexed: "Indexed"
           indexing: "Indexing"
           uploaded: "Ready to be indexed"
+          uploading: "Uploading..."
+          remove: "Remove upload"
 
       related_topics:
         title: "Related Topics"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -96,6 +96,7 @@ en:
     ai_bot_enabled: "Enable the AI Bot module."
     ai_bot_enable_chat_warning: "Display a warning when PM chat is initiated. Can be overriden by editing the translation string: discourse_ai.ai_bot.pm_warning"
     ai_bot_allowed_groups: "When the GPT Bot has access to the PM, it will reply to members of these groups."
+    ai_bot_debugging_allowed_groups: "Allow these groups to see a debug button on posts which displays the raw AI request and response"
     ai_bot_public_sharing_allowed_groups: "Allow these groups to share AI personal messages with the public via a unique publicly available link"
     ai_bot_enabled_chat_bots: "Available models to act as an AI Bot"
     ai_bot_add_to_header: "Display a button in the header to start a PM with a AI Bot"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,9 @@ DiscourseAi::Engine.routes.draw do
   end
 
   scope module: :ai_bot, path: "/ai-bot", defaults: { format: :json } do
-    post "post/:post_id/stop-streaming" => "bot#stop_streaming_response"
     get "bot-username" => "bot#show_bot_username"
+    get "post/:post_id/show-debug-info" => "bot#show_debug_info"
+    post "post/:post_id/stop-streaming" => "bot#stop_streaming_response"
   end
 
   scope module: :ai_bot, path: "/ai-bot/shared-ai-conversations" do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -313,6 +313,11 @@ discourse_ai:
   ai_bot_enable_chat_warning:
     default: false
     client: true
+  ai_bot_debugging_allowed_groups:
+    type: group_list
+    list_type: compact
+    default: ""
+    allow_any: false
   ai_bot_allowed_groups:
     type: group_list
     list_type: compact

--- a/lib/ai_bot/bot.rb
+++ b/lib/ai_bot/bot.rb
@@ -33,7 +33,6 @@ module DiscourseAi
             system_insts,
             messages: conversation_context,
             topic_id: post.topic_id,
-            post_id: post.id,
           )
 
         title_prompt.push(

--- a/lib/ai_bot/entry_point.rb
+++ b/lib/ai_bot/entry_point.rb
@@ -163,11 +163,15 @@ module DiscourseAi
           SQL
 
           bots.each { |hash| hash["model_name"] = model_map[hash["id"]] }
-          mentionables = AiPersona.mentionables(user: scope.user)
-          if mentionables.present?
+          persona_users = AiPersona.persona_users(user: scope.user)
+          if persona_users.present?
             bots.concat(
-              mentionables.map do |mentionable|
-                { "id" => mentionable[:user_id], "username" => mentionable[:username] }
+              persona_users.map do |persona_user|
+                {
+                  "id" => persona_user[:user_id],
+                  "username" => persona_user[:username],
+                  "mentionable" => persona_user[:mentionable],
+                }
               end,
             )
           end

--- a/lib/ai_bot/entry_point.rb
+++ b/lib/ai_bot/entry_point.rb
@@ -141,6 +141,16 @@ module DiscourseAi
 
         plugin.add_to_serializer(
           :current_user,
+          :can_debug_ai_bot_conversations,
+          include_condition: -> do
+            SiteSetting.ai_bot_enabled && scope.authenticated? &&
+              SiteSetting.ai_bot_debugging_allowed_groups.present? &&
+              scope.user.in_any_groups?(SiteSetting.ai_bot_debugging_allowed_groups_map)
+          end,
+        ) { true }
+
+        plugin.add_to_serializer(
+          :current_user,
           :ai_enabled_chat_bots,
           include_condition: -> do
             SiteSetting.ai_bot_enabled && scope.authenticated? &&

--- a/lib/ai_bot/tools/discourse_meta_search.rb
+++ b/lib/ai_bot/tools/discourse_meta_search.rb
@@ -118,10 +118,15 @@ module DiscourseAi
 
               category = categories[topic["category_id"]]
               category_names = +""
-              if category["parent_category_id"]
-                category_names << categories[category["parent_category_id"]]["name"] << " > "
+              # TODO @nbianca: this is broken now cause we are not getting child categories
+              # to avoid erroring out we simply skip
+              # sideloading from search would probably be easier
+              if category
+                if category["parent_category_id"]
+                  category_names << categories[category["parent_category_id"]]["name"] << " > "
+                end
+                category_names << category["name"]
               end
-              category_names << category["name"]
               row = {
                 title: topic["title"],
                 url: "https://meta.discourse.org/t/-/#{post["topic_id"]}/#{post["post_number"]}",

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -2,6 +2,19 @@
 
 module DiscourseAi
   module GuardianExtensions
+    def can_debug_ai_bot_conversation?(target)
+      return false if anonymous?
+
+      return false if !can_see?(target)
+
+      if !SiteSetting.discourse_ai_enabled || !SiteSetting.ai_bot_enabled ||
+           !SiteSetting.ai_bot_debugging_allowed_groups_map.any?
+        return false
+      end
+
+      user.in_any_groups?(SiteSetting.ai_bot_debugging_allowed_groups_map)
+    end
+
     def can_share_ai_bot_conversation?(target)
       return false if anonymous?
 

--- a/spec/lib/modules/ai_bot/entry_point_spec.rb
+++ b/spec/lib/modules/ai_bot/entry_point_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe DiscourseAi::AiBot::EntryPoint do
         bot_allowed_group.add(admin)
       end
 
+      it "adds a can_debug_ai_bot_conversations method to current user" do
+        SiteSetting.ai_bot_debugging_allowed_groups = bot_allowed_group.id.to_s
+        serializer = CurrentUserSerializer.new(admin, scope: Guardian.new(admin))
+        serializer = serializer.as_json
+
+        expect(serializer[:current_user][:can_debug_ai_bot_conversations]).to eq(true)
+      end
+
       it "adds mentionables to current_user_serializer" do
         Group.refresh_automatic_groups!
 

--- a/spec/lib/modules/ai_bot/entry_point_spec.rb
+++ b/spec/lib/modules/ai_bot/entry_point_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe DiscourseAi::AiBot::EntryPoint do
         persona_bot = bots.find { |bot| bot["id"] == persona.user_id }
 
         expect(persona_bot["username"]).to eq(persona.user.username)
+        expect(persona_bot["mentionable"]).to eq(true)
+      end
+
+      it "includes user ids for all personas in the serializer" do
+        Group.refresh_automatic_groups!
+
+        persona = Fabricate(:ai_persona, enabled: true, allowed_group_ids: [bot_allowed_group.id])
+        persona.create_user!
+
+        serializer = CurrentUserSerializer.new(admin, scope: Guardian.new(admin))
+        serializer = serializer.as_json
+        bots = serializer[:current_user][:ai_enabled_chat_bots]
+
+        persona_bot = bots.find { |bot| bot["id"] == persona.user_id }
+        expect(persona_bot["username"]).to eq(persona.user.username)
+        expect(persona_bot["mentionable"]).to eq(false)
       end
 
       it "queues a job to generate a reply by the AI" do

--- a/spec/requests/ai_bot/bot_controller_spec.rb
+++ b/spec/requests/ai_bot/bot_controller_spec.rb
@@ -36,13 +36,20 @@ RSpec.describe DiscourseAi::AiBot::BotController do
       SiteSetting.ai_bot_debugging_allowed_groups = user.groups.first.id.to_s
 
       get "/discourse-ai/ai-bot/post/#{pm_post.id}/show-debug-info"
-
       expect(response.status).to eq(200)
 
       expect(response.parsed_body["request_tokens"]).to eq(1)
       expect(response.parsed_body["response_tokens"]).to eq(2)
       expect(response.parsed_body["raw_request_payload"]).to eq("request")
       expect(response.parsed_body["raw_response_payload"]).to eq("response")
+
+      post2 = Fabricate(:post, topic: pm_topic)
+
+      # return previous post if current has no debug info
+      get "/discourse-ai/ai-bot/post/#{post2.id}/show-debug-info"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["request_tokens"]).to eq(1)
+      expect(response.parsed_body["response_tokens"]).to eq(2)
     end
   end
 

--- a/test/javascripts/unit/models/ai-persona-test.js
+++ b/test/javascripts/unit/models/ai-persona-test.js
@@ -87,6 +87,9 @@ module("Discourse AI | Unit | Model | ai-persona", function () {
       vision_enabled: true,
       vision_max_pixels: 100,
       rag_uploads: [],
+      rag_chunk_tokens: 374,
+      rag_chunk_overlap_tokens: 10,
+      rag_conversation_chunks: 10,
     };
 
     const aiPersona = AiPersona.create({ ...properties });


### PR DESCRIPTION
This commit introduces the ability for specified user groups to access AI debugging tools, creates the modal presentation for AI interactions, and performs various code cleanups. 


1. **Bot Debugging and Tracking:**
   - Addition of `ai_bot_debugging_allowed_groups` setting to allow specified user groups to access debugging tools.
   - Introduction of routes to display debug info for posts and adjustments for stopping bot streaming. (streaming was not working when you created an AI user for a persona)
   - New backend methods to facilitate debugging capabilities, `show_debug_info` which fetches debug data related to AI interactions.

2. **UI Enhancements and Adjustments:**
   - Updates to SCSS files to modify the modal presentation for AI-related interfaces.
   - Changes within JavaScript components to accommodate the new debugging feature by adding button and modal displays for AI interactions.

3. **Code Cleanup and Optimization:**
   - Removal of unused variables and parameters in several .rb and .js files.
   - Code standardization for persona management in frontend components, emphasizing consistency and clarity.

4. **RAG fixes**
   - Missing localization 
   - Was not saving properly after create
   - Cleaned up description

5. **Hot fix for Discourse Helper**
    - New interfaces are not giving us child category ids (pagination only works for logged on users on categories) bypass when missing


