### PR TITLE
FEATURE: allow access to private topics if tool permits

### DIFF
--- a/app/controllers/discourse_ai/admin/ai_llms_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_llms_controller.rb
@@ -6,7 +6,7 @@ module DiscourseAi
       requires_plugin ::DiscourseAi::PLUGIN_NAME
 
       def index
-        llms = LlmModel.all
+        llms = LlmModel.all.order(:display_name)
 
         render json: {
                  ai_llms:

--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -18,9 +18,7 @@ class LlmModel < ActiveRecord::Base
           provider: "vllm",
           tokenizer: "DiscourseAi::Tokenizer::MixtralTokenizer",
           url: RESERVED_VLLM_SRV_URL,
-          vllm_key: "",
-          user_id: nil,
-          enabled_chat_bot: false,
+          max_prompt_tokens: 8000,
         )
 
       record.save(validate: false) # Ignore reserved URL validation
@@ -55,7 +53,8 @@ class LlmModel < ActiveRecord::Base
         new_user.save!(validate: false)
         self.update!(user: new_user)
       else
-        user.update!(active: true)
+        user.active = true
+        user.save!(validate: false)
       end
     elsif user
       # will include deleted

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -210,7 +210,7 @@ en:
         max_prompt_tokens: "Number of tokens for the prompt"
         url: "URL of the service hosting the model"
         api_key: "API Key of the service hosting the model"
-        enabled_chat_bot: "Allow Companion user to act as an AI Bot"
+        enabled_chat_bot: "Allow AI Bot"
         save: "Save"
         edit: "Edit"
         saved: "LLM Model Saved"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -207,6 +207,10 @@ en:
       summarizing: "Summarizing topic"
       searching: "Searching for: '%{query}'"
       tool_options:
+        read:
+          read_private:
+            name: "Read Private"
+            description: "Allow access to all topics user has access to (by default only public topics are included)"
         search:
           search_private:
             name: "Search Private"

--- a/db/post_migrate/20240603143158_seed_oss_models.rb
+++ b/db/post_migrate/20240603143158_seed_oss_models.rb
@@ -40,7 +40,7 @@ class SeedOssModels < ActiveRecord::Migration[7.0]
         reserved: srv_reserved_url,
       ).first
 
-    if vllm_srv.present? && srv.record.nil?
+    if vllm_srv.present? && srv_record.nil?
       url = "https://vllm.shadowed-by-srv.invalid"
       name = "mistralai/Mixtral"
 

--- a/lib/ai_bot/tools/tool.rb
+++ b/lib/ai_bot/tools/tool.rb
@@ -72,7 +72,7 @@ module DiscourseAi
             if val
               case option.type
               when :boolean
-                val = val == "true"
+                val = (val.to_s == "true")
               when :integer
                 val = val.to_i
               end

--- a/spec/system/ai_bot/persona_spec.rb
+++ b/spec/system/ai_bot/persona_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "AI personas", type: :system, js: true do
     expect(persona.name).to eq("Test Persona")
     expect(persona.description).to eq("I am a test persona")
     expect(persona.system_prompt).to eq("You are a helpful bot")
-    expect(persona.tools).to eq(["Read"])
+    expect(persona.tools).to eq([["Read", { "read_private" => nil }]])
   end
 
   it "will not allow deletion or editing of system personas" do


### PR DESCRIPTION
Previously read tool only had access to public topics, this allows
access to all topics user has access to, if admin opts for the option


Also fixes VLLM migration
