### PR TITLE
UX: update icon and text for copying message

### DIFF
--- a/assets/javascripts/initializers/ai-bot-replies.js
+++ b/assets/javascripts/initializers/ai-bot-replies.js
@@ -177,7 +177,7 @@ function initializeShareButton(api) {
 
     return {
       action: shareAiResponse,
-      icon: "share-alt",
+      icon: "far-copy",
       className: "post-action-menu__share",
       title: "discourse_ai.ai_bot.share",
       position: "first",

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -375,7 +375,7 @@ en:
         cancel_streaming: "Stop reply"
         default_pm_prefix: "[Untitled AI bot PM]"
         shortcut_title: "Start a PM with an AI bot"
-        share: "Share AI conversation"
+        share: "Copy AI conversation"
         conversation_shared: "Conversation copied"
         debug_ai: "View raw AI request and response"
         debug_ai_modal:


### PR DESCRIPTION
"Share" doesn't make a lot of sense here because you're copying the message contents on click, especially considering we have a share feature now.



Before:
![image](https://github.com/user-attachments/assets/d5b9cfa6-5793-4da2-a833-0da5709d397f)


After:
![image](https://github.com/user-attachments/assets/0a4f229e-2164-460c-9dad-e52d88ed83d5)
