### PR TITLE
FIX: Tool editing code editor resetting on every keypress

### DIFF
--- a/assets/javascripts/discourse/components/ai-tool-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-tool-editor.gjs
@@ -192,7 +192,6 @@ export default class AiToolEditor extends Component {
           <label>{{I18n.t "discourse_ai.tools.script"}}</label>
           <AceEditor
             @content={{this.editingModel.script}}
-            @onChange={{withEventValue (fn (mut this.editingModel.script))}}
             @mode={{ACE_EDITOR_MODE}}
             @theme={{ACE_EDITOR_THEME}}
             @editorId="ai-tool-script-editor"


### PR DESCRIPTION
`withEventValue` is not needed here, because the `onChange` event comes from ace, not a normal DOM event. But even with that fix, it seems AceEditor doesn't yet work well with the DDAU pattern. On every keypress, the editor re-renders and puts the cursor back at the beginning.

For now, this commit removes the `@onChange` hook, so we go back to relying on the two-way binding of `@content`.

Followup to a5a39dd2ee5a71365cd349cabc1f34e261235d24