### PR TITLE
FEATURE: safeguard to avoid over triage

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -359,7 +359,7 @@ discourse_ai:
     default: ""
     secret: true
   ai_automation_max_triage_per_minute:
-    default: 40
+    default: 60
     hidden: true
   ai_automation_max_triage_per_post_per_minute:
     default: 2

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -358,3 +358,9 @@ discourse_ai:
   ai_bot_github_access_token:
     default: ""
     secret: true
+  ai_automation_max_triage_per_minute:
+    default: 40
+    hidden: true
+  ai_automation_max_triage_per_post_per_minute:
+    default: 2
+    hidden: true

--- a/discourse_automation/llm_triage.rb
+++ b/discourse_automation/llm_triage.rb
@@ -54,12 +54,14 @@ if defined?(DiscourseAutomation)
 
       begin
         RateLimiter.new(
+          Discourse.system_user,
           "llm_triage_#{post.id}",
           SiteSetting.ai_automation_max_triage_per_post_per_minute,
           1.minute,
         ).performed!
 
         RateLimiter.new(
+          Discourse.system_user,
           "llm_triage",
           SiteSetting.ai_automation_max_triage_per_minute,
           1.minute,


### PR DESCRIPTION
- a post can be triage a maximum of twice a minute
- system can run a total of 40 triages a minute

Low defaults were picked to safeguard against any possible loops
