### PR TITLE
UX: QoL impromevements to the admin LLM models page.

### DIFF
--- a/app/serializers/llm_model_serializer.rb
+++ b/app/serializers/llm_model_serializer.rb
@@ -14,6 +14,8 @@ class LlmModelSerializer < ApplicationSerializer
              :enabled_chat_bot,
              :url_editable
 
+  has_one :user, serializer: BasicUserSerializer, embed: :object
+
   def url_editable
     object.url != LlmModel::RESERVED_VLLM_SRV_URL
   end

--- a/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
+++ b/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
@@ -32,4 +32,13 @@
       color: var(--success);
     }
   }
+
+  &__api-key {
+    margin-right: 0.5em;
+  }
+
+  &__secret-api-key-group {
+    display: flex;
+    align-items: center;
+  }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -211,6 +211,7 @@ en:
         url: "URL of the service hosting the model"
         api_key: "API Key of the service hosting the model"
         enabled_chat_bot: "Allow AI Bot"
+        ai_bot_user: "AI Bot User"
         save: "Save"
         edit: "Edit"
         saved: "LLM Model Saved"


### PR DESCRIPTION
API Key value is secret by default, and we include a link to the AI bot user.

<img width="500" alt="Screenshot 2024-06-19 at 10 52 35 AM" src="https://github.com/discourse/discourse-ai/assets/5025816/76034813-ad13-4aba-bbcd-4a421a379d51">
<img width="514" alt="Screenshot 2024-06-19 at 10 52 40 AM" src="https://github.com/discourse/discourse-ai/assets/5025816/3580b3d0-a105-4876-af7b-7c054034e1e7">
