### PR TITLE
FIX: Remove doubled up breadcrumb in persona UI

### DIFF
--- a/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-ai-personas/new.hbs
+++ b/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-ai-personas/new.hbs
@@ -1,9 +1,3 @@
-<DBreadcrumbsItem as |linkClass|>
-  <LinkTo @route="adminPlugins.show.discourse-ai-personas" class={{linkClass}}>
-    {{@model.plugin.nameTitleized}}
-  </LinkTo>
-</DBreadcrumbsItem>
-
 <AiPersonaListEditor
   @personas={{this.allPersonas}}
   @currentPersona={{this.model}}


### PR DESCRIPTION
Followup to 06137ac7066d35606ed54104a06e53535cf6f08c
