### PR TITLE
FIX: context repairs for @mentioned bot

### DIFF
--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -262,7 +262,7 @@ module DiscourseAi
 
         messages.each do |m|
           # restore stripped message
-          m.message = instruction_message if m.id == current_id
+          m.message = instruction_message if m.id == current_id && instruction_message
 
           if available_bot_user_ids.include?(m.user_id)
             builder.push(type: :model, content: m.message)

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -147,6 +147,77 @@ RSpec.describe DiscourseAi::AiBot::Playground do
         persona.update!(allow_chat: true, mentionable: true, default_llm: "anthropic:claude-3-opus")
       end
 
+      it "should behave in a sane way when threading is enabled" do
+        channel.update!(threading_enabled: true)
+
+        message =
+          ChatSDK::Message.create(
+            channel_id: channel.id,
+            raw: "thread 1 message 1",
+            guardian: guardian,
+          )
+
+        message =
+          ChatSDK::Message.create(
+            channel_id: channel.id,
+            raw: "thread 1 message 2",
+            in_reply_to_id: message.id,
+            guardian: guardian,
+          )
+
+        thread = message.thread
+        thread.update!(title: "a magic thread")
+
+        message =
+          ChatSDK::Message.create(
+            channel_id: channel.id,
+            raw: "thread 2 message 1",
+            guardian: guardian,
+          )
+
+        message =
+          ChatSDK::Message.create(
+            channel_id: channel.id,
+            raw: "thread 2 message 2",
+            in_reply_to_id: message.id,
+            guardian: guardian,
+          )
+
+        prompts = nil
+        DiscourseAi::Completions::Llm.with_prepared_responses(["world"]) do |_, _, _prompts|
+          message =
+            ChatSDK::Message.create(
+              channel_id: channel.id,
+              raw: "Hello @#{persona.user.username}",
+              guardian: guardian,
+            )
+
+          prompts = _prompts
+        end
+
+        # don't start a thread cause it will get confusing
+        message.reload
+        expect(message.thread_id).to be_nil
+
+        prompt = prompts[0]
+
+        content = prompt.messages[1][:content]
+        # this is fragile by design, mainly so the example can be ultra clear
+        expected = (<<~TEXT).strip
+          You are replying inside a Discourse chat. Here is a summary of the conversation so far:
+          {{{
+          bruce1: (a magic thread)
+          thread 1 message 1
+          bruce1: thread 2 message 1
+          }}}
+
+          Your instructions:
+          bruce1 said Hello
+        TEXT
+
+        expect(content.strip).to eq(expected)
+      end
+
       it "should reply to a mention if properly enabled" do
         prompts = nil
 

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -206,13 +206,13 @@ RSpec.describe DiscourseAi::AiBot::Playground do
         expected = (<<~TEXT).strip
           You are replying inside a Discourse chat. Here is a summary of the conversation so far:
           {{{
-          bruce1: (a magic thread)
+          #{user.username}: (a magic thread)
           thread 1 message 1
-          bruce1: thread 2 message 1
+          #{user.username}: thread 2 message 1
           }}}
 
           Your instructions:
-          bruce1 said Hello
+          #{user.username} said Hello
         TEXT
 
         expect(content.strip).to eq(expected)


### PR DESCRIPTION
When the bot is @mentioned, we need to be a lot more careful
about constructing context otherwise bot gets ultra confused.

This changes multiple things:

1. We were omitting all thread first messages (fixed)
2. Include thread title (if available) in context
3. Construct context in a clearer way separating user request from data
