### PR TITLE
DEV: remove ignore column syntax for the removed provider column in completion prompt model

### DIFF
--- a/app/models/completion_prompt.rb
+++ b/app/models/completion_prompt.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CompletionPrompt < ActiveRecord::Base
-  # TODO(roman): Remove may 2024.
-  self.ignored_columns = ["provider"]
-
   TRANSLATE = -301
   GENERATE_TITLES = -307
   PROOFREAD = -303


### PR DESCRIPTION
This provider column was removed 10 months ago in this PR https://github.com/discourse/discourse-ai/pull/312, there is no usage of this attribute in our codebase, so there is no potential danger to remove this ignored column. 