### PR TITLE
UX: suppress "this is a warning"

### DIFF
--- a/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
+++ b/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
@@ -4,6 +4,7 @@ nav.post-controls .actions button.cancel-streaming {
 
 .ai-bot-chat {
   #reply-control {
+    .user-selector,
     .title-and-category,
     #private-message-users {
       display: none;


### PR DESCRIPTION
When triggering a PM from new-message route, we still had the UI
for "this is an official warning"

This removes that UI from bot messages, which is all clutter.
