### PR TITLE
DEV: Conditionally show AI results toggle based on sort order

### DIFF
--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
@@ -24,11 +24,14 @@ export default class SemanticSearch extends Component {
   @tracked searching = false;
   @tracked AIResults = [];
   @tracked showingAIResults = false;
-  @tracked preventAISearch = false;
   initialSearchTerm = this.args.outletArgs.search;
 
   get disableToggleSwitch() {
-    if (this.searching || this.AIResults.length === 0 || this.preventAISearch) {
+    if (
+      this.searching ||
+      this.AIResults.length === 0 ||
+      this.args.outletArgs.sortOrder !== 0
+    ) {
       return true;
     }
   }
@@ -51,11 +54,6 @@ export default class SemanticSearch extends Component {
           }
         );
       }
-    }
-
-    // Search disabled for sort order:
-    if (this.preventAISearch) {
-      return I18n.t("discourse_ai.embeddings.semantic_search_disabled_sort");
     }
 
     // Search loading:
@@ -88,7 +86,8 @@ export default class SemanticSearch extends Component {
   get searchEnabled() {
     return (
       this.args.outletArgs.type === SEARCH_TYPE_DEFAULT &&
-      isValidSearchTerm(this.searchTerm, this.siteSettings)
+      isValidSearchTerm(this.searchTerm, this.siteSettings) &&
+      this.args.outletArgs.sortOrder === 0
     );
   }
 
@@ -113,15 +112,6 @@ export default class SemanticSearch extends Component {
   handleSearch() {
     if (!this.searchEnabled) {
       return;
-    }
-    if (
-      this.searchPreferencesManager?.sortOrder !== undefined &&
-      this.searchPreferencesManager?.sortOrder !== 0
-    ) {
-      this.preventAISearch = true;
-      return;
-    } else {
-      this.preventAISearch = false;
     }
 
     if (this.initialSearchTerm && !this.searching) {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -215,7 +215,7 @@ en:
         confirm_delete: Are you sure you want to delete this model?
         delete: Delete
 
-        tests: 
+        tests:
           title: "Run Test"
           running: "Running test..."
           success: "Success!"
@@ -295,7 +295,6 @@ en:
       embeddings:
         semantic_search: "Topics (Semantic)"
         semantic_search_loading: "Searching for more results using AI"
-        semantic_search_disabled_sort: "AI Search disabled for this sort order, sort by Relevance to enable."
         semantic_search_results:
           toggle: "Showing %{count} results found using AI"
           toggle_hidden: "Hiding %{count} results found using AI"


### PR DESCRIPTION
As mentioned on [Meta](https://meta.discourse.org/t/sorting-by-relevance-needs-additional-reload/300366?u=keegan), previously the sort order required a refresh to see the change in state of the AI toggle disabled text.

After merging https://github.com/discourse/discourse/pull/27247, we get access to the `sortOrder`'s tracking context so the changes can be updated properly in the respective getters.

We also simplify things so that we conditionally show the entire AI results toggle only when it is in an allowed `searchOrder`. There are too many edge cases when we show text for each scenario and conditionally showing/hiding the element presents a cleaner UX.