### PR TITLE
FEATURE: API scope for semantic search

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,6 +1,12 @@
 en:
   admin_js:
     admin:
+      api:
+        scopes:
+          descriptions:
+            discourse_ai:
+              search: "Allows semantic search via the /discourse-ai/embeddings/semantic-search endpoint."
+
       site_settings:
         categories:
           discourse_ai: "Discourse AI"

--- a/lib/embeddings/entry_point.rb
+++ b/lib/embeddings/entry_point.rb
@@ -67,6 +67,11 @@ module DiscourseAi
         plugin.on(:topic_edited, &callback)
         plugin.on(:post_created, &callback)
         plugin.on(:post_edited, &callback)
+
+        plugin.add_api_key_scope(
+          :discourse_ai,
+          { search: { actions: %w[discourse_ai/embeddings/embeddings#search] } },
+        )
       end
     end
   end


### PR DESCRIPTION
The new API scope allows restricting access to semantic search
only.
