### PR TITLE
FIX: Bail earlier when a chat thread has no messages

### DIFF
--- a/lib/ai_helper/chat_thread_titler.rb
+++ b/lib/ai_helper/chat_thread_titler.rb
@@ -8,12 +8,14 @@ module DiscourseAi
       end
 
       def suggested_title
-        @thread.then { thread_content(_1) }.then { call_llm(_1) }.then { cleanup(_1) }
+        content = thread_content(@thread)
+        return nil if content.blank?
+
+        suggested_title = call_llm(content)
+        cleanup(suggested_title)
       end
 
       def call_llm(thread_content)
-        return nil if thread_content.blank?
-
         chat = "<input>\n#{thread_content}\n</input>"
 
         prompt =

--- a/spec/lib/modules/ai_helper/chat_thread_titler_spec.rb
+++ b/spec/lib/modules/ai_helper/chat_thread_titler_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe DiscourseAi::AiHelper::ChatThreadTitler do
   fab!(:chat_message) { Fabricate(:chat_message, thread: thread) }
   fab!(:user)
 
+  describe "#suggested_title" do
+    it "bails early if thread has no content" do
+      empty_thread = Chat::Thread.new
+
+      result = described_class.new(empty_thread).suggested_title
+
+      expect(result).to be_nil
+    end
+  end
+
   describe "#cleanup" do
     it "picks the first when there are multiple" do
       titles = "The solitary horse\nThe horse etched in gold"


### PR DESCRIPTION
Fixes:

```
Job exception: undefined method `split' for nil
```