### PR TITLE
FIX: AI Helper not visible on iPad in DiscourseHub

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -606,6 +606,10 @@
   z-index: z("mobile-composer");
 }
 
+html.footer-nav-ipad .fk-d-menu[data-identifier="ai-composer-helper-menu"] {
+  z-index: z("ipad-header-nav") + 1;
+}
+
 .fk-d-toasts:has(.ai-proofread-error-toast) {
   top: unset;
   bottom: calc(var(--composer-height) - 5%);


### PR DESCRIPTION
### 🔍 Overview
This PR fixes an issue where the composer AI helper was not visible on iPad in DiscourseHub. This was due to the z-index being different for `reply-control` when Discourse Hub inserts its `footer-nav`

No tests as its difficult to test this UX issue for this specific device.

### 📸 Screenshots

|Before|After|
|---|---|
|![IMG_0005](https://github.com/user-attachments/assets/9be02027-c75b-4ff1-8e0d-9dd7b30d9228)|![IMG_0006](https://github.com/user-attachments/assets/d9590d8f-c25a-4741-af2b-c7b31f4969c1)

