### PR TITLE
UX: Remove AdminPageSubheader style override

### DIFF
--- a/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
+++ b/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
@@ -58,13 +58,6 @@
 }
 
 [class*="ai-llms-list-editor"] {
-  .admin-page-subheader {
-    h3 {
-      font-size: var(--font-up-2);
-      margin: 0;
-      font-weight: bold;
-    }
-  }
   h3 {
     font-weight: normal;
     margin: 0;


### PR DESCRIPTION
In this core commit https://github.com/discourse/discourse/pull/29149 we
are changing the subheader title to H2 and making the size smaller,
this style override is no longer needed.
