### PR TITLE
FIX: Handle nil reply_to_post in AI Bot event handler

### DIFF
--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -80,7 +80,7 @@ module DiscourseAi
           mentions = post.mentions.map(&:downcase)
 
           # in case we are replying to a post by a bot
-          if post.reply_to_post_number && post.reply_to_post.user
+          if post.reply_to_post_number && post.reply_to_post&.user
             mentions << post.reply_to_post.user.username_lower
           end
 


### PR DESCRIPTION
Somehow it's possible to have a nil `post.reply_to_post` with a non-nil `post.reply_to_post_number`.