### PR TITLE
FEATURE: search command now support searching in context of user

### DIFF
--- a/assets/javascripts/discourse/components/ai-persona-command-option-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-command-option-editor.gjs
@@ -1,17 +1,44 @@
+import Component from "@glimmer/component";
 import { Input } from "@ember/component";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
 
-const AiPersonaCommandOptionEditor = <template>
-  <div class="control-group ai-persona-command-option-editor">
-    <label>
-      {{@option.name}}
-    </label>
-    <div class="">
-      <Input @value={{@option.value.value}} />
-    </div>
-    <div class="ai-persona-command-option-editor__instructions">
-      {{@option.description}}
-    </div>
-  </div>
-</template>;
+export default class AiPersonaCommandOptionEditor extends Component {
+  get isBoolean() {
+    return this.args.option.type === "boolean";
+  }
 
-export default AiPersonaCommandOptionEditor;
+  get selectedValue() {
+    return this.args.option.value.value === "true";
+  }
+
+  @action
+  onCheckboxChange(event) {
+    this.args.option.value.value = event.target.checked ? "true" : "false";
+  }
+
+  <template>
+    <div class="control-group ai-persona-command-option-editor">
+      <label>
+        {{@option.name}}
+      </label>
+      <div class="">
+        {{#if this.isBoolean}}
+          <input
+            type="checkbox"
+            checked={{this.selectedValue}}
+            {{on "click" this.onCheckboxChange}}
+          />
+          {{@option.description}}
+        {{else}}
+          <Input @value={{@option.value.value}} />
+        {{/if}}
+      </div>
+      {{#unless this.isBoolean}}
+        <div class="ai-persona-command-option-editor__instructions">
+          {{@option.description}}
+        </div>
+      {{/unless}}
+    </div>
+  </template>
+}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -205,6 +205,9 @@ en:
       searching: "Searching for: '%{query}'"
       command_options:
         search:
+          search_private:
+            name: "Search Private"
+            description: "Include all topics user has access to in search results (by default only public topics are included)"
           max_results:
             name: "Maximum number of results"
             description: "Maximum number of results to include in the search - if empty default rules will be used and count will be scaled depending on model used. Highest value is 100."

--- a/lib/ai_bot/tools/search.rb
+++ b/lib/ai_bot/tools/search.rb
@@ -83,7 +83,11 @@ module DiscourseAi
           end
 
           def accepted_options
-            [option(:base_query, type: :string), option(:max_results, type: :integer)]
+            [
+              option(:base_query, type: :string),
+              option(:max_results, type: :integer),
+              option(:search_private, type: :boolean),
+            ]
           end
         end
 
@@ -106,12 +110,18 @@ module DiscourseAi
             search_string = "#{search_string} #{options[:base_query]}"
           end
 
+          safe_search_string = search_string.to_s
+          guardian = nil
+
+          if options[:search_private] && context[:user]
+            guardian = Guardian.new(context[:user])
+          else
+            guardian = Guardian.new
+            safe_search_string += " status:public"
+          end
+
           results =
-            ::Search.execute(
-              search_string.to_s + " status:public",
-              search_type: :full_page,
-              guardian: Guardian.new(),
-            )
+            ::Search.execute(safe_search_string, search_type: :full_page, guardian: guardian)
 
           # let's be frugal with tokens, 50 results is too much and stuff gets cut off
           max_results = calculate_max_results(llm)
@@ -129,10 +139,10 @@ module DiscourseAi
           posts = posts[0..results_limit.to_i - 1]
 
           if should_try_semantic_search
-            semantic_search = DiscourseAi::Embeddings::SemanticSearch.new(Guardian.new())
+            semantic_search = DiscourseAi::Embeddings::SemanticSearch.new(guardian)
             topic_ids = Set.new(posts.map(&:topic_id))
 
-            search = ::Search.new(search_string, guardian: Guardian.new)
+            search = ::Search.new(search_string, guardian: guardian)
 
             results = nil
             begin

--- a/lib/ai_bot/tools/tool.rb
+++ b/lib/ai_bot/tools/tool.rb
@@ -66,14 +66,20 @@ module DiscourseAi
         end
 
         def options
-          self
-            .class
-            .accepted_options
-            .reduce(HashWithIndifferentAccess.new) do |memo, option|
-              val = @persona_options[option.name]
-              memo[option.name] = val if val
-              memo
+          result = HashWithIndifferentAccess.new
+          self.class.accepted_options.each do |option|
+            val = @persona_options[option.name]
+            if val
+              case option.type
+              when :boolean
+                val = val == "true"
+              when :integer
+                val = val.to_i
+              end
+              result[option.name] = val
             end
+          end
+          result
         end
 
         def chain_next_response?

--- a/spec/requests/admin/ai_personas_controller_spec.rb
+++ b/spec/requests/admin/ai_personas_controller_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
             "description" =>
               I18n.t("discourse_ai.ai_bot.command_options.search.max_results.description"),
           },
+          "search_private" => {
+            "type" => "boolean",
+            "name" => I18n.t("discourse_ai.ai_bot.command_options.search.search_private.name"),
+            "description" =>
+              I18n.t("discourse_ai.ai_bot.command_options.search.search_private.description"),
+          },
         },
       )
 


### PR DESCRIPTION
This optional feature allows search to be performed in the context
of the user that executed it.

By default we do not allow this behavior cause it means llm gets
access to potentially secure data.
