### PR TITLE
FEATURE: Stable diffusion 3 support

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -122,6 +122,8 @@ discourse_ai:
     default: "stable-diffusion-xl-1024-v1-0"
     type: enum
     choices:
+      - "sd3"
+      - "sd3-turbo"
       - "stable-diffusion-xl-1024-v1-0"
       - "stable-diffusion-768-v2-1"
       - "stable-diffusion-v1-5"

--- a/lib/ai_bot/bot.rb
+++ b/lib/ai_bot/bot.rb
@@ -203,10 +203,6 @@ module DiscourseAi
         end
       end
 
-      def tool_invocation?(partial)
-        Nokogiri::HTML5.fragment(partial).at("invoke").present?
-      end
-
       def build_placeholder(summary, details, custom_raw: nil)
         placeholder = +(<<~HTML)
         <details>

--- a/lib/ai_bot/personas/persona.rb
+++ b/lib/ai_bot/personas/persona.rb
@@ -188,7 +188,7 @@ module DiscourseAi
                 begin
                   JSON.parse(value)
                 rescue JSON::ParserError
-                  nil
+                  [value.to_s]
                 end
             end
 

--- a/lib/ai_bot/tools/image.rb
+++ b/lib/ai_bot/tools/image.rb
@@ -24,7 +24,13 @@ module DiscourseAi
                   "The seed used to generate the image (optional) - can be used to retain image style on amended prompts",
                 type: "array",
                 item_type: "integer",
-                required: true,
+              },
+              {
+                name: "aspect_ratio",
+                description: "The aspect ratio of the image (optional defaults to 1:1)",
+                type: "string",
+                required: false,
+                enum: %w[16:9 1:1 21:9 2:3 3:2 4:5 5:4 9:16 9:21],
               },
             ],
           }
@@ -35,7 +41,11 @@ module DiscourseAi
         end
 
         def prompts
-          JSON.parse(parameters[:prompts].to_s)
+          parameters[:prompts]
+        end
+
+        def aspect_ratio
+          parameters[:aspect_ratio]
         end
 
         def seeds
@@ -75,6 +85,7 @@ module DiscourseAi
                   api_url: api_url,
                   image_count: 1,
                   seed: inner_seed,
+                  aspect_ratio: aspect_ratio,
                 )
               rescue => e
                 attempts += 1
@@ -116,7 +127,7 @@ module DiscourseAi
           #{
             uploads
               .map do |item|
-                "![#{item[:prompt].gsub(/\|\'\"/, "")}|512x512, 50%](#{item[:upload].short_url})"
+                "![#{item[:prompt].gsub(/\|\'\"/, "")}|50%](#{item[:upload].short_url})"
               end
               .join(" ")
           }

--- a/lib/ai_helper/painter.rb
+++ b/lib/ai_helper/painter.rb
@@ -7,7 +7,6 @@ module DiscourseAi
         return [] if input.blank?
 
         model = SiteSetting.ai_helper_illustrate_post_model
-        attribution = "discourse_ai.ai_helper.painter.attribution.#{model}"
 
         if model == "stable_diffusion_xl"
           stable_diffusion_prompt = diffusion_prompt(input, user)


### PR DESCRIPTION
- Adds support for sd3 and sd3 turbo models - this requires new endpoints
- Adds a hack to normalize arrays in the tool calls
- Removes some leftover code 
- Adds support for aspect ratio as well so you can generate wide or tall images


![image](https://github.com/discourse/discourse-ai/assets/5213/754f85ac-3e81-42d7-90d0-7106aca3013a)
