### PR TITLE
FIX: Disabled chat breaks `ai-chat-summarization`

### DIFF
--- a/assets/javascripts/initializers/ai-chat-summarization.js
+++ b/assets/javascripts/initializers/ai-chat-summarization.js
@@ -11,7 +11,11 @@ export default apiInitializer("1.34.0", (api) => {
     currentUser &&
     currentUser.can_summarize;
 
-  if (!chatService.userCanChat || !siteSettings.chat_enabled || !canSummarize) {
+  if (
+    !siteSettings.chat_enabled ||
+    !chatService?.userCanChat ||
+    !canSummarize
+  ) {
     return;
   }
 


### PR DESCRIPTION
This PR fixes an issue where chat when disabled breaks sites.