### PR TITLE
FIX: Clicking on summary links breaks summary

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
@@ -69,8 +69,10 @@ export default class AiSummaryBox extends Component {
   }
 
   @bind
-  subscribe(unsubscribe) {
-    if (unsubscribe && this._channel) {
+  subscribe(unsubscribe, [topicId]) {
+    const sameTopicId = this.args.outletArgs.topic.id === topicId;
+
+    if (unsubscribe && this._channel && !sameTopicId) {
       this.unsubscribe();
     }
     const channel = `/discourse-ai/summaries/topic/${this.args.outletArgs.topic.id}`;

--- a/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
@@ -37,7 +37,7 @@
           }
         }
         &-box {
-          padding-bottom: 1rem;
+          padding-block: 1rem;
         }
       }
     }

--- a/test/javascripts/acceptance/topic-summary-test.js
+++ b/test/javascripts/acceptance/topic-summary-test.js
@@ -66,6 +66,37 @@ acceptance("Topic - Summary", function (needs) {
       .dom(".ai-summary-box .summarized-on")
       .exists("summary metadata exists");
   });
+
+  test("clicking summary links", async function (assert) {
+    await visit("/t/-/1");
+
+    const partialSummary = "In this post,";
+    await publishToMessageBus("/discourse-ai/summaries/topic/1", {
+      done: false,
+      ai_topic_summary: { summarized_text: partialSummary },
+    });
+
+    await click(".ai-topic-summarization");
+    const finalSummaryCooked =
+      "In this post,  <a href='/t/-/1/1'>bianca</a> said some stuff.";
+    const finalSummaryResult = "In this post, bianca said some stuff.";
+    await publishToMessageBus("/discourse-ai/summaries/topic/1", {
+      done: true,
+      ai_topic_summary: {
+        summarized_text: finalSummaryCooked,
+        summarized_on: "2023-01-01T04:00:00.000Z",
+        algorithm: "OpenAI GPT-4",
+        outdated: false,
+        new_posts_since_summary: false,
+        can_regenerate: true,
+      },
+    });
+
+    await click(".generated-summary a");
+    assert
+      .dom(".ai-summary-box .generated-summary p")
+      .hasText(finalSummaryResult, "Retains final summary after clicking link");
+  });
 });
 
 acceptance("Topic - Summary - Anon", function (needs) {


### PR DESCRIPTION
**This PR fixes an issue where the summary breaks when you click on a link inside the summary.**


---


**Additionally, this PR also sneaks in a small UX fix:**

_Before_
![Screenshot 2024-08-19 at 17 08 40](https://github.com/user-attachments/assets/d8fd1621-b6da-4390-8e73-71e5d15f252e)


_After_
![Screenshot 2024-08-19 at 17 08 33](https://github.com/user-attachments/assets/569dfc6b-4625-4a13-881a-24bf0c517be5)
