### PR TITLE
FIX: when excluding categories also exclude children

### DIFF
--- a/lib/automation/report_context_generator.rb
+++ b/lib/automation/report_context_generator.rb
@@ -45,8 +45,8 @@ module DiscourseAi
         @posts = @posts.where("categories.id IN (?)", @category_ids) if @category_ids.present?
         @posts =
           @posts.where(
-            "categories.id NOT IN (?)",
-            exclude_category_ids,
+            "categories.id NOT IN (:ids) AND parent_category_id NOT IN (:ids)",
+            ids: exclude_category_ids,
           ) if exclude_category_ids.present?
 
         if exclude_tags.present?

--- a/spec/lib/modules/automation/report_runner_spec.rb
+++ b/spec/lib/modules/automation/report_runner_spec.rb
@@ -52,7 +52,12 @@ module DiscourseAi
           )
         end
 
-        it "can exclude categories" do
+        it "can exclude categories (including sub categories)" do
+          subcategory = Fabricate(:category, parent_category_id: category.id)
+          topic_in_subcategory = Fabricate(:topic, category: subcategory)
+          post_in_subcategory =
+            Fabricate(:post, raw: "I am in a subcategory abcd", topic: topic_in_subcategory)
+
           freeze_time
 
           DiscourseAi::Completions::Llm.with_prepared_responses(["magical report"]) do
@@ -79,6 +84,7 @@ module DiscourseAi
           debugging = report.ordered_posts.last.raw
 
           expect(debugging).not_to include(post_in_category.raw)
+          expect(debugging).not_to include(post_in_subcategory.raw)
         end
 
         it "can suppress notifications by remapping content" do


### PR DESCRIPTION
This allows you to exclude trees of categories in a simple way

It also means you can no longer exclude "just the parent" but
this is a fair compromise.
