### PR TITLE
FEATURE: Use DBreadcrumbsItem in admin UI

### DIFF
--- a/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-ai-personas/new.hbs
+++ b/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-ai-personas/new.hbs
@@ -1,3 +1,9 @@
+<DBreadcrumbsItem as |linkClass|>
+  <LinkTo @route="adminPlugins.show.discourse-ai-personas" class={{linkClass}}>
+    {{@model.plugin.nameTitleized}}
+  </LinkTo>
+</DBreadcrumbsItem>
+
 <AiPersonaListEditor
   @personas={{this.allPersonas}}
   @currentPersona={{this.model}}

--- a/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
 import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 import I18n from "discourse-i18n";
@@ -11,6 +12,15 @@ export default class AiLlmsListEditor extends Component {
   }
 
   <template>
+    <DBreadcrumbsItem as |linkClass|>
+      <LinkTo
+        @route="adminPlugins.show.discourse-ai-personas"
+        class={{linkClass}}
+      >
+        {{i18n "discourse_ai.llms.short_title"}}
+      </LinkTo>
+    </DBreadcrumbsItem>
+
     <section class="ai-llms-list-editor admin-detail pull-left">
 
       <div class="ai-llms-list-editor__header">

--- a/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
@@ -4,6 +4,7 @@ import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
 import concatClass from "discourse/helpers/concat-class";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -42,6 +43,15 @@ export default class AiPersonaListEditor extends Component {
   }
 
   <template>
+    <DBreadcrumbsItem as |linkClass|>
+      <LinkTo
+        @route="adminPlugins.show.discourse-ai-personas"
+        class={{linkClass}}
+      >
+        {{i18n "discourse_ai.ai_persona.short_title"}}
+      </LinkTo>
+    </DBreadcrumbsItem>
+
     <section class="ai-persona-list-editor__current admin-detail pull-left">
       {{#if @currentPersona}}
         <AiPersonaEditor @model={{@currentPersona}} @personas={{@personas}} />


### PR DESCRIPTION
This commit uses the new DBreadcrumbsItem and DBreadcrumbsContainer
from core to show a path back to the admin plugins list.

![image](https://github.com/discourse/discourse-ai/assets/920448/cb65223a-49c1-4a87-9202-a63f5b7c3d09)
