### PR TITLE
FIX: Display cached summaries with our new streamer.

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
@@ -5,6 +5,7 @@ import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
+import { next } from "@ember/runloop";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import { ajax } from "discourse/lib/ajax";
@@ -130,7 +131,9 @@ export default class AiSummaryBox extends Component {
     return ajax(url).then((data) => {
       if (data?.ai_topic_summary?.summarized_text) {
         data.done = true;
-        this._updateSummary(data);
+        // Our streamer won't display the summary unless the summary box is in the DOM.
+        // Wait for the next runloop or cached summaries won't appear.
+        next(() => this._updateSummary(data));
       }
     });
   }

--- a/spec/system/summarization/topic_summarization_spec.rb
+++ b/spec/system/summarization/topic_summarization_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe "Summarize a topic ", type: :system do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:group)
+  fab!(:topic)
+  fab!(:post) do
+    Fabricate(
+      :post,
+      topic: topic,
+      raw:
+        "I like to eat pie. It is a very good dessert. Some people are wasteful by throwing pie at others but I do not do that. I always eat the pie.",
+    )
+  end
+  let(:summarization_result) { "This is a summary" }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+
+  before do
+    group.add(current_user)
+
+    assign_fake_provider_to(:ai_summarization_model)
+    SiteSetting.ai_summarization_enabled = true
+    SiteSetting.ai_custom_summarization_allowed_groups = group.id.to_s
+
+    sign_in(current_user)
+  end
+
+  context "when a summary is cached" do
+    before do
+      AiSummary.create!(
+        target: topic,
+        summarized_text: summarization_result,
+        algorithm: "test",
+        original_content_sha: "test",
+      )
+    end
+
+    it "displays it" do
+      topic_page.visit_topic(topic)
+
+      find(".ai-summarization-button button").click
+
+      expect(find(".generated-summary p").text).to eq(summarization_result)
+    end
+  end
+end


### PR DESCRIPTION
Make sure the summary box is in the DOM before attempting to display a cached summary.: