### PR TITLE
FIX: properly pass errors to client

### DIFF
--- a/app/controllers/discourse_ai/admin/ai_llms_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_llms_controller.rb
@@ -38,7 +38,7 @@ module DiscourseAi
           llm_model.toggle_companion_user
           render json: { ai_persona: LlmModelSerializer.new(llm_model) }, status: :created
         else
-          render_json_error LlmModelSerializer.new(llm_model)
+          render_json_error llm_model
         end
       end
 
@@ -49,7 +49,7 @@ module DiscourseAi
           llm_model.toggle_companion_user
           render json: LlmModelSerializer.new(llm_model)
         else
-          render_json_error LlmModelSerializer.new(llm_model)
+          render_json_error llm_model
         end
       end
 

--- a/app/controllers/discourse_ai/admin/ai_personas_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_personas_controller.rb
@@ -63,7 +63,7 @@ module DiscourseAi
 
           render json: LocalizedAiPersonaSerializer.new(@ai_persona, root: false)
         else
-          render_json_error LocalizedAiPersonaSerializer.new(@ai_persona, root: false)
+          render_json_error @ai_persona
         end
       end
 
@@ -71,7 +71,7 @@ module DiscourseAi
         if @ai_persona.destroy
           head :no_content
         else
-          render_json_error LocalizedAiPersonaSerializer.new(@ai_persona, root: false)
+          render_json_error @ai_persona
         end
       end
 


### PR DESCRIPTION
render_json_error expects a AR model not a serializer, using a
serializer eats up the error message
