### PR TITLE
Add missing gems for `rake ai:embeddings:backfill` task

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -10,6 +10,7 @@
 
 gem "tokenizers", "0.4.4"
 gem "tiktoken_ruby", "0.0.7"
+gem "parallel", "1.24.0"
 
 enabled_site_setting :discourse_ai_enabled
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -11,6 +11,7 @@
 gem "tokenizers", "0.4.4"
 gem "tiktoken_ruby", "0.0.7"
 gem "parallel", "1.24.0"
+gem "ruby-progressbar", "1.13.0"
 
 enabled_site_setting :discourse_ai_enabled
 


### PR DESCRIPTION
Add missing gems `ruby-progressbar` and `parallel` in plugin.rb