### PR TITLE
UX: Summary container should be fixed instead of growing

### DIFF
--- a/assets/stylesheets/modules/summarization/common/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/common/ai-summary.scss
@@ -40,7 +40,7 @@
 
 .topic-map__ai-summary-content {
   .ai-summary-container {
-    width: 100%;
+    width: 100vw;
   }
 
   .ai-summary {


### PR DESCRIPTION
This PR fixes a minor UX issue where the topic summary container was growing as the contents were streamed. We now instead have a full width to the container so it stays its full size rather than growing.

**Before:**

https://github.com/user-attachments/assets/419002bb-e673-47d5-8ed3-4012b24bad9d


**After:**

https://github.com/user-attachments/assets/1e87f155-95e6-44ef-8a6a-f7f673c6a1a1

