### PR TITLE
FIX: AI helper not being shown on mobile view

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -612,5 +612,5 @@
 }
 
 .mobile-view .fk-d-menu[data-identifier="ai-composer-helper-menu"] {
-  z-index: 1100;
+  z-index: z("mobile-composer");
 }


### PR DESCRIPTION
This PR fixes an issue where the AI composer helper was not being shown on mobile view. This is due to the z-index being insufficient for mobile.