### PR TITLE
FIX: don't reset open state on details tag when morphing

### DIFF
--- a/assets/javascripts/discourse/lib/ai-streamer.js
+++ b/assets/javascripts/discourse/lib/ai-streamer.js
@@ -67,6 +67,12 @@ class StreamUpdater {
 }
 
 class PostUpdater extends StreamUpdater {
+  morphingOptions = {
+    beforeAttributeUpdated: (element, attributeName) => {
+      return !(element.tagName === "DETAILS" && attributeName === "open");
+    },
+  };
+
   constructor(postStream, postId) {
     super();
     this.postStream = postStream;
@@ -116,13 +122,11 @@ class PostUpdater extends StreamUpdater {
   async setCooked(value) {
     this.post.set("cooked", value);
 
-    const oldElement = this.postElement.querySelector(".cooked");
-
-    // TODO: use `morphInner` once version morphlex 0.0.16 is out
-    const newElement = oldElement.cloneNode(false);
-    newElement.innerHTML = value;
-
-    (await loadMorphlex()).morph(oldElement, newElement);
+    (await loadMorphlex()).morphInner(
+      this.postElement.querySelector(".cooked"),
+      `<div>${value}</div>`,
+      this.morphingOptions
+    );
   }
 
   get raw() {


### PR DESCRIPTION
The issue is that when cooking a post, the `<details>` are always "closed". So when morphing, it would automatically removes the "`open`" state.

This changes ensures we never more the "`open`" attribute on `<details>` tags by using the `beforeAttributeUpdated` callback (the same way we do in [core](https://github.com/discourse/discourse/blob/32c8bcc3af88158d74d5c33563f407f00b0e6fa8/app/assets/javascripts/discourse/app/components/d-editor.js#L514-L517)).

While it works when streaming, the `<details>` resets once it's done, leading to a sub-par user-experience 😢 

Haven't yet found an easy way to fix this issue 🤔 

---

No tests since 1) it's pretty hard to test streaming / morphing and 2) we already use a `FakeStreamUpdater` in tests which bypasses all of that 🤷‍♂️

Here's a recording of how it works with this fix:

https://github.com/discourse/discourse-ai/assets/362783/ccfc4623-a5eb-45ab-82b3-e28aaa6fac6f

