### PR TITLE
FIX: more robust function call support

### DIFF
--- a/lib/completions/endpoints/gemini.rb
+++ b/lib/completions/endpoints/gemini.rb
@@ -105,9 +105,8 @@ module DiscourseAi
           @has_function_call
         end
 
-        def maybe_has_tool?(_partial_raw)
-          # we always get a full partial
-          false
+        def native_tool_support?
+          true
         end
 
         def add_to_function_buffer(function_buffer, payload: nil, partial: nil)

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -162,9 +162,8 @@ module DiscourseAi
           @has_function_call
         end
 
-        def maybe_has_tool?(_partial_raw)
-          # we always get a full partial
-          false
+        def native_tool_support?
+          true
         end
 
         def add_to_function_buffer(function_buffer, partial: nil, payload: nil)

--- a/lib/completions/function_call_normalizer.rb
+++ b/lib/completions/function_call_normalizer.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+class DiscourseAi::Completions::FunctionCallNormalizer
+  attr_reader :done
+
+  # blk is the block to call with filtered data
+  def initialize(blk, cancel)
+    @blk = blk
+    @cancel = cancel
+    @done = false
+
+    @in_tool = false
+
+    @buffer = +""
+    @function_buffer = +""
+  end
+
+  def self.normalize(data)
+    text = +""
+    cancel = -> {}
+    blk = ->(partial, _) { text << partial }
+
+    normalizer = self.new(blk, cancel)
+    normalizer << data
+
+    [text, normalizer.function_calls]
+  end
+
+  def function_calls
+    return nil if @function_buffer.blank?
+
+    xml = Nokogiri::HTML5.fragment(@function_buffer)
+    self.class.normalize_function_ids!(xml)
+    last_invoke = xml.at("invoke:last")
+    if last_invoke
+      last_invoke.next_sibling.remove while last_invoke.next_sibling
+      xml.at("invoke:last").add_next_sibling("\n") if !last_invoke.next_sibling
+    end
+    xml.at("function_calls").to_s.dup.force_encoding("UTF-8")
+  end
+
+  def <<(text)
+    @buffer << text
+
+    if !@in_tool
+      # double check if we are clearly in a tool
+      search_length = text.length + 20
+      search_string = @buffer[-search_length..-1] || @buffer
+
+      index = search_string.rindex("<function_calls>")
+      @in_tool = !!index
+      if @in_tool
+        @function_buffer = @buffer[index..-1]
+        text_index = text.rindex("<function_calls>")
+        @blk.call(text[0..text_index - 1].strip, @cancel) if text_index && text_index > 0
+      end
+    else
+      @function_buffer << text
+    end
+
+    if !@in_tool
+      if maybe_has_tool?(@buffer)
+        split_index = text.rindex("<").to_i - 1
+        if split_index >= 0
+          @function_buffer = text[split_index + 1..-1] || ""
+          text = text[0..split_index] || ""
+        else
+          @function_buffer << text
+          text = ""
+        end
+      else
+        if @function_buffer.length > 0
+          @blk.call(@function_buffer, @cancel)
+          @function_buffer = +""
+        end
+      end
+
+      @blk.call(text, @cancel) if text.length > 0
+    else
+      if text.include?("</function_calls>")
+        @done = true
+        @cancel.call
+      end
+    end
+  end
+
+  def self.normalize_function_ids!(function_buffer)
+    function_buffer
+      .css("invoke")
+      .each_with_index do |invoke, index|
+        if invoke.at("tool_id")
+          invoke.at("tool_id").content = "tool_#{index}" if invoke.at("tool_id").content.blank?
+        else
+          invoke.add_child("<tool_id>tool_#{index}</tool_id>\n") if !invoke.at("tool_id")
+        end
+      end
+  end
+
+  private
+
+  def maybe_has_tool?(text)
+    # 16 is the length of function calls
+    substring = text[-16..-1] || text
+    split = substring.split("<")
+
+    if split.length > 1
+      match = "<" + split.last
+      "<function_calls>".start_with?(match)
+    else
+      substring.ends_with?("<")
+    end
+  end
+end

--- a/spec/lib/completions/endpoints/endpoint_compliance.rb
+++ b/spec/lib/completions/endpoints/endpoint_compliance.rb
@@ -40,7 +40,7 @@ class EndpointMock
   end
 
   def tool_deltas
-    ["Let me use a tool for that<function", <<~REPLY.strip, <<~REPLY.strip, <<~REPLY.strip]
+    ["<function", <<~REPLY.strip, <<~REPLY.strip, <<~REPLY.strip]
       _calls>
       <invoke>
       <tool_name>get_weather</tool_name>
@@ -185,7 +185,7 @@ class EndpointsCompliance
     mock.stub_tool_call(a_dialect.translate)
 
     completion_response = endpoint.perform_completion!(a_dialect, user)
-    expect(completion_response).to eq(mock.invocation_response)
+    expect(completion_response.strip).to eq(mock.invocation_response.strip)
   end
 
   def streaming_mode_simple_prompt(mock)
@@ -223,7 +223,7 @@ class EndpointsCompliance
         cancel.call if buffered_partial.include?("<function_calls>")
       end
 
-      expect(buffered_partial).to eq(mock.invocation_response)
+      expect(buffered_partial.strip).to eq(mock.invocation_response.strip)
     end
   end
 

