### PR TITLE
FIX: coerce value before downcasing the hyde param

### DIFF
--- a/app/controllers/discourse_ai/embeddings/embeddings_controller.rb
+++ b/app/controllers/discourse_ai/embeddings/embeddings_controller.rb
@@ -9,7 +9,7 @@ module DiscourseAi
 
       def search
         query = params[:q].to_s
-        skip_hyde = params[:hyde].downcase.to_s == "false" || params[:hyde].to_s == "0"
+        skip_hyde = params[:hyde].to_s.downcase == "false" || params[:hyde].to_s == "0"
 
         if query.length < SiteSetting.min_search_term_length
           raise Discourse::InvalidParameters.new(:q)

--- a/spec/requests/embeddings/embeddings_controller_spec.rb
+++ b/spec/requests/embeddings/embeddings_controller_spec.rb
@@ -88,5 +88,21 @@ describe DiscourseAi::Embeddings::EmbeddingsController do
       expect(response.status).to eq(200)
       expect(response.parsed_body["topics"].map { |t| t["id"] }).to eq([topic_in_subcategory.id])
     end
+
+    it "doesn't skip HyDE if the hyde param is missing" do
+      assign_fake_provider_to(:ai_embeddings_semantic_search_hyde_model)
+      index(topic)
+      index(topic_in_subcategory)
+
+      query = "test category:#{category.slug}"
+      stub_embedding("test")
+
+      DiscourseAi::Completions::Llm.with_prepared_responses(["Hyde #{query}"]) do
+        get "/discourse-ai/embeddings/semantic-search.json?q=#{query}"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topics"].map { |t| t["id"] }).to eq([topic_in_subcategory.id])
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes 
```
NoMethodError (undefined method `downcase' for nil)
```