### PR TITLE
UX: replace "share" with "share-alt" icon

### DIFF
--- a/assets/javascripts/initializers/ai-bot-replies.js
+++ b/assets/javascripts/initializers/ai-bot-replies.js
@@ -177,7 +177,7 @@ function initializeShareButton(api) {
 
     return {
       action: shareAiResponse,
-      icon: "share",
+      icon: "share-alt",
       className: "post-action-menu__share",
       title: "discourse_ai.ai_bot.share",
       position: "first",


### PR DESCRIPTION
the default share arrow looks kind of like reply 

before:
![image](https://github.com/user-attachments/assets/3548cc33-fcb8-45b7-9b97-ab9af87563da)

after: 
![image](https://github.com/user-attachments/assets/0c7e1c5f-bc13-42e5-8d38-ae5033100d8f)
