### PR TITLE
FIX: Correctly save provider-specific params for new models.

### DIFF
--- a/admin/assets/javascripts/discourse/routes/admin-plugins-show-discourse-ai-llms-new.js
+++ b/admin/assets/javascripts/discourse/routes/admin-plugins-show-discourse-ai-llms-new.js
@@ -3,6 +3,7 @@ import DiscourseRoute from "discourse/routes/discourse";
 export default DiscourseRoute.extend({
   async model() {
     const record = this.store.createRecord("ai-llm");
+    record.provider_params = {};
     return record;
   },
 

--- a/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
+++ b/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
@@ -30,14 +30,6 @@ export default class AiLlmEditorForm extends Component {
   @tracked testError = null;
   @tracked apiKeySecret = true;
 
-  didReceiveAttrs() {
-    super.didReceiveAttrs(...arguments);
-
-    if (!this.args.model.provider_params) {
-      this.populateProviderParams(this.args.model.provider);
-    }
-  }
-
   get selectedProviders() {
     const t = (provName) => {
       return I18n.t(`discourse_ai.llms.providers.${provName}`);

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -326,3 +326,7 @@ en:
         hint:
           one: "Make sure the `%{settings}` setting was configured."
           other: "Make sure the settings of the provider you want were configured. Options are: %{settings}"
+
+    llm_models:
+      missing_provider_param: "%{param} can't be blank"
+      bedrock_invalid_url: "Please complete all the fields to contact this model."

--- a/db/migrate/20240807150605_add_default_to_provider_params.rb
+++ b/db/migrate/20240807150605_add_default_to_provider_params.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddDefaultToProviderParams < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :llm_models, :provider_params, from: nil, to: {}
+  end
+end

--- a/lib/completions/endpoints/aws_bedrock.rb
+++ b/lib/completions/endpoints/aws_bedrock.rb
@@ -66,6 +66,10 @@ module DiscourseAi
               llm_model.name
             end
 
+          if region.blank? || bedrock_model_id.blank?
+            raise CompletionFailed.new(I18n.t("discourse_ai.llm_models.bedrock_invalid_url"))
+          end
+
           api_url =
             "https://bedrock-runtime.#{region}.amazonaws.com/model/#{bedrock_model_id}/invoke"
 


### PR DESCRIPTION
Creating a new model, either manually or from presets, doesn't initialize the `provider_params` object, meaning their custom params won't persist.

Additionally, this change adds some validations for Bedrock params, which are mandatory, and a clear message when a completion fails because we cannot build the URL.