### PR TITLE
FEATURE: allows forced LLM tool use

### DIFF
--- a/app/controllers/discourse_ai/admin/ai_personas_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_personas_controller.rb
@@ -120,15 +120,12 @@ module DiscourseAi
       def permit_tools(tools)
         return [] if !tools.is_a?(Array)
 
-        tools.filter_map do |tool, options|
+        tools.filter_map do |tool, options, force_tool|
           break nil if !tool.is_a?(String)
           options&.permit! if options && options.is_a?(ActionController::Parameters)
 
-          if options
-            [tool, options]
-          else
-            tool
-          end
+          # this is simpler from a storage perspective, 1 way to store tools
+          [tool, options, !!force_tool]
         end
       end
     end

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -60,10 +60,10 @@ export default class PersonaEditor extends Component {
 
   @action
   toolsChanged(tools) {
-    this.selectedToolNames = tools;
     this.selectedTools = this.args.personas.resultSetMeta.tools.filter((tool) =>
-      this.editingModel.tools.includes(tool.id)
+      tools.includes(tool.id)
     );
+    this.selectedToolNames = tools.slice();
 
     this.forcedToolNames = this.forcedToolNames.filter(
       (tool) => this.editingModel.tools.indexOf(tool) !== -1

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -83,7 +83,7 @@ export default class PersonaEditor extends Component {
 
     this.selectedToolNames = this.editingModel.tools || [];
     this.selectedTools = this.args.personas.resultSetMeta.tools.filter((tool) =>
-      this.editingModel.tools.includes(tool.id)
+      this.selectedToolNames.includes(tool.id)
     );
     this.forcedToolNames = this.editingModel.forcedTools || [];
   }
@@ -391,7 +391,7 @@ export default class PersonaEditor extends Component {
       {{#unless this.editingModel.system}}
         <AiPersonaToolOptions
           @persona={{this.editingModel}}
-          @tools={{this.editingModel.tools}}
+          @tools={{this.selectedToolNames}}
           @allTools={{@personas.resultSetMeta.tools}}
         />
       {{/unless}}

--- a/assets/javascripts/discourse/components/ai-tool-selector.js
+++ b/assets/javascripts/discourse/components/ai-tool-selector.js
@@ -6,7 +6,7 @@ export default MultiSelectComponent.extend({
     this.selectKit.options.set("disabled", this.get("attrs.disabled.value"));
   }),
 
-  content: computed(function () {
+  content: computed("tools", function () {
     return this.tools;
   }),
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -145,6 +145,7 @@ en:
         saved: AI Persona Saved
         enabled: "Enabled?"
         tools: Enabled Tools
+        forced_tools: Forced Tools
         allowed_groups: Allowed Groups
         confirm_delete: Are you sure you want to delete this persona?
         new: "New Persona"

--- a/lib/ai_bot/personas/persona.rb
+++ b/lib/ai_bot/personas/persona.rb
@@ -113,6 +113,10 @@ module DiscourseAi
           []
         end
 
+        def force_tool_use
+          []
+        end
+
         def required_tools
           []
         end

--- a/lib/completions/dialects/dialect.rb
+++ b/lib/completions/dialects/dialect.rb
@@ -60,6 +60,10 @@ module DiscourseAi
           @tools ||= tools_dialect.translated_tools
         end
 
+        def tool_choice
+          prompt.tool_choice
+        end
+
         def translate
           messages = prompt.messages
 

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -54,8 +54,12 @@ module DiscourseAi
             # We'll fallback to guess this using the tokenizer.
             payload[:stream_options] = { include_usage: true } if llm_model.provider == "open_ai"
           end
-
-          payload[:tools] = dialect.tools if dialect.tools.present?
+          if dialect.tools.present?
+            payload[:tools] = dialect.tools
+            if dialect.tool_choice.present?
+              payload[:tool_choice] = { type: "function", function: { name: dialect.tool_choice } }
+            end
+          end
           payload
         end
 

--- a/lib/completions/llm.rb
+++ b/lib/completions/llm.rb
@@ -123,7 +123,7 @@ module DiscourseAi
         end
 
         def record_prompt(prompt)
-          @prompts << prompt if @prompts
+          @prompts << prompt.dup if @prompts
         end
 
         def proxy(model)

--- a/lib/completions/prompt.rb
+++ b/lib/completions/prompt.rb
@@ -6,7 +6,7 @@ module DiscourseAi
       INVALID_TURN = Class.new(StandardError)
 
       attr_reader :messages
-      attr_accessor :tools, :topic_id, :post_id, :max_pixels
+      attr_accessor :tools, :topic_id, :post_id, :max_pixels, :tool_choice
 
       def initialize(
         system_message_text = nil,
@@ -14,7 +14,8 @@ module DiscourseAi
         tools: [],
         topic_id: nil,
         post_id: nil,
-        max_pixels: nil
+        max_pixels: nil,
+        tool_choice: nil
       )
         raise ArgumentError, "messages must be an array" if !messages.is_a?(Array)
         raise ArgumentError, "tools must be an array" if !tools.is_a?(Array)
@@ -37,6 +38,7 @@ module DiscourseAi
         @messages.each_cons(2) { |last_turn, new_turn| validate_turn(last_turn, new_turn) }
 
         @tools = tools
+        @tool_choice = tool_choice
       end
 
       def push(type:, content:, id: nil, name: nil, upload_ids: nil)

--- a/spec/requests/admin/ai_personas_controller_spec.rb
+++ b/spec/requests/admin/ai_personas_controller_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
           name: "superbot",
           description: "Assists with tasks",
           system_prompt: "you are a helpful bot",
-          tools: [["search", { "base_query" => "test" }]],
+          tools: [["search", { "base_query" => "test" }, true]],
           top_p: 0.1,
           temperature: 0.5,
           mentionable: true,
@@ -186,7 +186,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
 
           persona = AiPersona.find(persona_json["id"])
 
-          expect(persona.tools).to eq([["search", { "base_query" => "test" }]])
+          expect(persona.tools).to eq([["search", { "base_query" => "test" }, true]])
           expect(persona.top_p).to eq(0.1)
           expect(persona.temperature).to eq(0.5)
         }.to change(AiPersona, :count).by(1)
@@ -296,7 +296,7 @@ RSpec.describe DiscourseAi::Admin::AiPersonasController do
         ai_persona.reload
         expect(ai_persona.name).to eq("SuperBot")
         expect(ai_persona.enabled).to eq(false)
-        expect(ai_persona.tools).to eq(["search"])
+        expect(ai_persona.tools).to eq([["search", nil, false]])
       end
     end
 

--- a/spec/system/admin_ai_persona_spec.rb
+++ b/spec/system/admin_ai_persona_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Admin AI persona configuration", type: :system, js: true do
     expect(persona.name).to eq("Test Persona")
     expect(persona.description).to eq("I am a test persona")
     expect(persona.system_prompt).to eq("You are a helpful bot")
-    expect(persona.tools).to eq([["Read", { "read_private" => nil }]])
+    expect(persona.tools).to eq([["Read", { "read_private" => nil }, false]])
   end
 
   it "will not allow deletion or editing of system personas" do

--- a/test/javascripts/unit/models/ai-persona-test.js
+++ b/test/javascripts/unit/models/ai-persona-test.js
@@ -60,7 +60,7 @@ module("Discourse AI | Unit | Model | ai-persona", function () {
     const updatedProperties = aiPersona.updateProperties();
 
     // perform remapping for save
-    properties.tools = [["ToolName", { option1: "value1" }]];
+    properties.tools = [["ToolName", { option1: "value1" }, false]];
 
     assert.deepEqual(updatedProperties, properties);
   });
@@ -100,7 +100,7 @@ module("Discourse AI | Unit | Model | ai-persona", function () {
 
     const createdProperties = aiPersona.createProperties();
 
-    properties.tools = [["ToolName", { option1: "value1" }]];
+    properties.tools = [["ToolName", { option1: "value1" }, false]];
 
     assert.deepEqual(createdProperties, properties);
   });


### PR DESCRIPTION
Sometimes we need to force LLMs to use tools, for example in RAG
like use cases we may want to force an unconditional search.

The new framework allows you backend to force tool usage.

This implements both front and and back end support.

Initial support is only written for OpenAI models, however follow up commits will backfill support to other providers.