--- a/spec/lib/completions/function_call_normalizer_spec.rb
+++ b/spec/lib/completions/function_call_normalizer_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::Completions::FunctionCallNormalizer do
+  let(:buffer) { +"" }
+
+  let(:normalizer) do
+    blk = ->(data, cancel) { buffer << data }
+    cancel = -> { @done = true }
+    DiscourseAi::Completions::FunctionCallNormalizer.new(blk, cancel)
+  end
+
+  def pass_through!(data)
+    normalizer << data
+    expect(buffer[-data.length..-1]).to eq(data)
+  end
+
+  it "is usable in non streaming mode" do
+    xml = (<<~XML).strip
+      hello
+      <function_calls>
+      <invoke>
+      <tool_name>hello</tool_name>
+      </invoke>
+    XML
+
+    text, function_calls = DiscourseAi::Completions::FunctionCallNormalizer.normalize(xml)
+
+    expect(text).to eq("hello")
+
+    expected_function_calls = (<<~XML).strip
+      <function_calls>
+      <invoke>
+      <tool_name>hello</tool_name>
+      <tool_id>tool_0</tool_id>
+      </invoke>
+      </function_calls>
+    XML
+
+    expect(function_calls).to eq(expected_function_calls)
+  end
+
+  it "strips junk from end of function calls" do
+    xml = (<<~XML).strip
+      hello
+      <function_calls>
+      <invoke>
+      <tool_name>hello</tool_name>
+      </invoke>
+      junk
+    XML
+
+    _text, function_calls = DiscourseAi::Completions::FunctionCallNormalizer.normalize(xml)
+
+    expected_function_calls = (<<~XML).strip
+      <function_calls>
+      <invoke>
+      <tool_name>hello</tool_name>
+      <tool_id>tool_0</tool_id>
+      </invoke>
+      </function_calls>
+    XML
+
+    expect(function_calls).to eq(expected_function_calls)
+  end
+
+  it "returns nil for function calls if there are none" do
+    input = "hello world\n"
+    text, function_calls = DiscourseAi::Completions::FunctionCallNormalizer.normalize(input)
+
+    expect(text).to eq(input)
+    expect(function_calls).to eq(nil)
+  end
+
+  it "passes through data if there are no function calls detected" do
+    pass_through!("hello")
+    pass_through!("<tool_name>hello</tool_name>")
+    pass_through!("<parameters><hello>world</hello></parameters>")
+    pass_through!("<function_call>")
+  end
+
+  it "properly handles non English tools" do
+    normalizer << "hello<function"
+    expect(buffer).to eq("hello")
+
+    normalizer << "_calls>\n"
+
+    normalizer << (<<~XML).strip
+      <invoke>
+      <tool_name>hello</tool_name>
+      <parameters>
+      <hello>世界</hello>
+      </parameters>
+      </invoke>
+    XML
+
+    expected = (<<~XML).strip
+      <function_calls>
+      <invoke>
+      <tool_name>hello</tool_name>
+      <parameters>
+      <hello>世界</hello>
+      </parameters>
+      <tool_id>tool_0</tool_id>
+      </invoke>
+      </function_calls>
+    XML
+
+    function_calls = normalizer.function_calls
+    expect(function_calls).to eq(expected)
+  end
+
+  it "works correctly even if you only give it 1 letter at a time" do
+    xml = (<<~XML).strip
+      abc
+      <function_calls>
+      <invoke>
+      <tool_name>hello</tool_name>
+      <parameters>
+      <hello>world</hello>
+      </parameters>
+      <tool_id>abc</tool_id>
+      </invoke>
+      <invoke>
+      <tool_name>hello2</tool_name>
+      <parameters>
+      <hello>world</hello>
+      </parameters>
+      <tool_id>aba</tool_id>
+      </invoke>
+      </function_calls>
+    XML
+
+    xml.each_char { |char| normalizer << char }
+
+    expect(buffer + normalizer.function_calls).to eq(xml)
+  end
+
+  it "supports multiple invokes" do
+    xml = (<<~XML).strip
+      <function_calls>
+      <invoke>
+      <tool_name>hello</tool_name>
+      <parameters>
+      <hello>world</hello>
+      </parameters>
+      <tool_id>abc</tool_id>
+      </invoke>
+      <invoke>
+      <tool_name>hello2</tool_name>
+      <parameters>
+      <hello>world</hello>
+      </parameters>
+      <tool_id>aba</tool_id>
+      </invoke>
+      </function_calls>
+    XML
+
+    normalizer << xml
+
+    expect(normalizer.function_calls).to eq(xml)
+  end
+
+  it "can will cancel if it encounteres </function_calls>" do
+    normalizer << "<function_calls>"
+    expect(normalizer.done).to eq(false)
+    normalizer << "</function_calls>"
+    expect(normalizer.done).to eq(true)
+    expect(@done).to eq(true)
+
+    expect(normalizer.function_calls).to eq("<function_calls></function_calls>")
+  end
+
+  it "pauses on function call and starts buffering" do
+    normalizer << "hello<function_call"
+    expect(buffer).to eq("hello")
+    expect(normalizer.done).to eq(false)
+
+    normalizer << ">"
+    expect(buffer).to eq("hello<function_call>")
+    expect(normalizer.done).to eq(false)
+  end
+end


### PR DESCRIPTION
For quite a few weeks now, some times, when running function calls
on Anthropic we would get a "stray" - "calls" line.

This has been enormously frustrating!

I have been unable to find the source of the bug so instead decoupled
the implementation and create a very clear "function call normalizer"

This new class is extensively tested and guards against the type of
edge cases we saw pre-normalizer.

This also simplifies the implementation of "endpoint" which no longer
needs to handle all this complex logic.
