### PR TITLE
DEV: Update ace-editor usage

### DIFF
--- a/assets/javascripts/discourse/components/ai-tool-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-tool-editor.gjs
@@ -192,6 +192,7 @@ export default class AiToolEditor extends Component {
           <label>{{I18n.t "discourse_ai.tools.script"}}</label>
           <AceEditor
             @content={{this.editingModel.script}}
+            @onChange={{fn (mut this.editingModel.script)}}
             @mode={{ACE_EDITOR_MODE}}
             @theme={{ACE_EDITOR_THEME}}
             @editorId="ai-tool-script-editor"


### PR DESCRIPTION
AceEditor is now a glimmer component (see: https://github.com/discourse/discourse/pull/28492) and it follows the "data down, actions up" pattern.