### PR TITLE
FIX: Amend incorrect translation keys

### DIFF
--- a/app/controllers/discourse_ai/ai_bot/shared_ai_conversations_controller.rb
+++ b/app/controllers/discourse_ai/ai_bot/shared_ai_conversations_controller.rb
@@ -19,7 +19,8 @@ module DiscourseAi
         if shared_conversation.persisted?
           render json: success_json.merge(share_key: shared_conversation.share_key)
         else
-          render json: failed_json.merge(error: I18n.t("discourse_ai.share_ai.failed_to_share")),
+          render json:
+                   failed_json.merge(error: I18n.t("discourse_ai.share_ai.errors.failed_to_share")),
                  status: :unprocessable_entity
         end
       end
@@ -30,7 +31,9 @@ module DiscourseAi
         SharedAiConversation.destroy_conversation(@shared_conversation)
 
         render json:
-                 success_json.merge(message: I18n.t("discourse_ai.share_ai.conversation_deleted"))
+                 success_json.merge(
+                   message: I18n.t("discourse_ai.share_ai.errors.conversation_deleted"),
+                 )
       end
 
       def show

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -245,7 +245,7 @@ en:
         search: "Search all public topics on the forum"
         tags: "List all tags on the forum"
         time: "Find time in various time zones"
-        summarize: "Summarize a topic"
+        summary: "Summarize a topic"
         image: "Generate image using Stable Diffusion"
         google: "Search Google for a query"
         read: "Read public topic on the forum"


### PR DESCRIPTION
### What is this fix?

I am enabling `config.i18n.raise_on_missing_translations` in core. This revealed a couple of broken translations in the plugin. This PR fixes that.