### PR TITLE
UX: show image caption button on image hover

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -482,37 +482,49 @@
 }
 
 // AI Image Caption Feature:
-.image-wrapper .button-wrapper {
-  .generate-caption {
-    background: var(--tertiary-low);
-    color: var(--tertiary);
-    box-shadow: var(--shadow-dropdown);
-    position: absolute;
-    white-space: nowrap;
-    top: -3.15rem;
-    left: 0.75rem;
-    padding: 0.5em 0.75em;
-    transition: all 0.25s ease;
+.image-wrapper {
+  .button-wrapper {
+    .generate-caption {
+      background: var(--tertiary-low);
+      color: var(--tertiary);
+      box-shadow: var(--shadow-dropdown);
+      position: absolute;
+      white-space: nowrap;
+      top: -2rem;
+      left: 0.35rem;
+      padding: 0.33em 0.75em;
+      transition: all 0.25s ease;
+      .discourse-no-touch & {
+        display: none;
+      }
 
-    .d-icon {
-      margin-right: 0.25rem;
+      .d-icon {
+        margin-right: 0.25rem;
+      }
+
+      &:active {
+        box-shadow: none;
+      }
+
+      &:hover,
+      &:focus {
+        background: var(--tertiary-400);
+        color: var(--tertiary-hover);
+        cursor: pointer;
+      }
+
+      &.disabled {
+        pointer-events: none;
+        cursor: not-allowed;
+        opacity: 0.7;
+      }
     }
-
-    &:active {
-      box-shadow: none;
-    }
-
-    &:hover,
-    &:focus {
-      background: var(--tertiary-400);
-      color: var(--tertiary-hover);
-      cursor: pointer;
-    }
-
-    &.disabled {
-      pointer-events: none;
-      cursor: not-allowed;
-      opacity: 0.7;
+  }
+  .discourse-no-touch & {
+    &:hover {
+      .button-wrapper .generate-caption {
+        display: block;
+      }
     }
   }
 }


### PR DESCRIPTION
This hides the image caption button on non-touch devices (desktop) until the image is hovered. 

In https://github.com/discourse/discourse/commit/0a99407bfb363a28ae1a419cc5e4c16346b784f8 we made the image controls always visible (not just on hover), and the caption button can kind of get in the way. So this helps hide it until needed since it's a little large. 

Before (button obscures image always): 

![image](https://github.com/discourse/discourse-ai/assets/1681963/c5dff7c1-69db-40b7-b051-1f9601e01f24)


After (button appears on control or image hover):
![image](https://github.com/discourse/discourse-ai/assets/1681963/62a9df57-cff2-4be5-ba32-7ea221a4e324)
