### PR TITLE
FEATURE: Allow specific groups access to summary feature on PMs

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -80,6 +80,7 @@ en:
     ai_summarization_enabled: "Enable the topic summarization module."
     ai_summarization_model: "Model to use for summarization."
     ai_custom_summarization_allowed_groups: "Groups allowed to use create new summaries."
+    ai_pm_summarization_allowed_groups: "Groups allowed to create and view summaries in PMs."
 
     ai_bot_enabled: "Enable the AI Bot module."
     ai_bot_enable_chat_warning: "Display a warning when PM chat is initiated. Can be overriden by editing the translation string: discourse_ai.ai_bot.pm_warning"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -353,6 +353,10 @@ discourse_ai:
     type: enum
     enum: "DiscourseAi::Configuration::LlmEnumerator"
     validator: "DiscourseAi::Configuration::LlmValidator"
+  ai_pm_summarization_allowed_groups:
+    type: group_list
+    list_type: compact
+    default: ""
   ai_custom_summarization_allowed_groups:
     type: group_list
     list_type: compact

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -5,8 +5,14 @@ module DiscourseAi
     def can_see_summary?(target)
       return false if !SiteSetting.ai_summarization_enabled
 
-      # TODO we want a switch to allow summaries for all topics
-      return false if target.class == Topic && target.private_message?
+      if target.class == Topic && target.private_message?
+        allowed =
+          SiteSetting.ai_pm_summarization_allowed_groups_map.any? do |group_id|
+            user.group_ids.include?(group_id)
+          end
+
+        return false if !allowed
+      end
 
       has_cached_summary = AiSummary.exists?(target: target)
       return has_cached_summary if user.nil?

--- a/spec/lib/guardian_extensions_spec.rb
+++ b/spec/lib/guardian_extensions_spec.rb
@@ -50,6 +50,11 @@ describe DiscourseAi::GuardianExtensions do
       it "returns false" do
         expect(guardian.can_see_summary?(pm)).to eq(false)
       end
+
+      it "returns true if user is in a group that is allowed summaries" do
+        SiteSetting.ai_pm_summarization_allowed_groups = group.id
+        expect(guardian.can_see_summary?(pm)).to eq(true)
+      end
     end
 
     context "when there is no user" do


### PR DESCRIPTION
New `ai_pm_summarization_allowed_groups` can be used to allow
visibility of the summarization feature on PMs.

This can be useful on forums where a lot of communication happens
inside PMs.
