### PR TITLE
FEATURE: LLM Triage support for systemless models.

### DIFF
--- a/admin/assets/javascripts/discourse/routes/admin-plugins-show-discourse-ai-llms-show.js
+++ b/admin/assets/javascripts/discourse/routes/admin-plugins-show-discourse-ai-llms-show.js
@@ -4,7 +4,9 @@ export default DiscourseRoute.extend({
   async model(params) {
     const allLlms = this.modelFor("adminPlugins.show.discourse-ai-llms");
     const id = parseInt(params.id, 10);
-    return allLlms.findBy("id", id);
+    const record = allLlms.findBy("id", id);
+    record.provider_params = record.provider_params || {};
+    return record;
   },
 
   setupController(controller, model) {

--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -17,12 +17,17 @@ class LlmModel < ActiveRecord::Base
   def self.provider_params
     {
       aws_bedrock: {
-        url_editable: false,
-        fields: %i[access_key_id region],
+        access_key_id: :text,
+        region: :text,
       },
       open_ai: {
-        url_editable: true,
-        fields: %i[organization],
+        organization: :text,
+      },
+      hugging_face: {
+        disable_system_prompt: :checkbox,
+      },
+      vllm: {
+        disable_system_prompt: :checkbox,
       },
     }
   end

--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -29,6 +29,9 @@ class LlmModel < ActiveRecord::Base
       vllm: {
         disable_system_prompt: :checkbox,
       },
+      ollama: {
+        disable_system_prompt: :checkbox,
+      },
     }
   end
 

--- a/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
+++ b/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
@@ -7,6 +7,7 @@ import { action, computed } from "@ember/object";
 import { LinkTo } from "@ember/routing";
 import { later } from "@ember/runloop";
 import { inject as service } from "@ember/service";
+import { eq } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
 import Avatar from "discourse/helpers/bound-avatar-template";
@@ -52,9 +53,9 @@ export default class AiLlmEditorForm extends Component {
     return this.testRunning || this.testResult !== null;
   }
 
+  @computed("args.model.provider")
   get canEditURL() {
-    // Explicitly false.
-    return this.metaProviderParams.url_editable !== false;
+    return this.args.model.provider === "aws_bedrock";
   }
 
   get modulesUsingModel() {
@@ -227,18 +228,24 @@ export default class AiLlmEditorForm extends Component {
           <DButton @action={{this.toggleApiKeySecret}} @icon="far-eye-slash" />
         </div>
       </div>
-      {{#each this.metaProviderParams.fields as |field|}}
-        <div class="control-group">
+      {{#each-in this.metaProviderParams as |field type|}}
+        <div class="control-group ai-llm-editor-provider-param__{{type}}">
           <label>{{I18n.t
               (concat "discourse_ai.llms.provider_fields." field)
             }}</label>
-          <Input
-            @type="text"
-            @value={{mut (get @model.provider_params field)}}
-            class="ai-llm-editor-input ai-llm-editor__{{field}}"
-          />
+          {{#if (eq type "checkbox")}}
+            <Input
+              @type={{type}}
+              @checked={{mut (get @model.provider_params field)}}
+            />
+          {{else}}
+            <Input
+              @type={{type}}
+              @value={{mut (get @model.provider_params field)}}
+            />
+          {{/if}}
         </div>
-      {{/each}}
+      {{/each-in}}
       <div class="control-group">
         <label>{{I18n.t "discourse_ai.llms.tokenizer"}}</label>
         <ComboBox

--- a/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
+++ b/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
@@ -18,6 +18,15 @@
     width: 350px;
   }
 
+  .ai-llm-editor-provider-param {
+    &__checkbox {
+      display: flex;
+      align-items: flex-start;
+      flex-direction: row-reverse;
+      justify-content: left;
+    }
+  }
+
   .fk-d-tooltip__icon {
     padding-left: 0.25em;
     color: var(--primary-medium);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -273,6 +273,7 @@ en:
           access_key_id: "AWS Bedrock Access key ID"
           region: "AWS Bedrock Region"
           organization: "Optional OpenAI Organization ID"
+          disable_system_prompt: "Disable system message in prompts"
 
       related_topics:
         title: "Related Topics"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,7 +4,6 @@ en:
       llm_triage:
         title: Triage posts using AI
         description: "Triage posts using a large language model"
-        system_prompt_missing_post_placeholder: "System prompt must contain a placeholder for the post: %%POST%%"
         flagged_post: |
           <div>Response from the model:</div>
           <p>%%LLM_RESPONSE%%</p>

--- a/discourse_automation/llm_triage.rb
+++ b/discourse_automation/llm_triage.rb
@@ -9,17 +9,7 @@ if defined?(DiscourseAutomation)
 
     triggerables %i[post_created_edited]
 
-    field :system_prompt,
-          component: :message,
-          required: true,
-          validator: ->(input) do
-            if !input.include?("%%POST%%")
-              I18n.t(
-                "discourse_automation.scriptables.llm_triage.system_prompt_missing_post_placeholder",
-              )
-            end
-          end,
-          accepts_placeholders: true
+    field :system_prompt, component: :message, required: false
     field :search_for_text, component: :text, required: true
     field :model,
           component: :choices,

--- a/lib/completions/dialects/open_ai_compatible.rb
+++ b/lib/completions/dialects/open_ai_compatible.rb
@@ -24,6 +24,18 @@ module DiscourseAi
           32_000
         end
 
+        def translate
+          translated = super
+
+          return translated unless llm_model.lookup_custom_param("disable_system_prompt")
+
+          system_and_user_msgs = translated.shift(2)
+          user_msg = system_and_user_msgs.last
+          user_msg[:content] = [system_and_user_msgs.first[:content], user_msg[:content]].join("\n")
+
+          translated.unshift(user_msg)
+        end
+
         private
 
         def system_msg(msg)

--- a/spec/lib/completions/dialects/open_ai_compatible_spec.rb
+++ b/spec/lib/completions/dialects/open_ai_compatible_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::Completions::Dialects::OpenAiCompatible do
+  context "when system prompts are disabled" do
+    it "merges the system prompt into the first message" do
+      system_msg = "This is a system message"
+      user_msg = "user message"
+      prompt =
+        DiscourseAi::Completions::Prompt.new(
+          system_msg,
+          messages: [{ type: :user, content: user_msg }],
+        )
+
+      model = Fabricate(:vllm_model, provider_params: { disable_system_prompt: true })
+
+      translated_messages = described_class.new(prompt, model).translate
+
+      expect(translated_messages.length).to eq(1)
+      expect(translated_messages).to contain_exactly(
+        { role: "user", content: [system_msg, user_msg].join("\n") },
+      )
+    end
+  end
+
+  context "when system prompts are enabled" do
+    it "includes system and user messages separately" do
+      system_msg = "This is a system message"
+      user_msg = "user message"
+      prompt =
+        DiscourseAi::Completions::Prompt.new(
+          system_msg,
+          messages: [{ type: :user, content: user_msg }],
+        )
+
+      model = Fabricate(:vllm_model, provider_params: { disable_system_prompt: false })
+
+      translated_messages = described_class.new(prompt, model).translate
+
+      expect(translated_messages.length).to eq(2)
+      expect(translated_messages).to contain_exactly(
+        { role: "system", content: system_msg },
+        { role: "user", content: user_msg },
+      )
+    end
+  end
+end

--- a/spec/requests/admin/ai_llms_controller_spec.rb
+++ b/spec/requests/admin/ai_llms_controller_spec.rb
@@ -136,6 +136,24 @@ RSpec.describe DiscourseAi::Admin::AiLlmsController do
         expect(created_model.lookup_custom_param("region")).to eq("us-east-1")
         expect(created_model.lookup_custom_param("access_key_id")).to eq("test")
       end
+
+      it "supports boolean values" do
+        post "/admin/plugins/discourse-ai/ai-llms.json",
+             params: {
+               ai_llm:
+                 valid_attrs.merge(
+                   provider: "vllm",
+                   provider_params: {
+                     disable_system_prompt: true,
+                   },
+                 ),
+             }
+
+        created_model = LlmModel.last
+
+        expect(response.status).to eq(201)
+        expect(created_model.lookup_custom_param("disable_system_prompt")).to eq(true)
+      end
     end
   end
 


### PR DESCRIPTION
This change adds support for OSS models without support for system messages. LlmTriage's system message field is no longer mandatory. We now send the post contents in a separate user message.