### PR TITLE
FIX: info not working, not suppressing hidden tags from report

### DIFF
--- a/assets/javascripts/discourse/lib/utilities.js
+++ b/assets/javascripts/discourse/lib/utilities.js
@@ -5,6 +5,10 @@ export const IMAGE_MARKDOWN_REGEX =
   /!\[(.*?)\|(\d{1,4}x\d{1,4})(,\s*\d{1,3}%)?(.*?)\]\((upload:\/\/.*?)\)(?!(.*`))/g;
 
 export function jsonToHtml(json) {
+  if (json === null) {
+    return "null";
+  }
+
   if (typeof json !== "object") {
     return escapeExpression(json);
   }

--- a/lib/automation/report_context_generator.rb
+++ b/lib/automation/report_context_generator.rb
@@ -85,8 +85,10 @@ module DiscourseAi
         info << "topic_id: #{topic.id}"
         info << "solved: true" if @solutions.key?(topic.id)
         info << "category: #{topic.category&.name}"
-        tags = topic.tags.pluck(:name)
-        info << "tags: #{topic.tags.pluck(:name).join(", ")}" if tags.present?
+        # We may make this optional, but for now we remove all
+        # tags that are not visible to anon
+        tags = topic.tags.visible(Guardian.new).pluck(:name)
+        info << "tags: #{tags.join(", ")}" if tags.present?
         info << topic.created_at.strftime("%Y-%m-%d %H:%M")
         { created_at: topic.created_at, info: info.join("\n"), posts: {} }
       end

--- a/spec/lib/modules/automation/report_runner_spec.rb
+++ b/spec/lib/modules/automation/report_runner_spec.rb
@@ -20,7 +20,16 @@ module DiscourseAi
       end
 
       fab!(:tag)
-      fab!(:topic_with_tag) { Fabricate(:topic, tags: [tag]) }
+      fab!(:hidden_tag) { Fabricate(:tag, name: "hidden-tag") }
+      fab!(:tag_group) do
+        tag_group = TagGroup.new(name: "test tag group")
+        tag_group.tag_group_permissions.build(group_id: Group::AUTO_GROUPS[:trust_level_1])
+
+        tag_group.save!
+        TagGroupMembership.create!(tag_group_id: tag_group.id, tag_id: hidden_tag.id)
+        tag_group
+      end
+      fab!(:topic_with_tag) { Fabricate(:topic, tags: [tag, hidden_tag]) }
       fab!(:post_with_tag) { Fabricate(:post, raw: "I am in a tag", topic: topic_with_tag) }
 
       describe "#run!" do
@@ -90,6 +99,9 @@ module DiscourseAi
           expect(debugging).not_to include(post_in_category.raw)
           expect(debugging).not_to include(post_in_subcategory.raw)
           expect(debugging).to include(post2.raw)
+          expect(debugging).to include(post_with_tag.raw)
+          expect(debugging).to include(tag.name)
+          expect(debugging).not_to include(hidden_tag.name)
         end
 
         it "can suppress notifications by remapping content" do

--- a/test/javascripts/unit/lib/utilities-test.js
+++ b/test/javascripts/unit/lib/utilities-test.js
@@ -1,0 +1,65 @@
+import { module, test } from "qunit";
+import { jsonToHtml } from "discourse/plugins/discourse-ai/discourse/lib/utilities";
+
+module("Unit | Utility | json-to-html", function () {
+  test("it properly handles nulls", function (assert) {
+    const input = null;
+    const result = jsonToHtml(input).toString();
+
+    assert.equal(result, "null", "Null should be properly formatted");
+  });
+
+  test("it properly handles boolean", function (assert) {
+    const input = true;
+    const result = jsonToHtml(input).toString();
+
+    assert.equal(result, "true", "Boolean should be properly formatted");
+  });
+
+  test("it properly handles numbers", function (assert) {
+    const input = 42.1;
+    const result = jsonToHtml(input).toString();
+
+    assert.equal(result, "42.1", "Numbers should be properly formatted");
+  });
+
+  test("it properly handles undefined", function (assert) {
+    const input = undefined;
+    const result = jsonToHtml(input).toString();
+
+    assert.equal(result, "", "Undefined should be properly formatted");
+  });
+
+  test("it handles nested objects correctly", function (assert) {
+    const input = {
+      outer: {
+        inner: {
+          key: "value",
+        },
+      },
+    };
+
+    const result = jsonToHtml(input).toString();
+    const expected =
+      "<ul><li><strong>outer:</strong> <ul><li><ul><li><strong>inner:</strong> <ul><li><ul><li><strong>key:</strong> value</li></ul></li></ul></li></ul></li></ul></li></ul>";
+
+    assert.equal(
+      result,
+      expected,
+      "Nested objects should be properly formatted"
+    );
+  });
+
+  test("it handles arrays correctly", function (assert) {
+    const input = {
+      array: [1, 2, 3],
+    };
+
+    const result = jsonToHtml(input).toString();
+
+    const expected =
+      "<ul><li><strong>array:</strong> <ul><li><strong>0:</strong> 1</li><li><strong>1:</strong> 2</li><li><strong>2:</strong> 3</li></ul></li></ul>";
+
+    assert.equal(result, expected, "Arrays should be properly formatted");
+  });
+});


### PR DESCRIPTION
2 small fixes

1. The info button was not properly working post refactor
2. Suppress any secured tags from report input
