### PR TITLE
FIX: do not mark column read only so certain deployments work

### DIFF
--- a/db/migrate/20240609061418_tool_details_and_command_removal.rb
+++ b/db/migrate/20240609061418_tool_details_and_command_removal.rb
@@ -4,7 +4,10 @@ class ToolDetailsAndCommandRemoval < ActiveRecord::Migration[7.0]
   def change
     add_column :ai_personas, :tool_details, :boolean, default: true, null: false
     add_column :ai_personas, :tools, :json, null: false, default: []
-    Migration::ColumnDropper.mark_readonly(:ai_personas, :commands)
+    # we can not do this cause we are seeding the data and in certain
+    # build scenarios we seed prior to running post migrations
+    # this risks potentially dropping data but the window is small
+    # Migration::ColumnDropper.mark_readonly(:ai_personas, :commands)
 
     execute <<~SQL
       UPDATE ai_personas


### PR DESCRIPTION
In some case we may be deploying migrations, seeding and then
running post migrations, we need this to work so we give up
on this small window of protection
