### PR TITLE
UX: prevent social share content from overflowing container

### DIFF
--- a/public/ai-share/share.css
+++ b/public/ai-share/share.css
@@ -306,6 +306,11 @@ h1 h2 h3 h4 h5 h6 {
 .post__content {
   line-height: 1.4;
   color: var(--primary-800);
+  overflow: hidden;
+}
+
+.post__content img {
+  max-width: 100%;
 }
 
 .post__content p:first-child {


### PR DESCRIPTION
This prevents content from overflowing and breaking the layout, and constrains all images to be no wider than 100% of the content container. 


Before:
![image](https://github.com/discourse/discourse-ai/assets/1681963/972ed8fd-a791-43cc-a17f-01a64523f15b)

After:
![image](https://github.com/discourse/discourse-ai/assets/1681963/8b4113f5-81cd-4f4e-9575-187894b94c65)
