### PR TITLE
FIX: ensure ai translation works for all possible locales

### DIFF
--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -59,7 +59,9 @@ module DiscourseAi
       def custom_locale_instructions(user = nil, force_default_locale)
         locale = SiteSetting.default_locale
         locale = user.effective_locale if !force_default_locale
-        locale_hash = LocaleSiteSetting.language_names[locale]
+        locale_hash =
+          LocaleSiteSetting.language_names[locale] ||
+            LocaleSiteSetting.language_names[locale.split("_")[0]]
 
         if locale != "en" && locale_hash
           locale_description = "#{locale_hash["name"]} (#{locale_hash["nativeName"]})"
@@ -80,7 +82,9 @@ module DiscourseAi
 
           locale = user.effective_locale if user && !force_default_locale
 
-          locale_hash = LocaleSiteSetting.language_names[locale]
+          locale_hash =
+            LocaleSiteSetting.language_names[locale] ||
+              LocaleSiteSetting.language_names[locale.split("_")[0]]
 
           prompt.messages[0][:content] = prompt.messages[0][:content].gsub(
             "%LANGUAGE%",


### PR DESCRIPTION
This PR is a follow-up to [#705](https://github.com/discourse/discourse-ai/pull/705). After deploying the previous fix to the production environment, I found that the AI translation functionality was still not working correctly. Upon further inspection, I discovered that there were two additional pieces of code in the [assistant.rb](https://github.com/discourse/discourse-ai/blob/main/lib/ai_helper/assistant.rb) file that had not been addressed.

This PR rectifies those issues. I have thoroughly searched the plugin’s codebase for LocaleSiteSetting and it appears that no other instances remain that require modification.

Additionally, I have revised the test cases from the previous PR to include all possible locales, not just Simplified Chinese. 

With these changes, AI translation now functions correctly as demonstrated in the image below (translate from English to Simplified Chinese):

![image](https://github.com/discourse/discourse-ai/assets/51732678/39450739-065c-47fa-b2ea-17eea7d62de6)



