### PR TITLE
UX: Improve toast message location

### DIFF
--- a/assets/javascripts/initializers/ai-helper.js
+++ b/assets/javascripts/initializers/ai-helper.js
@@ -5,17 +5,6 @@ import ModalDiffModal from "../discourse/components/modal/diff-modal";
 import { showComposerAiHelper } from "../discourse/lib/show-ai-helper";
 
 function initializeAiHelperTrigger(api) {
-  const showErrorToast = () => {
-    const toasts = api.container.lookup("service:toasts");
-
-    return toasts.error({
-      duration: 3000,
-      data: {
-        message: i18n("discourse_ai.ai_helper.no_content_error"),
-      },
-    });
-  };
-
   api.onToolbarCreate((toolbar) => {
     const currentUser = api.getCurrentUser();
     const modal = api.container.lookup("service:modal");
@@ -41,7 +30,15 @@ function initializeAiHelperTrigger(api) {
       shortcut: "ALT+P",
       shortcutAction: (toolbarEvent) => {
         if (toolbarEvent.getText().length === 0) {
-          return showErrorToast();
+          const toasts = api.container.lookup("service:toasts");
+
+          return toasts.error({
+            class: "ai-proofread-error-toast",
+            duration: 3000,
+            data: {
+              message: i18n("discourse_ai.ai_helper.no_content_error"),
+            },
+          });
         }
 
         const mode = currentUser?.ai_helper_prompts.find(
@@ -64,10 +61,6 @@ function initializeAiHelperTrigger(api) {
           "context_menu"
         ),
       sendAction: (event) => {
-        if (toolbar.context.value.length === 0) {
-          return showErrorToast();
-        }
-
         const menu = api.container.lookup("service:menu");
         menu.show(document.querySelector(".ai-helper-trigger"), {
           identifier: "ai-composer-helper-menu",

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -605,3 +605,23 @@
 .mobile-view .fk-d-menu[data-identifier="ai-composer-helper-menu"] {
   z-index: z("mobile-composer");
 }
+
+.fk-d-toasts:has(.ai-proofread-error-toast) {
+  top: unset;
+  bottom: calc(var(--composer-height) - 5%);
+  right: unset;
+  left: 0;
+}
+
+@media screen and (min-width: $reply-area-max-width) {
+  .has-sidebar-page {
+    .fk-d-toasts:has(.ai-proofread-error-toast) {
+      transform: translateX(
+        calc(
+          (100vw - var(--d-max-width) - var(--d-sidebar-width) / 0.5) / 2 + 17em +
+            1rem
+        )
+      );
+    }
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -332,7 +332,7 @@ en:
             prompt: "This post contains non-captioned images. Would you like to enable automatic AI captions on image uploads? (This can be changed in your preferences later)"
             confirm: "Enable"
             cancel: "Don't ask again"
-        no_content_error: "Please add some content to perform AI actions on."
+        no_content_error: "Add content first to perform AI actions on it"
 
       reviewables:
         model_used: "Model used:"


### PR DESCRIPTION
### 🔍  Overview
This PR updates the error toast message location for the composer AI helper. Previously, when trying to invoke the Proofread feature or AI composer helper feature when there's no content in the composer, the toast is displayed at its default location (top right of screen). This is too far away to notice.

The new location will now be updated to right within the composer where the actual dropdown occurs. This should help teach the user what the right expected usage of the tool would be.

A few other small changes in this PR:
- We update the string so that it is shorter for the new location so that it doesn't wrap.
- Since the proofread shortcut also triggers the toast error, but it immediately invokes a modal instead, we use `scss` to position the Toast in a better location on the composer. Its not in the perfect location (i.e. right below the :sparkles: icon, but its only found by keyboard shortcut so it'll likely be less invoked anyways)

No tests necessary here as there is already test coverage from before. Its simply a location change.

### 📸 Screenshots

**Before:**
![Screenshot 2024-09-13 at 15 20 16](https://github.com/user-attachments/assets/a716ba33-e249-4f39-9216-fb5efedd459c)

**After:**
![Screenshot 2024-09-13 at 15 19 19](https://github.com/user-attachments/assets/ae3eb603-d008-4d1e-b7e2-a4a53541ba4a)

