### PR TITLE
FIX: many missing topics when categories excluded

### DIFF
--- a/lib/automation/report_context_generator.rb
+++ b/lib/automation/report_context_generator.rb
@@ -45,7 +45,8 @@ module DiscourseAi
         @posts = @posts.where("categories.id IN (?)", @category_ids) if @category_ids.present?
         @posts =
           @posts.where(
-            "categories.id NOT IN (:ids) AND parent_category_id NOT IN (:ids)",
+            "categories.id NOT IN (:ids) AND
+            (parent_category_id NOT IN (:ids) OR parent_category_id IS NULL)",
             ids: exclude_category_ids,
           ) if exclude_category_ids.present?
 

--- a/spec/lib/modules/automation/report_runner_spec.rb
+++ b/spec/lib/modules/automation/report_runner_spec.rb
@@ -58,6 +58,10 @@ module DiscourseAi
           post_in_subcategory =
             Fabricate(:post, raw: "I am in a subcategory abcd", topic: topic_in_subcategory)
 
+          other_category = Fabricate(:category)
+          topic2 = Fabricate(:topic, category: other_category)
+          post2 = Fabricate(:post, raw: "I am in another category 123", topic: topic2)
+
           freeze_time
 
           DiscourseAi::Completions::Llm.with_prepared_responses(["magical report"]) do
@@ -85,6 +89,7 @@ module DiscourseAi
 
           expect(debugging).not_to include(post_in_category.raw)
           expect(debugging).not_to include(post_in_subcategory.raw)
+          expect(debugging).to include(post2.raw)
         end
 
         it "can suppress notifications by remapping content" do


### PR DESCRIPTION
We were forgetting about the NULL parent_category_id handling in
our check for sub categories
