### PR TITLE
FEATURE: disable rate limiting when skipping hyde

### DIFF
--- a/spec/requests/embeddings/embeddings_controller_spec.rb
+++ b/spec/requests/embeddings/embeddings_controller_spec.rb
@@ -60,6 +60,19 @@ describe DiscourseAi::Embeddings::EmbeddingsController do
       expect(response.parsed_body["topics"].map { |t| t["id"] }).to contain_exactly(topic.id)
     end
 
+    context "when rate limiting is enabled" do
+      before { RateLimiter.enable }
+
+      it "will not rate limit API for hyde search" do
+        10.times do |i|
+          query = "test #{SecureRandom.hex}"
+          stub_embedding(query)
+          get "/discourse-ai/embeddings/semantic-search.json?q=#{query}&hyde=false"
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+
     it "returns results correctly when performing a non Hyde search" do
       index(topic)
       index(topic_in_subcategory)


### PR DESCRIPTION
Embedding search is rate limited due to potentially expensive
hyde operation (which require LLM access).

Embedding generally is very cheap compared to it. (usually 100x cheaper)

This raises the limit to 100 per minute for embedding searches,
while keeping the old 4 per minute for HyDE powered search.
