### PR TITLE
FIX: Keyboard shortcut should be platform specific

### DIFF
--- a/assets/javascripts/discourse/components/ai-helper-options-list.gjs
+++ b/assets/javascripts/discourse/components/ai-helper-options-list.gjs
@@ -3,6 +3,8 @@ import { fn } from "@ember/helper";
 import { service } from "@ember/service";
 import { and } from "truth-helpers";
 import DButton from "discourse/components/d-button";
+import { PLATFORM_KEY_MODIFIER } from "discourse/lib/keyboard-shortcuts";
+import { translateModKey } from "discourse/lib/utilities";
 import eq from "truth-helpers/helpers/eq";
 import AiHelperCustomPrompt from "../components/ai-helper-custom-prompt";
 
@@ -11,6 +13,10 @@ export default class AiHelperOptionsList extends Component {
 
   get showShortcut() {
     return this.site.desktopView && this.args.shortcutVisible;
+  }
+
+  get shortcut() {
+    return translateModKey(`${PLATFORM_KEY_MODIFIER}+alt+p`);
   }
 
   <template>
@@ -33,7 +39,7 @@ export default class AiHelperOptionsList extends Component {
               class="ai-helper-options__button"
             >
               {{#if (and (eq option.name "proofread") this.showShortcut)}}
-                <kbd class="shortcut">⌘⌥p</kbd>
+                <kbd class="shortcut">{{this.shortcut}}</kbd>
               {{/if}}
             </DButton>
           </li>


### PR DESCRIPTION
With the recent composer AI helper change (https://github.com/discourse/discourse-ai/commit/9cd14b0003700d89e1a499b9e28924ef8e1443de), we accidentally hardcoded the keyboard shortcut string for proofreading. 

This PR updates that by using platform specific keys:
i.e. <kbd>⌘</kbd><kbd>⌥</kbd><kbd>P</kbd> (macOS) / <kbd>ctrl</kbd><kbd>alt</kbd><kbd>p</kbd> (Windows)