### PR TITLE
UX: improve appearance of attributed quote when sharing

### DIFF
--- a/public/ai-share/share.css
+++ b/public/ai-share/share.css
@@ -325,7 +325,6 @@ h1 h2 h3 h4 h5 h6 {
   margin-bottom: 0;
 }
 
-
 .post__date {
   color: var(--primary-500);
   margin-left: auto;

--- a/public/ai-share/share.css
+++ b/public/ai-share/share.css
@@ -325,6 +325,7 @@ h1 h2 h3 h4 h5 h6 {
   margin-bottom: 0;
 }
 
+
 .post__date {
   color: var(--primary-500);
   margin-left: auto;
@@ -417,12 +418,29 @@ li, p {
   height: auto;
 }
 
+aside .title,
 blockquote {
   background-color: var(--primary-50);
   border-left: 6px solid var(--primary-200);
   padding: 0.5em 1em;
   margin: 1em 0;
 }
+
+aside .title + blockquote {
+  margin-top: 0;
+}
+
+aside .title  {
+  margin: 0;
+  display: flex;
+  align-items: center;
+}
+
+aside .title .avatar {
+  border-radius: 100%;
+  margin-right: 0.5em;
+}
+
 
 .lightbox-wrapper .meta svg, .lightbox-wrapper .meta .informations {
   display: none;


### PR DESCRIPTION
before:

![image](https://github.com/discourse/discourse-ai/assets/1681963/b8241cb2-6d13-4fb7-aeac-b5a1a88d856b)


after:

![image](https://github.com/discourse/discourse-ai/assets/1681963/e63c95cd-6d7b-43a3-b0c0-9a54d1135209)
