### PR TITLE
FIX: display search correctly, bug when stripping XML

### DIFF
--- a/lib/ai_bot/personas/sql_helper.rb
+++ b/lib/ai_bot/personas/sql_helper.rb
@@ -58,7 +58,18 @@ module DiscourseAi
             - When generating SQL always use ```sql Markdown code blocks.
             - When generating SQL NEVER end SQL samples with a semicolon (;).
 
-            Eg:
+            - You also understand the special formatting rules for Data Explorer in Discourse.
+               - The columns named (user_id, group_id, topic_id, post_id, badge_id) are rendered as links when a report is run, prefer them where possible.
+               - You can define custom params to create flexible queries, example:
+                  -- [params]
+                  -- int :num = 1
+                  -- text :name
+
+                  SELECT :num, :name
+               - You support the types (integer, text, boolean, date)
+
+
+            - When generating SQL use markdown formatting for code blocks, example:
 
             ```sql
             select 1 from table

--- a/lib/completions/xml_tag_stripper.rb
+++ b/lib/completions/xml_tag_stripper.rb
@@ -17,6 +17,7 @@ module DiscourseAi
           end
         end
         @parsed.concat(parse_tags(text))
+
         @parsed, result = process_parsed(@parsed)
         result
       end
@@ -69,9 +70,14 @@ module DiscourseAi
         while true
           before, after = text.split("<", 2)
 
-          parsed << { type: :text, content: before }
+          parsed << { type: :text, content: before } if before && !before.empty?
 
           break if after.nil?
+
+          if before.empty? && after.empty?
+            parsed << { type: :maybe_tag, content: "<" }
+            break
+          end
 
           tag, after = after.split(">", 2)
 

--- a/spec/lib/completions/xml_tag_stripper_spec.rb
+++ b/spec/lib/completions/xml_tag_stripper_spec.rb
@@ -29,6 +29,32 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
     expect(result).to eq("\nhello\n")
   end
 
+  it "does not crash when we send a <" do
+    result = +""
+    result << (tag_stripper << "based:\n")
+    result << (tag_stripper << "<").to_s
+    result << (tag_stripper << " href")
+    result << (tag_stripper << ">")
+    result << (tag_stripper << "test ")
+
+    expect(result).to eq("based:\n< href>test ")
+  end
+
+  it "strips thinking correctly in a stream" do
+    result = +""
+    result << (tag_stripper << "hello")
+    result << (tag_stripper << "<").to_s
+    result << (tag_stripper << "thinking").to_s
+    result << (tag_stripper << ">").to_s
+    result << (tag_stripper << "test").to_s
+    result << (tag_stripper << "<").to_s
+    result << (tag_stripper << "/").to_s
+    result << (tag_stripper << "thinking").to_s
+    result << (tag_stripper << "> world")
+
+    expect(result).to eq("hello world")
+  end
+
   it "works when nesting unrelated tags it strips correctly" do
     text = <<~TEXT
       <thinking>

--- a/spec/lib/modules/ai_bot/tools/search_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/search_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe DiscourseAi::AiBot::Tools::Search do
       results = search.invoke(&progress_blk)
       expect(results[:rows].length).to eq(1)
 
+      expect(search.last_query).to eq("#funny order:latest")
+
       GroupUser.create!(group: group, user: user)
 
       results = search.invoke(&progress_blk)


### PR DESCRIPTION
- Display filtered search correctly, so it is not confusing
- When XML stripping, if a chunk was `<` it would crash
- SQL Helper improved to be better aware of Data Explorer
