### PR TITLE
FIX: Move image caption group check logic to server side

### DIFF
--- a/assets/javascripts/discourse/connectors/user-preferences-nav/ai-preferences.gjs
+++ b/assets/javascripts/discourse/connectors/user-preferences-nav/ai-preferences.gjs
@@ -3,28 +3,19 @@ import { LinkTo } from "@ember/routing";
 import dIcon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 
-function showAiPreferences(user, siteSettings) {
+function showAiPreferences(user) {
   // Since we only have one AI related user setting we don't show
   // AI preferences if these conditions aren't met.
   // If we add more user settings in the future we can move this
   // logic to the the specific settings and conditionally show it in the template.
-  if (!user.groups) {
-    return false;
-  }
-
-  const userGroups = user.groups.map((g) => g.id);
-  const captionGroups = siteSettings.ai_auto_image_caption_allowed_groups
-    .split("|")
-    .map((id) => parseInt(id, 10));
-
-  return userGroups.some((groupId) => captionGroups.includes(groupId));
+  return user?.user_allowed_ai_auto_image_captions;
 }
 
 export default class AutoImageCaptionSetting extends Component {
   static shouldRender(outletArgs, helper) {
     return (
       helper.siteSettings.discourse_ai_enabled &&
-      showAiPreferences(outletArgs.model, helper.siteSettings)
+      showAiPreferences(outletArgs.model)
     );
   }
 

--- a/assets/javascripts/discourse/connectors/user-preferences-nav/ai-preferences.gjs
+++ b/assets/javascripts/discourse/connectors/user-preferences-nav/ai-preferences.gjs
@@ -8,6 +8,10 @@ function showAiPreferences(user, siteSettings) {
   // AI preferences if these conditions aren't met.
   // If we add more user settings in the future we can move this
   // logic to the the specific settings and conditionally show it in the template.
+  if (!user.groups) {
+    return false;
+  }
+
   const userGroups = user.groups.map((g) => g.id);
   const captionGroups = siteSettings.ai_auto_image_caption_allowed_groups
     .split("|")

--- a/lib/ai_helper/entry_point.rb
+++ b/lib/ai_helper/entry_point.rb
@@ -43,6 +43,10 @@ module DiscourseAi
           )
         end
 
+        plugin.add_to_serializer(:current_user, :user_allowed_ai_auto_image_captions) do
+          scope.user.in_any_groups?(SiteSetting.ai_auto_image_caption_allowed_groups_map)
+        end
+
         UserUpdater::OPTION_ATTR.push(:auto_image_caption)
         plugin.add_to_serializer(
           :user_option,


### PR DESCRIPTION
This PR moves the logic that checks whether a user in the allowed groups to use auto image captions to the server side. This is necessary because we don't serialize all of a user's groups to the client, so it can lead to issues if we handle it on the client side.