### PR TITLE
FEATURE: Make emotion analysis enabled by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -66,7 +66,7 @@ discourse_ai:
   ai_sentiment_models:
     type: list
     list_type: compact
-    default: "emotion"
+    default: "emotion|sentiment"
     allow_any: false
     choices:
       - sentiment


### PR DESCRIPTION
Every week someone gets confused because this isn't enabled, so let's enable it by default when the module is enabled.