### PR TITLE
FIX: Mobile composer helper trigger should work on Android and iOS

### DIFF
--- a/assets/stylesheets/modules/ai-helper/mobile/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/mobile/ai-helper.scss
@@ -15,7 +15,8 @@
   max-width: unset;
   z-index: z("fullscreen");
   top: calc(
-    var(--mobile-virtual-screen-height) - var(--composer-helper-menu-height)
+    var(--mobile-virtual-screen-height) - var(--composer-helper-menu-height) -
+      env(keyboard-inset-height)
   );
   right: 0;
   padding-right: 1rem;
@@ -61,6 +62,12 @@
       margin: 0;
     }
   }
+}
+
+.ios-safari-composer-hacks .ai-composer-helper-menu:not(.is-expanded) {
+  top: calc(
+    var(--mobile-virtual-screen-height) - var(--composer-helper-menu-height)
+  );
 }
 
 @keyframes slide-in {


### PR DESCRIPTION
In a previous commit https://github.com/discourse/discourse-ai/commit/10dae65740043e2d6e30e5eea8938fe99624e16c we improved the UX for showing the composer helper menu on mobile devices. However, it was only working on iOS and was having issues on Android.

This PR updates the positioning to take into account the `env(keyboard-inset-height)` so it works correctly on Android. Additionally, this makes the positioning incorrect for iOS so we fallback to the previous CSS using the existing body class `ios-safari-composer-hacks`.