### PR TITLE
FEATURE: restrict public sharing on login required sites

### DIFF
--- a/app/controllers/discourse_ai/ai_bot/shared_ai_conversations_controller.rb
+++ b/app/controllers/discourse_ai/ai_bot/shared_ai_conversations_controller.rb
@@ -7,7 +7,7 @@ module DiscourseAi
       requires_login only: %i[create update destroy]
       before_action :require_site_settings!
 
-      skip_before_action :preload_json, :check_xhr, :redirect_to_login_if_required, only: %i[show]
+      skip_before_action :preload_json, :check_xhr, only: %i[show]
 
       def create
         ensure_allowed_create!

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -99,7 +99,7 @@ en:
     ai_bot_enable_chat_warning: "Display a warning when PM chat is initiated. Can be overriden by editing the translation string: discourse_ai.ai_bot.pm_warning"
     ai_bot_allowed_groups: "When the GPT Bot has access to the PM, it will reply to members of these groups."
     ai_bot_debugging_allowed_groups: "Allow these groups to see a debug button on posts which displays the raw AI request and response"
-    ai_bot_public_sharing_allowed_groups: "Allow these groups to share AI personal messages with the public via a unique publicly available link"
+    ai_bot_public_sharing_allowed_groups: "Allow these groups to share AI personal messages with the public via a unique publicly available link. Note: if your site requires login, shares will also require login."
     ai_bot_enabled_chat_bots: "Available models to act as an AI Bot"
     ai_bot_add_to_header: "Display a button in the header to start a PM with a AI Bot"
     ai_bot_github_access_token: "GitHub access token for use with GitHub AI tools (required for search support)"
@@ -319,7 +319,7 @@ en:
         configuration_hint:
           one: "Make sure the `%{settings}` setting was configured."
           other: "Make sure these settings were configured: %{settings}"
-      
+
       delete_failed:
         one: "We couldn't delete this model because %{settings} is using it. Update the setting and try again."
         other: "We couldn't delete this model because %{settings} are using it. Update the settings and try again."

--- a/spec/requests/ai_bot/shared_ai_conversations_spec.rb
+++ b/spec/requests/ai_bot/shared_ai_conversations_spec.rb
@@ -252,6 +252,12 @@ RSpec.describe DiscourseAi::AiBot::SharedAiConversationsController do
   end
 
   describe "GET show" do
+    it "redirects to home page if site require login" do
+      SiteSetting.login_required = true
+      get "#{path}/#{shared_conversation.share_key}"
+      expect(response).to redirect_to("/login")
+    end
+
     it "renders the shared conversation" do
       get "#{path}/#{shared_conversation.share_key}"
       expect(response).to have_http_status(:success)


### PR DESCRIPTION
Initial implementation allowed internet wide sharing of
AI conversations, on sites that require login.

This feature can be an anti feature for private sites cause they
can not share conversations internally.

For now we are removing support for public sharing on login required
sites, if the community need the feature we can consider adding a
setting.
