### PR TITLE
Fix: AiHelper malfunction when site's locale is Simplified Chinese

### DIFF
--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -29,7 +29,9 @@ module DiscourseAi
               prompts.map do |prompt|
                 if prompt.name == "translate"
                   locale = user.effective_locale
-                  locale_hash = LocaleSiteSetting.language_names[locale]
+                  locale_hash =
+                    LocaleSiteSetting.language_names[locale] ||
+                      LocaleSiteSetting.language_names[locale.split("_")[0]]
                   translation =
                     I18n.t(
                       "discourse_ai.ai_helper.prompts.translate",

--- a/spec/lib/modules/ai_helper/assistant_spec.rb
+++ b/spec/lib/modules/ai_helper/assistant_spec.rb
@@ -59,6 +59,11 @@ RSpec.describe DiscourseAi::AiHelper::Assistant do
       )
     end
 
+    it "does not raise an error when effective_locale does not exactly match keys in LocaleSiteSetting" do
+      SiteSetting.default_locale = "zh_CN"
+      expect { subject.available_prompts(user) }.not_to raise_error
+    end
+
     context "when illustrate post model is enabled" do
       before do
         SiteSetting.ai_helper_illustrate_post_model = "stable_diffusion_xl"


### PR DESCRIPTION
The latest AI plugin encounters an error when using the editor AI assistant's translation feature if the site setting or user custom language is set to Simplified Chinese (zh_CN).

I noticed a similar issue being reported on meta: [NoMethodError after upgrade](https://meta.discourse.org/t/nomethoderror-after-upgrade/315073).

The error originates from:
https://github.com/discourse/discourse-ai/blob/d555f18c6fadd4676d70ddd44f0bf63f2a8e8228/lib/ai_helper/assistant.rb#L32

The cause of the problem is that Simplified Chinese is coded as "zh_CN" in the site settings, but the key in LocaleSiteSetting is "zh", leading to a mismatch.

This PR fixes the issue by copying the approach used in Discourse core:

https://github.com/discourse/discourse/blob/bb0daa33cd93eeffb230689d1daacd737f61b2e7/app/models/locale_site_setting.rb#L11