### PR TITLE
FEATURE: Store provider-specific parameters.

### DIFF
--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -3,6 +3,7 @@
 class LlmModel < ActiveRecord::Base
   FIRST_BOT_USER_ID = -1200
   RESERVED_VLLM_SRV_URL = "https://vllm.shadowed-by-srv.invalid"
+  BEDROCK_PROVIDER_NAME = "aws_bedrock"
 
   belongs_to :user
 
@@ -26,6 +27,19 @@ class LlmModel < ActiveRecord::Base
     elsif srv_model.present?
       srv_model.destroy!
     end
+  end
+
+  def self.provider_params
+    {
+      aws_bedrock: {
+        url_editable: false,
+        fields: %i[access_key_id region],
+      },
+      open_ai: {
+        url_editable: true,
+        fields: %i[organization],
+      },
+    }
   end
 
   def toggle_companion_user_before_save
@@ -76,6 +90,10 @@ class LlmModel < ActiveRecord::Base
 
   def tokenizer_class
     tokenizer.constantize
+  end
+
+  def lookup_custom_param(key)
+    provider_params&.dig(key)
   end
 end
 

--- a/app/serializers/llm_model_serializer.rb
+++ b/app/serializers/llm_model_serializer.rb
@@ -12,11 +12,12 @@ class LlmModelSerializer < ApplicationSerializer
              :api_key,
              :url,
              :enabled_chat_bot,
-             :url_editable
+             :shadowed_by_srv,
+             :provider_params
 
   has_one :user, serializer: BasicUserSerializer, embed: :object
 
-  def url_editable
-    object.url != LlmModel::RESERVED_VLLM_SRV_URL
+  def shadowed_by_srv
+    object.url == LlmModel::RESERVED_VLLM_SRV_URL
   end
 end

--- a/assets/javascripts/discourse/admin/models/ai-llm.js
+++ b/assets/javascripts/discourse/admin/models/ai-llm.js
@@ -12,7 +12,8 @@ export default class AiLlm extends RestModel {
       "max_prompt_tokens",
       "url",
       "api_key",
-      "enabled_chat_bot"
+      "enabled_chat_bot",
+      "provider_params"
     );
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -230,6 +230,11 @@ en:
           google: "Google"
           azure: "Azure"
           ollama: "Ollama"
+      
+        provider_fields:
+          access_key_id: "AWS Bedrock Access key ID"
+          region: "AWS Bedrock Region"
+          organization: "Optional OpenAI Organization ID"
 
       related_topics:
         title: "Related Topics"

--- a/db/migrate/20240624135356_llm_model_custom_params.rb
+++ b/db/migrate/20240624135356_llm_model_custom_params.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class LlmModelCustomParams < ActiveRecord::Migration[7.1]
+  def change
+    add_column :llm_models, :provider_params, :jsonb
+  end
+end

--- a/db/post_migrate/20240624202602_add_provider_specific_params_to_llm_models.rb
+++ b/db/post_migrate/20240624202602_add_provider_specific_params_to_llm_models.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+class AddProviderSpecificParamsToLlmModels < ActiveRecord::Migration[7.1]
+  def up
+    open_ai_organization = fetch_setting("ai_openai_organization")
+
+    DB.exec(<<~SQL, organization: open_ai_organization) if open_ai_organization
+      UPDATE llm_models
+      SET provider_params = jsonb_build_object('organization', :organization)
+      WHERE provider = 'open_ai' AND provider_params IS NULL
+    SQL
+
+    bedrock_region = fetch_setting("ai_bedrock_region") || "us-east-1"
+    bedrock_access_key_id = fetch_setting("ai_bedrock_access_key_id")
+
+    DB.exec(<<~SQL, key_id: bedrock_access_key_id, region: bedrock_region) if bedrock_access_key_id
+      UPDATE llm_models
+      SET 
+        provider_params = jsonb_build_object('access_key_id', :key_id, 'region', :region),
+        name = CASE name WHEN 'claude-2' THEN 'anthropic.claude-v2:1'
+                         WHEN 'claude-3-haiku' THEN 'anthropic.claude-3-haiku-20240307-v1:0'
+                         WHEN 'claude-3-sonnet' THEN 'anthropic.claude-3-sonnet-20240229-v1:0'
+                         WHEN 'claude-instant-1' THEN 'anthropic.claude-instant-v1'
+                         WHEN 'claude-3-opus' THEN 'anthropic.claude-3-opus-20240229-v1:0'
+                         WHEN 'claude-3-5-sonnet' THEN 'anthropic.claude-3-5-sonnet-20240620-v1:0'
+                         ELSE name
+                         END
+      WHERE provider = 'aws_bedrock' AND provider_params IS NULL
+    SQL
+  end
+
+  def fetch_setting(name)
+    DB.query_single(
+      "SELECT value FROM site_settings WHERE name = :setting_name",
+      setting_name: name,
+    ).first
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -128,9 +128,9 @@ module DiscourseAi
             headers["Authorization"] = "Bearer #{api_key}"
           end
 
-          if SiteSetting.ai_openai_organization.present?
-            headers["OpenAI-Organization"] = SiteSetting.ai_openai_organization
-          end
+          org_id =
+            llm_model&.lookup_custom_param("organization") || SiteSetting.ai_openai_organization
+          headers["OpenAI-Organization"] = org_id if org_id.present?
 
           Net::HTTP::Post.new(model_uri, headers).tap { |r| r.body = payload }
         end


### PR DESCRIPTION
Previously, we stored request parameters like the OpenAI organization and Bedrock's access key and region as site settings. This change stores them in the `llm_models` table instead, letting us drop more settings while also becoming more flexible.