### PR TITLE
DEV: Fix mismatched column types in tests

### DIFF
--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -14,4 +14,14 @@ module DiscourseAi::ChatBotHelper
   end
 end
 
-RSpec.configure { |c| c.include DiscourseAi::ChatBotHelper }
+RSpec.configure do |config|
+  config.include DiscourseAi::ChatBotHelper
+
+  config.before(:suite) do
+    if defined?(migrate_column_to_bigint)
+      migrate_column_to_bigint(RagDocumentFragment, :target_id)
+      migrate_column_to_bigint("ai_document_fragment_embeddings", "rag_document_fragment_id")
+      migrate_column_to_bigint(ClassificationResult, :target_id)
+    end
+  end
+end


### PR DESCRIPTION
The primary key is usually a bigint column, but the foreign key columns usually are of integer type. This can lead to issues when joining these columns due to mismatched types and different value ranges.

In a recent core change, all bigint sequences will start at a very high value in the test environment to surface this type of errors. The same change also added a temporary API that changes the column type to bigint in order to allow for the tests to run.

The plugin API is only temporary and it is important for these plugins to migrate their columns to bigint to avoid issues in the future.