### PR TITLE
DEV: More topic title prompt tweaks

### DIFF
--- a/db/fixtures/ai_helper/603_completion_prompts.rb
+++ b/db/fixtures/ai_helper/603_completion_prompts.rb
@@ -177,11 +177,11 @@ CompletionPrompt.seed do |cp|
       and you will generate five titles. Please keep the title concise and under 20 words,
       and ensure that the meaning is maintained. Replies will utilize the language type of the topic.
       I want you to only reply the list of options and nothing else, do not write explanations.
-      Never ever use colons in the title. Always use sentence case with only one capital letter at
+      Never ever use colons in the title. Always use sentence case, using a capital letter at
       the start of the title, never start the title with a lower case letter. Proper nouns in the title
-      can have a capital letter. Frame the title as a question if it makes sense to, only make the title
-      a statement if a question doesn't make sense.
-      Each title you generate must be separated by *.
+      can have a capital letter, and acronyms like LLM can use capital letters. Format some titles
+      as questions, some as statements. Make sure to use question marks if the title is a question.
+      Each title you generate must be separated by *
       You will find the text between <input></input> XML tags.
     TEXT
     examples: [


### PR DESCRIPTION
Followup 8d4a67fbe22f78d5907a9979f9954abebf068483

The prompt worked better, but it took the instructions
about never using lowercase a little too literally,
it wasn't using it for things like LLM or Discourse,
also it was almost always framing the title as questions
so now I asked it for a mix of questions and statements
because that's less ambiguous.
