### PR TITLE
FIX: Correctly display errors when parent module needs to be disabled first

### DIFF
--- a/lib/configuration/llm_validator.rb
+++ b/lib/configuration/llm_validator.rb
@@ -9,9 +9,9 @@ module DiscourseAi
 
       def valid_value?(val)
         if val == ""
-          parent_module_name = modules_and_choose_llm_settings.invert[@opts[:name]]
+          @parent_module_name = modules_and_choose_llm_settings.invert[@opts[:name]]
 
-          @parent_enabled = SiteSetting.public_send(parent_module_name)
+          @parent_enabled = SiteSetting.public_send(@parent_module_name)
           return !@parent_enabled
         end
 
@@ -42,7 +42,7 @@ module DiscourseAi
           return(
             I18n.t(
               "discourse_ai.llm.configuration.disable_module_first",
-              setting: parent_module_name,
+              setting: @parent_module_name,
             )
           )
         end

--- a/spec/configuration/llm_validator_spec.rb
+++ b/spec/configuration/llm_validator_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::Configuration::LlmValidator do
+  describe "#valid_value?" do
+    context "when the parent module is enabled and we try to reset the selected model" do
+      before do
+        assign_fake_provider_to(:ai_summarization_model)
+        SiteSetting.ai_summarization_enabled = true
+      end
+
+      it "returns false and display an error message" do
+        validator = described_class.new(name: :ai_summarization_model)
+
+        value = validator.valid_value?("")
+
+        expect(value).to eq(false)
+        expect(validator.error_message).to include("ai_summarization_enabled")
+      end
+    end
+  end
+end

--- a/spec/configuration/llm_validator_spec.rb
+++ b/spec/configuration/llm_validator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DiscourseAi::Configuration::LlmValidator do
         SiteSetting.ai_summarization_enabled = true
       end
 
-      it "returns false and display an error message" do
+      it "returns false and displays an error message" do
         validator = described_class.new(name: :ai_summarization_model)
 
         value = validator.valid_value?("")


### PR DESCRIPTION
Fixes:

```
NameError (undefined local variable or method `parent_module_name' for an instance of DiscourseAi::Configuration::LlmValidator)
```