### PR TITLE
FIX: Update model name to Qwen2

### DIFF
--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -21,7 +21,7 @@ class LlmModel < ActiveRecord::Base
         record =
           new(
             display_name: "vLLM SRV LLM",
-            name: "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            name: "Qwen/Qwen2-72B-Instruct-GPTQ-Int8",
             provider: "vllm",
             tokenizer: "DiscourseAi::Tokenizer::MixtralTokenizer",
             url: RESERVED_VLLM_SRV_URL,

--- a/db/post_migrate/20240708193243_fix_vllm_model_name.rb
+++ b/db/post_migrate/20240708193243_fix_vllm_model_name.rb
@@ -7,7 +7,7 @@ class FixVllmModelName < ActiveRecord::Migration[7.1]
 
     DB.exec(<<~SQL, target_id: vllm_mixtral_model_id) if vllm_mixtral_model_id
       UPDATE llm_models
-      SET name = 'mistralai/Mixtral-8x7B-Instruct-v0.1'
+      SET name = 'Qwen/Qwen2-72B-Instruct-GPTQ-Int8'
       WHERE id = :target_id
     SQL
   end

--- a/spec/models/llm_model_spec.rb
+++ b/spec/models/llm_model_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe LlmModel do
         llm_model = described_class.find_by(url: described_class::RESERVED_VLLM_SRV_URL)
 
         expect(llm_model).to be_present
-        expect(llm_model.name).to eq("mistralai/Mixtral-8x7B-Instruct-v0.1")
+        expect(llm_model.name).to eq("Qwen/Qwen2-72B-Instruct-GPTQ-Int8")
         expect(llm_model.api_key).to eq(SiteSetting.ai_vllm_api_key)
       end
     end


### PR DESCRIPTION
We updated our SRV-backed model to "Qwen/Qwen2-72B-Instruct-GPTQ-Int8".

We'll devise a different strategy to seed models without hardcoded names soon.  It's a temporary solution.