### PR TITLE
Revert "FEATURE: Triage rule can skip posts created via email"

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -99,9 +99,6 @@ en:
             model:
               label: "Model"
               description: "Language model used for triage"
-            skip_via_email:
-              label: "Skip via email"
-              description: "Don't triage posts created via email"
 
     discourse_ai:
       title: "AI"

--- a/discourse_automation/llm_triage.rb
+++ b/discourse_automation/llm_triage.rb
@@ -19,7 +19,6 @@ if defined?(DiscourseAutomation)
           }
     field :category, component: :category
     field :tags, component: :tags
-    field :skip_via_email, component: :boolean
     field :hide_topic, component: :boolean
     field :flag_post, component: :boolean
     field :canned_reply, component: :message
@@ -42,9 +41,6 @@ if defined?(DiscourseAutomation)
       tags = fields.dig("tags", "value")
       hide_topic = fields.dig("hide_topic", "value")
       flag_post = fields.dig("flag_post", "value")
-
-      skip_via_email = fields.dig("skip_via_email", "value")
-      next if skip_via_email && post.via_email?
 
       begin
         RateLimiter.new(

--- a/spec/lib/discourse_automation/llm_triage_spec.rb
+++ b/spec/lib/discourse_automation/llm_triage_spec.rb
@@ -62,38 +62,4 @@ describe DiscourseAi::Automation::LlmTriage do
     last_post = post.topic.reload.posts.order(:post_number).last
     expect(last_post.raw).to eq post.raw
   end
-
-  describe "posts created via email" do
-    fab!(:email_post) { Fabricate(:post_via_email) }
-
-    context "when skip_via_email is enabled" do
-      before { add_automation_field("skip_via_email", true, type: "boolean") }
-
-      it "does nothing" do
-        DiscourseAi::Completions::Llm.with_prepared_responses(["bad"]) do
-          automation.running_in_background!
-          automation.trigger!({ "post" => email_post })
-        end
-
-        reviewable = ReviewablePost.find_by(target: email_post)
-
-        expect(reviewable).to be_nil
-      end
-    end
-
-    context "when skip_via_email is disabled" do
-      before { add_automation_field("skip_via_email", false, type: "boolean") }
-
-      it "flags the post" do
-        DiscourseAi::Completions::Llm.with_prepared_responses(["bad"]) do
-          automation.running_in_background!
-          automation.trigger!({ "post" => email_post })
-        end
-
-        reviewable = ReviewablePost.find_by(target: email_post)
-
-        expect(reviewable).to be_present
-      end
-    end
-  end
 end

--- a/spec/lib/modules/automation/llm_triage_spec.rb
+++ b/spec/lib/modules/automation/llm_triage_spec.rb
@@ -4,15 +4,19 @@ describe DiscourseAi::Automation::LlmTriage do
   fab!(:llm_model)
 
   def triage(**args)
-    rule_args = { model: "custom:#{llm_model.id}", automation: nil, system_prompt: "test" }.merge(
-      args,
-    )
-    DiscourseAi::Automation::LlmTriage.handle(**rule_args)
+    DiscourseAi::Automation::LlmTriage.handle(**args)
   end
 
   it "does nothing if it does not pass triage" do
     DiscourseAi::Completions::Llm.with_prepared_responses(["good"]) do
-      triage(post: post, hide_topic: true, search_for_text: "bad")
+      triage(
+        post: post,
+        model: "custom:#{llm_model.id}",
+        hide_topic: true,
+        system_prompt: "test %%POST%%",
+        search_for_text: "bad",
+        automation: nil,
+      )
     end
 
     expect(post.topic.reload.visible).to eq(true)
@@ -20,7 +24,14 @@ describe DiscourseAi::Automation::LlmTriage do
 
   it "can hide topics on triage" do
     DiscourseAi::Completions::Llm.with_prepared_responses(["bad"]) do
-      triage(post: post, hide_topic: true, search_for_text: "bad")
+      triage(
+        post: post,
+        model: "custom:#{llm_model.id}",
+        hide_topic: true,
+        system_prompt: "test %%POST%%",
+        search_for_text: "bad",
+        automation: nil,
+      )
     end
 
     expect(post.topic.reload.visible).to eq(false)
@@ -30,7 +41,14 @@ describe DiscourseAi::Automation::LlmTriage do
     category = Fabricate(:category)
 
     DiscourseAi::Completions::Llm.with_prepared_responses(["bad"]) do
-      triage(post: post, category_id: category.id, search_for_text: "bad")
+      triage(
+        post: post,
+        model: "custom:#{llm_model.id}",
+        category_id: category.id,
+        system_prompt: "test %%POST%%",
+        search_for_text: "bad",
+        automation: nil,
+      )
     end
 
     expect(post.topic.reload.category_id).to eq(category.id)
@@ -41,9 +59,12 @@ describe DiscourseAi::Automation::LlmTriage do
     DiscourseAi::Completions::Llm.with_prepared_responses(["bad"]) do
       triage(
         post: post,
+        model: "custom:#{llm_model.id}",
+        system_prompt: "test %%POST%%",
         search_for_text: "bad",
         canned_reply: "test canned reply 123",
         canned_reply_user: user.username,
+        automation: nil,
       )
     end
 
@@ -55,7 +76,14 @@ describe DiscourseAi::Automation::LlmTriage do
 
   it "can add posts to the review queue" do
     DiscourseAi::Completions::Llm.with_prepared_responses(["bad"]) do
-      triage(post: post, search_for_text: "bad", flag_post: true)
+      triage(
+        post: post,
+        model: "custom:#{llm_model.id}",
+        system_prompt: "test %%POST%%",
+        search_for_text: "bad",
+        flag_post: true,
+        automation: nil,
+      )
     end
 
     reviewable = ReviewablePost.last
@@ -66,7 +94,14 @@ describe DiscourseAi::Automation::LlmTriage do
 
   it "can handle garbled output from LLM" do
     DiscourseAi::Completions::Llm.with_prepared_responses(["Bad.\n\nYo"]) do
-      triage(post: post, search_for_text: "bad", flag_post: true)
+      triage(
+        post: post,
+        model: "custom:#{llm_model.id}",
+        system_prompt: "test %%POST%%",
+        search_for_text: "bad",
+        flag_post: true,
+        automation: nil,
+      )
     end
 
     reviewable = ReviewablePost.last
@@ -76,7 +111,14 @@ describe DiscourseAi::Automation::LlmTriage do
 
   it "treats search_for_text as case-insensitive" do
     DiscourseAi::Completions::Llm.with_prepared_responses(["bad"]) do
-      triage(post: post, search_for_text: "BAD", flag_post: true)
+      triage(
+        post: post,
+        model: "custom:#{llm_model.id}",
+        system_prompt: "test %%POST%%",
+        search_for_text: "BAD",
+        flag_post: true,
+        automation: nil,
+      )
     end
 
     reviewable = ReviewablePost.last


### PR DESCRIPTION
Reverts discourse/discourse-ai#775

We think it's best to add it as a trigger field in the `automation` plugin instead.