### PR TITLE
DEV: Tweak topic title generator prompt

### DIFF
--- a/db/fixtures/ai_helper/603_completion_prompts.rb
+++ b/db/fixtures/ai_helper/603_completion_prompts.rb
@@ -174,9 +174,13 @@ CompletionPrompt.seed do |cp|
   cp.messages = {
     insts: <<~TEXT,
       I want you to act as a title generator for written pieces. I will provide you with a text,
-      and you will generate five attention-grabbing titles. Please keep the title concise and under 20 words,
+      and you will generate five titles. Please keep the title concise and under 20 words,
       and ensure that the meaning is maintained. Replies will utilize the language type of the topic.
       I want you to only reply the list of options and nothing else, do not write explanations.
+      Never ever use colons in the title. Always use sentence case with only one capital letter at
+      the start of the title, never start the title with a lower case letter. Proper nouns in the title
+      can have a capital letter. Frame the title as a question if it makes sense to, only make the title
+      a statement if a question doesn't make sense.
       Each title you generate must be separated by *.
       You will find the text between <input></input> XML tags.
     TEXT


### PR DESCRIPTION
Changes the title generator prompt to avoid clickbait-y
titles and also try to avoid AI's favourite title format,
which is "Some Thing: Other Thing"

Leaving the chat thread title generator for now, that's
not as important, the bizarre titles add to the experience there.
