### PR TITLE
FIX: Prevent proofreading when there is no content

### DIFF
--- a/assets/javascripts/initializers/ai-helper.js
+++ b/assets/javascripts/initializers/ai-helper.js
@@ -1,10 +1,23 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
+import i18n from "discourse-common/helpers/i18n";
 import ModalDiffModal from "../discourse/components/modal/diff-modal";
 
 function initializeProofread(api) {
   api.addComposerToolbarPopupMenuOption({
     action: (toolbarEvent) => {
       const modal = api.container.lookup("service:modal");
+      const composer = api.container.lookup("service:composer");
+      const toasts = api.container.lookup("service:toasts");
+
+      if (composer.model.reply?.length === 0) {
+        toasts.error({
+          duration: 3000,
+          data: {
+            message: i18n("discourse_ai.ai_helper.proofread.no_content_error"),
+          },
+        });
+        return;
+      }
 
       modal.show(ModalDiffModal, {
         model: {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -240,7 +240,6 @@ en:
           one: "This model is currently used by the %{settings} setting. If misconfigured, the feature won't work as expected."
           other: "This model is currently used by the following settings: %{settings}. If misconfigured, features won't work as expected. "
 
-
         preconfigured_llms: "Select your LLM"
         preconfigured:
           none: "Configure manually..."
@@ -329,6 +328,8 @@ en:
             prompt: "This post contains non-captioned images. Would you like to enable automatic AI captions on image uploads? (This can be changed in your preferences later)"
             confirm: "Enable"
             cancel: "Don't ask again"
+        proofread:
+          no_content_error: "Unable to proofread text, please add some content to proofread."
 
       reviewables:
         model_used: "Model used:"

--- a/spec/system/ai_helper/ai_proofreading_spec.rb
+++ b/spec/system/ai_helper/ai_proofreading_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "AI Composer Proofreading Features", type: :system, js: true do
   end
 
   let(:composer) { PageObjects::Components::Composer.new }
+  let(:toasts) { PageObjects::Components::Toasts.new }
 
   it "proofreads selected text using the composer toolbar" do
     visit "/new-topic"
@@ -39,6 +40,18 @@ RSpec.describe "AI Composer Proofreading Features", type: :system, js: true do
 
       find(".composer-ai-helper-modal .btn-primary.confirm").click
       expect(composer.composer_input.value).to eq("hello world")
+    end
+  end
+
+  it "does not trigger proofread modal if composer is empty" do
+    visit "/new-topic"
+
+    # Simulate AI response
+    DiscourseAi::Completions::Llm.with_prepared_responses(["hello world"]) do
+      ai_toolbar = PageObjects::Components::SelectKit.new(".toolbar-popup-menu-options")
+      ai_toolbar.expand
+      ai_toolbar.select_row_by_name("Proofread Text")
+      expect(toasts).to have_error(I18n.t("js.discourse_ai.ai_helper.proofread.no_content_error"))
     end
   end
 end


### PR DESCRIPTION
This PR adds a minor fix to the recently added single click proofreading feature (https://github.com/discourse/discourse-ai/commit/f148452f4c7362ea4f9b7e9fb9f0f5c76aa608ff) to prevent the modal from being triggered when the composer has no content.

When no content is present and proofread is selected (either clicked on via keyboard shortcut), it will short circuit early and provide a message to the user in the form of an error toast.