### PR TITLE
FEATURE: add support for all vision models

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -246,9 +246,7 @@ discourse_ai:
   ai_helper_image_caption_model:
     default: "llava"
     type: enum
-    choices:
-      - "llava"
-      - "open_ai:gpt-4-vision-preview"
+    enum: "DiscourseAi::Configuration::LlmVisionEnumerator"
   ai_auto_image_caption_allowed_groups:
     client: true
     type: group_list

--- a/lib/completions/llm.rb
+++ b/lib/completions/llm.rb
@@ -28,6 +28,15 @@ module DiscourseAi
           DiscourseAi::Tokenizer::BasicTokenizer.available_llm_tokenizers.map(&:name)
         end
 
+        def vision_models_by_provider
+          @vision_models_by_provider ||= {
+            aws_bedrock: %w[claude-3-sonnet claude-3-opus claude-3-haiku],
+            anthropic: %w[claude-3-sonnet claude-3-opus claude-3-haiku],
+            open_ai: %w[gpt-4-vision-preview gpt-4-turbo gpt-4o],
+            google: %w[gemini-1.5-pro gemini-1.5-flash],
+          }
+        end
+
         def models_by_provider
           # ChatGPT models are listed under open_ai but they are actually available through OpenAI and Azure.
           # However, since they use the same URL/key settings, there's no reason to duplicate them.

--- a/lib/configuration/llm_vision_enumerator.rb
+++ b/lib/configuration/llm_vision_enumerator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "enum_site_setting"
+
+module DiscourseAi
+  module Configuration
+    class LlmVisionEnumerator < ::EnumSiteSetting
+      def self.valid_value?(val)
+        true
+      end
+
+      def self.values
+        begin
+          result =
+            DiscourseAi::Completions::Llm.vision_models_by_provider.flat_map do |provider, models|
+              endpoint = DiscourseAi::Completions::Endpoints::Base.endpoint_for(provider.to_s)
+
+              models.map do |model_name|
+                { name: endpoint.display_name(model_name), value: "#{provider}:#{model_name}" }
+              end
+            end
+
+          result << { name: "Llava", value: "llava" }
+
+          result
+          # TODO add support for LlmModel as well
+          # LlmModel.all.each do |model|
+          #  llm_models << { name: model.display_name, value: "custom:#{model.id}" }
+          # end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/ai_helper/assistant_controller_spec.rb
+++ b/spec/requests/ai_helper/assistant_controller_spec.rb
@@ -87,11 +87,6 @@ RSpec.describe DiscourseAi::AiHelper::AssistantController do
         expected_diff =
           "<div class=\"inline-diff\"><p><ins>Un </ins><ins>usuario </ins><ins>escribio </ins><ins>esto</ins><del>A </del><del>user </del><del>wrote </del><del>this</del></p></div>"
 
-        expected_input = <<~TEXT.strip
-        <input>Translate to Spanish:
-        A user wrote this</input>
-        TEXT
-
         DiscourseAi::Completions::Llm.with_prepared_responses([translated_text]) do
           post "/discourse-ai/ai-helper/suggest",
                params: {


### PR DESCRIPTION
Previoulsy on GPT-4-vision was supported, change introduces support
for Google/Anthropic and new OpenAI models

Additionally this makes vision work properly in dev environments
cause we send the encoded payload via prompt vs sending urls
