### PR TITLE
FIX: repair id sequence identity on summary table

### DIFF
--- a/app/models/ai_summary.rb
+++ b/app/models/ai_summary.rb
@@ -26,3 +26,7 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #
+# Indexes
+#
+#  index_ai_summaries_on_target_type_and_target_id  (target_type,target_id)
+#

--- a/db/migrate/20240704020102_reset_identity_on_ai_summary.rb
+++ b/db/migrate/20240704020102_reset_identity_on_ai_summary.rb
@@ -4,7 +4,6 @@ class ResetIdentityOnAiSummary < ActiveRecord::Migration[7.0]
     add_index :ai_summaries, %i[target_type target_id]
 
     # we need to reset identity since we moved this from the old summary_sections table
-    # so ids may be way too low on the table
     execute <<-SQL
       DO $$
       DECLARE

--- a/db/migrate/20240704020102_reset_identity_on_ai_summary.rb
+++ b/db/migrate/20240704020102_reset_identity_on_ai_summary.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class ResetIdentityOnAiSummary < ActiveRecord::Migration[7.0]
+  def up
+    add_index :ai_summaries, %i[target_type target_id]
+
+    # we need to reset identity since we moved this from the old summary_sections table
+    # so ids may be way too low on the table
+    execute <<-SQL
+      DO $$
+      DECLARE
+          max_id integer;
+      BEGIN
+          SELECT MAX(id) INTO max_id FROM ai_summaries;
+          IF max_id IS NOT NULL THEN
+              PERFORM setval(pg_get_serial_sequence('ai_summaries', 'id'), max_id);
+          END IF;
+      END $$
+    SQL
+  end
+
+  def down
+    remove_index :ai_summaries, %i[target_type target_id]
+  end
+end


### PR DESCRIPTION
This PR

1. Repairs the identity on the summary table, we migrated data without resetting it.
2. Adds an index into ai_summary table to match expected retrieval pattern
