### PR TITLE
FIX: Diff modal closing along with composer menu on mobile

### DIFF
--- a/assets/javascripts/discourse/components/ai-composer-helper-menu.gjs
+++ b/assets/javascripts/discourse/components/ai-composer-helper-menu.gjs
@@ -109,19 +109,20 @@ export default class AiComposerHelperMenu extends Component {
   }
 
   @action
-  suggestChanges(option) {
+  async suggestChanges(option) {
+    await this.args.close();
+
     if (option.name === "illustrate_post") {
-      this.modal.show(ThumbnailSuggestion, {
+      return this.modal.show(ThumbnailSuggestion, {
         model: {
           mode: option.id,
           selectedText: this.args.data.selectedText,
           thumbnails: this.thumbnailSuggestions,
         },
       });
-      return this.args.close();
     }
 
-    this.modal.show(ModalDiffModal, {
+    return this.modal.show(ModalDiffModal, {
       model: {
         mode: option.id,
         selectedText: this.args.data.selectedText,
@@ -130,7 +131,6 @@ export default class AiComposerHelperMenu extends Component {
         customPromptValue: this.customPromptValue,
       },
     });
-    return this.args.close();
   }
 
   @action

--- a/spec/system/ai_helper/ai_composer_helper_spec.rb
+++ b/spec/system/ai_helper/ai_composer_helper_spec.rb
@@ -342,4 +342,19 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
       expect(page).to have_no_css(".d-editor-button-bar button.ai-helper-trigger")
     end
   end
+
+  context "when triggering composer AI helper", mobile: true do
+    it "should close the composer helper before showing the diff modal" do
+      visit("/latest")
+      page.find("#create-topic").click
+      composer.fill_content(input)
+      composer.click_toolbar_button("ai-helper-trigger")
+
+      DiscourseAi::Completions::Llm.with_prepared_responses([input]) do
+        ai_helper_menu.select_helper_model(CompletionPrompt::TRANSLATE)
+        expect(ai_helper_menu).to have_no_context_menu
+        expect(diff_modal).to be_visible
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🔍 Overview
The `DiffModal` is triggered after selecting an option in the composer helper menu. After selecting an option, we should close the composer helper menu and only show the diff modal. On mobile, there was an edge-case where `this.args.close()` for was causing the closing of both the `DiffModal` and the `AiComposerHelperMenu`. This PR resolves that by ensuring the menu is closed _first_ asynchronously, followed by opening the relevant modal.

## 📹 Preview

**Before**

https://github.com/user-attachments/assets/8f7c0cf0-864a-4875-ade2-be44dc0b5a7c


**After**



https://github.com/user-attachments/assets/b91f8999-4981-4da3-9449-f163245f1812


