### PR TITLE
UX: summary fixed positioning

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
@@ -124,7 +124,7 @@ export default class AiSummaryBox extends Component {
       })
       .then(() => {
         if (update.done) {
-          this.summarizedOn = shortDateNoYear(topicSummary.updated_at);
+          this.summarizedOn = shortDateNoYear(moment(topicSummary.updated_at, 'YYYY-MM-DD HH:mm:ss Z'));
           this.summarizedBy = topicSummary.algorithm;
           this.newPostsSinceSummary = topicSummary.new_posts_since_summary;
           this.outdated = topicSummary.outdated;

--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
@@ -21,6 +21,7 @@ export default class AiSummaryBox extends Component {
   @service siteSettings;
   @service messageBus;
   @service currentUser;
+  @service site;
 
   @tracked text = "";
   @tracked summarizedOn = null;
@@ -160,12 +161,14 @@ export default class AiSummaryBox extends Component {
             <div class="ai-summary-container">
               <header class="ai-summary__header">
                 <h3>{{i18n "discourse_ai.summarization.topic.title"}}</h3>
-                <DButton
-                  @title="discourse_ai.summarization.topic.close"
-                  @action={{this.unsubscribe}}
-                  @icon="times"
-                  @class="btn-transparent ai-summary__close"
-                />
+                {{#if this.site.desktopView}}
+                  <DButton
+                    @title="discourse_ai.summarization.topic.close"
+                    @action={{this.unsubscribe}}
+                    @icon="times"
+                    @class="btn-transparent ai-summary__close"
+                  />
+                {{/if}}
               </header>
 
               <article class="ai-summary-box">

--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
@@ -124,7 +124,9 @@ export default class AiSummaryBox extends Component {
       })
       .then(() => {
         if (update.done) {
-          this.summarizedOn = shortDateNoYear(moment(topicSummary.updated_at, 'YYYY-MM-DD HH:mm:ss Z'));
+          this.summarizedOn = shortDateNoYear(
+            moment(topicSummary.updated_at, "YYYY-MM-DD HH:mm:ss Z")
+          );
           this.summarizedBy = topicSummary.algorithm;
           this.newPostsSinceSummary = topicSummary.new_posts_since_summary;
           this.outdated = topicSummary.outdated;

--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
@@ -135,6 +135,17 @@ export default class AiSummaryBox extends Component {
       });
   }
 
+  @action
+  onRegisterApi(api) {
+    this.dMenu = api;
+  }
+
+  @action
+  async onClose(buttonAction) {
+    await this.dMenu.close();
+    this.unsubscribe();
+  }
+
   <template>
     {{#if @outletArgs.topic.summarizable}}
       <div
@@ -146,6 +157,7 @@ export default class AiSummaryBox extends Component {
           @onShow={{this.generateSummary}}
           @arrow={{true}}
           @identifier="topic-map__ai-summary"
+          @onRegisterApi={{this.onRegisterApi}}
           @interactive={{true}}
           @triggers="click"
           @placement="left"
@@ -164,7 +176,7 @@ export default class AiSummaryBox extends Component {
                 {{#if this.site.desktopView}}
                   <DButton
                     @title="discourse_ai.summarization.topic.close"
-                    @action={{this.unsubscribe}}
+                    @action={{this.onClose}}
                     @icon="times"
                     @class="btn-transparent ai-summary__close"
                   />

--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
@@ -158,7 +158,16 @@ export default class AiSummaryBox extends Component {
         >
           <:content>
             <div class="ai-summary-container">
-              <h3>Topic Summary</h3>
+              <header class="ai-summary__header">
+                <h3>{{i18n "discourse_ai.summarization.topic.title"}}</h3>
+                <DButton
+                  @title="discourse_ai.summarization.topic.close"
+                  @action={{this.unsubscribe}}
+                  @icon="times"
+                  @class="btn-transparent ai-summary__close"
+                />
+              </header>
+
               <article class="ai-summary-box">
                 {{#if this.loading}}
                   <AiSummarySkeleton />

--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
@@ -141,7 +141,7 @@ export default class AiSummaryBox extends Component {
   }
 
   @action
-  async onClose(buttonAction) {
+  async onClose() {
     await this.dMenu.close();
     this.unsubscribe();
   }

--- a/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
@@ -1,0 +1,16 @@
+.topic-map {
+  .ai-summarization-button {
+    .fk-d-menu {
+      position: fixed;
+      top: calc(var(--header-offset) + 1rem) !important;
+      left: unset !important;
+      right: 1rem !important;
+      max-width: 470px !important; //overruling JS
+      max-height: calc(100vh - var(--header-offset) - 3rem);
+
+      &__inner-content {
+        max-height: unset;
+      }
+    }
+  }
+}

--- a/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
@@ -5,6 +5,7 @@
       top: calc(var(--header-offset) + 1rem) !important;
       left: unset !important;
       right: 1rem !important;
+      width: 470px;
       max-width: 470px !important; //overruling JS
       max-height: calc(100vh - var(--header-offset) - 3rem);
 

--- a/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
@@ -10,6 +10,34 @@
 
       &__inner-content {
         max-height: unset;
+        padding: 0;
+      }
+
+      .ai-summary__header,
+      .ai-summary-box {
+        padding-inline: 1.5rem;
+        box-sizing: border-box;
+      }
+
+      .ai-summary {
+        &__header {
+          position: sticky;
+          top: 0;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding-block: 0.5rem;
+          padding-right: 0.5rem;
+          background: var(--secondary);
+          border-bottom: 1px solid var(--primary-low);
+
+          h3 {
+            margin: 0;
+          }
+        }
+        &-box {
+          padding-bottom: 1rem;
+        }
       }
     }
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -404,6 +404,9 @@ en:
           since:
             one: "Last hour"
             other: "Last %{count} hours"
+        topic:
+          title: "Topic summary"
+          close: "Close summary panel"
     review:
       types:
         reviewable_ai_post:

--- a/plugin.rb
+++ b/plugin.rb
@@ -16,6 +16,7 @@ enabled_site_setting :discourse_ai_enabled
 register_asset "stylesheets/modules/ai-helper/common/ai-helper.scss"
 
 register_asset "stylesheets/modules/summarization/common/ai-summary.scss"
+register_asset "stylesheets/modules/summarization/desktop/ai-summary.scss", :desktop
 
 register_asset "stylesheets/modules/ai-bot/common/bot-replies.scss"
 register_asset "stylesheets/modules/ai-bot/common/ai-persona.scss"


### PR DESCRIPTION
This commit:

* positions the topic summary on desktop fixed to the right hand side
* increases the max-width and uses the same value for default width, avoiding jumpyness
* introduces a sticky header + close button

<img width="1447" alt="image" src="https://github.com/user-attachments/assets/f3bd78cd-a124-4809-af5a-318d61ee3b15">
