### PR TITLE
FIX: Move the bot user toggling to the controller.

### DIFF
--- a/app/controllers/discourse_ai/admin/ai_llms_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_llms_controller.rb
@@ -35,6 +35,7 @@ module DiscourseAi
       def create
         llm_model = LlmModel.new(ai_llm_params)
         if llm_model.save
+          llm_model.toggle_companion_user
           render json: { ai_persona: llm_model }, status: :created
         else
           render_json_error llm_model
@@ -69,6 +70,10 @@ module DiscourseAi
             )
           )
         end
+
+        # Clean up companion users
+        llm_model.enabled_chat_bot = false
+        llm_model.toggle_companion_user
 
         if llm_model.destroy
           head :no_content

--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -8,7 +8,6 @@ class LlmModel < ActiveRecord::Base
   belongs_to :user
 
   validates :url, exclusion: { in: [RESERVED_VLLM_SRV_URL] }
-  before_save :toggle_companion_user_before_save
 
   def self.enable_or_disable_srv_llm!
     srv_model = find_by(url: RESERVED_VLLM_SRV_URL)
@@ -40,10 +39,6 @@ class LlmModel < ActiveRecord::Base
         fields: %i[organization],
       },
     }
-  end
-
-  def toggle_companion_user_before_save
-    toggle_companion_user if enabled_chat_bot_changed? || new_record?
   end
 
   def toggle_companion_user


### PR DESCRIPTION
Having this as a callback prevents deploys of sites with a vLLM SRV configured and pending migrations. Additionally, this fixes a bug where we didn't delete/deactivate the companion user after deleting an LLM.