### PR TITLE
FEATURE: allow llm triage to automatically hide posts

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -99,12 +99,12 @@ en:
             hide_topic:
               label: "Hide topic"
               description: "Make topic non visible to the public if triggered"
-            hide_post:
-              label: "Hide post"
-              description: "Make post non visible to the public if triggered"
+            flag_type:
+              label: "Flag type"
+              description: "Type of flag to apply to the post (spam or simply raise for review)"
             flag_post:
-              label: "Send to review"
-              description: "Puts the post into the review queue if triggered, for moderators to triage"
+              label: "Flag post"
+              description: "Flags post (either as spam or for review)"
             model:
               label: "Model"
               description: "Language model used for triage"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -99,6 +99,9 @@ en:
             hide_topic:
               label: "Hide topic"
               description: "Make topic non visible to the public if triggered"
+            hide_post:
+              label: "Hide post"
+              description: "Make post non visible to the public if triggered"
             flag_post:
               label: "Send to review"
               description: "Puts the post into the review queue if triggered, for moderators to triage"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,5 +1,9 @@
 en:
   discourse_automation:
+    ai:
+      flag_types:
+        review: "Add post to review queue"
+        spam: "Flag as spam and hide post"
     scriptables:
       llm_triage:
         title: Triage posts using AI

--- a/discourse_automation/llm_triage.rb
+++ b/discourse_automation/llm_triage.rb
@@ -20,8 +20,10 @@ if defined?(DiscourseAutomation)
     field :category, component: :category
     field :tags, component: :tags
     field :hide_topic, component: :boolean
-    field :hide_post, component: :boolean
     field :flag_post, component: :boolean
+    field :flag_type, component: :choices, required: false, extra:{
+      content: DiscourseAi::Automation.flag_types
+    }, default: "review"
     field :canned_reply, component: :message
     field :canned_reply_user, component: :user
 
@@ -41,8 +43,8 @@ if defined?(DiscourseAutomation)
       category_id = fields.dig("category", "value")
       tags = fields.dig("tags", "value")
       hide_topic = fields.dig("hide_topic", "value")
-      hide_post = fields.dig("hide_post", "value")
       flag_post = fields.dig("flag_post", "value")
+      flag_type = fields.dig("flag_type", "value")
 
       begin
         RateLimiter.new(
@@ -69,8 +71,8 @@ if defined?(DiscourseAutomation)
           canned_reply: canned_reply,
           canned_reply_user: canned_reply_user,
           hide_topic: hide_topic,
-          hide_post: hide_post,
           flag_post: flag_post,
+          flag_type: flag_type.to_s.to_sym,
           automation: self.automation,
         )
       rescue => e

--- a/discourse_automation/llm_triage.rb
+++ b/discourse_automation/llm_triage.rb
@@ -20,6 +20,7 @@ if defined?(DiscourseAutomation)
     field :category, component: :category
     field :tags, component: :tags
     field :hide_topic, component: :boolean
+    field :hide_post, component: :boolean
     field :flag_post, component: :boolean
     field :canned_reply, component: :message
     field :canned_reply_user, component: :user
@@ -40,6 +41,7 @@ if defined?(DiscourseAutomation)
       category_id = fields.dig("category", "value")
       tags = fields.dig("tags", "value")
       hide_topic = fields.dig("hide_topic", "value")
+      hide_post = fields.dig("hide_post", "value")
       flag_post = fields.dig("flag_post", "value")
 
       begin
@@ -67,6 +69,7 @@ if defined?(DiscourseAutomation)
           canned_reply: canned_reply,
           canned_reply_user: canned_reply_user,
           hide_topic: hide_topic,
+          hide_post: hide_post,
           flag_post: flag_post,
           automation: self.automation,
         )

--- a/discourse_automation/llm_triage.rb
+++ b/discourse_automation/llm_triage.rb
@@ -21,9 +21,13 @@ if defined?(DiscourseAutomation)
     field :tags, component: :tags
     field :hide_topic, component: :boolean
     field :flag_post, component: :boolean
-    field :flag_type, component: :choices, required: false, extra:{
-      content: DiscourseAi::Automation.flag_types
-    }, default: "review"
+    field :flag_type,
+          component: :choices,
+          required: false,
+          extra: {
+            content: DiscourseAi::Automation.flag_types,
+          },
+          default: "review"
     field :canned_reply, component: :message
     field :canned_reply_user, component: :user
 

--- a/lib/automation.rb
+++ b/lib/automation.rb
@@ -2,6 +2,12 @@
 
 module DiscourseAi
   module Automation
+    def self.flag_types
+      [
+        { id: "review", translated_name: I18n.t("discourse_automation.ai.flag_types.review") },
+        { id: "spam", translated_name: I18n.t("discourse_automation.ai.flag_types.spam") },
+      ]
+    end
     def self.available_models
       values = DB.query_hash(<<~SQL)
         SELECT display_name AS translated_name, id AS id


### PR DESCRIPTION
Previous to this change we could flag, but there was no way
to hide content.

We had the option to hide topics, but this is not desirable for
a spam reply.

New option allows triage to hide a post if it is a reply, if the
post happens to be the first post on the topic, the topic will
be hidden.
