### PR TITLE
FIX: Properly fix ai_summaries table sequence

### DIFF
--- a/db/migrate/20240726164937_fix_ai_summaries_sequence.rb
+++ b/db/migrate/20240726164937_fix_ai_summaries_sequence.rb
@@ -2,30 +2,34 @@
 
 class FixAiSummariesSequence < ActiveRecord::Migration[7.0]
   def up
-    execute <<-SQL
-      SELECT
-        SETVAL (
-          'ai_summaries_id_seq',
-          (
-            SELECT
-              GREATEST (
-                (
-                  SELECT
-                    MAX(id)
-                  FROM
-                    summary_sections
-                ),
-                (
-                  SELECT
-                    MAX(id)
-                  FROM
-                    ai_summaries
+    begin
+      execute <<-SQL
+        SELECT
+          SETVAL (
+            'ai_summaries_id_seq',
+            (
+              SELECT
+                GREATEST (
+                  (
+                    SELECT
+                      MAX(id)
+                    FROM
+                      summary_sections
+                  ),
+                  (
+                    SELECT
+                      MAX(id)
+                    FROM
+                      ai_summaries
+                  )
                 )
-              )
-          ),
-          true
-        );
-    SQL
+            ),
+            true
+          );
+      SQL
+    rescue ActiveRecord::StatementInvalid => e
+      # if the summary_table does not exist, we can ignore the error
+    end
   end
 
   def down

--- a/db/migrate/20240726164937_fix_ai_summaries_sequence.rb
+++ b/db/migrate/20240726164937_fix_ai_summaries_sequence.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class FixAiSummariesSequence < ActiveRecord::Migration[7.0]
+  def up
+    execute <<-SQL
+      SELECT
+        SETVAL (
+          'ai_summaries_id_seq',
+          (
+            SELECT
+              GREATEST (
+                (
+                  SELECT
+                    MAX(id)
+                  FROM
+                    summary_sections
+                ),
+                (
+                  SELECT
+                    max(id)
+                  FROM
+                    summary_sections
+                )
+              )
+          ),
+          true
+        );
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20240726164937_fix_ai_summaries_sequence.rb
+++ b/db/migrate/20240726164937_fix_ai_summaries_sequence.rb
@@ -19,7 +19,7 @@ class FixAiSummariesSequence < ActiveRecord::Migration[7.0]
                   SELECT
                     max(id)
                   FROM
-                    summary_sections
+                    ai_summaries
                 )
               )
           ),

--- a/db/migrate/20240726164937_fix_ai_summaries_sequence.rb
+++ b/db/migrate/20240726164937_fix_ai_summaries_sequence.rb
@@ -17,7 +17,7 @@ class FixAiSummariesSequence < ActiveRecord::Migration[7.0]
                 ),
                 (
                   SELECT
-                    max(id)
+                    MAX(id)
                   FROM
                     ai_summaries
                 )


### PR DESCRIPTION
Previous attempt at 3815360 could fail due to a race introduced in 1b0ba91 where summaries are migrated to core in a post_migrate erroneously.