### PR TITLE
FEATURE: Add a new setting to disable the automatic topic title feature of the AI bot

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -87,6 +87,7 @@ en:
 
     ai_bot_enabled: "Enable the AI Bot module."
     ai_bot_enable_chat_warning: "Display a warning when PM chat is initiated. Can be overriden by editing the translation string: discourse_ai.ai_bot.pm_warning"
+    ai_bot_automatic_topic_title: "Automatically set the topic titles based on post contents."
     ai_bot_allowed_groups: "When the GPT Bot has access to the PM, it will reply to members of these groups."
     ai_bot_debugging_allowed_groups: "Allow these groups to see a debug button on posts which displays the raw AI request and response"
     ai_bot_public_sharing_allowed_groups: "Allow these groups to share AI personal messages with the public via a unique publicly available link. Note: if your site requires login, shares will also require login."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -393,6 +393,8 @@ discourse_ai:
   ai_bot_enable_chat_warning:
     default: false
     client: true
+  ai_bot_automatic_topic_title:
+    default: true
   ai_bot_debugging_allowed_groups:
     type: group_list
     list_type: compact

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -487,9 +487,7 @@ module DiscourseAi
         reply_post
       ensure
         publish_final_update(reply_post) if stream_reply
-        if reply_post && post.post_number == 1 && post.topic.private_message?
-          title_playground(reply_post)
-        end
+        title_playground(reply_post) if reply_post && can_automatically_update_title?(post)
       end
 
       def available_bot_usernames
@@ -502,6 +500,14 @@ module DiscourseAi
       end
 
       private
+
+      def can_automatically_update_title?(post)
+        return false if !SiteSetting.ai_bot_automatic_topic_title
+        return false if !post.topic.private_message?
+        return false if post.post_number != 1
+
+        true
+      end
 
       def available_bot_users
         @available_bots ||=


### PR DESCRIPTION
I’m on the fence about this implementation, actually. Given that we’re about to implement a quota system to limit AI tokens, it makes sense to me to allow the Admin to prevent the AI bot from automatically updating the title of the inbox topic, as it does consume a significant number of tokens.

In this PR, we add a new setting with the default set to true to maintain backward compatibility with the current behavior. We can utilize this setting to prevent our Playground from automatically generating the title right after it finishes the reply_to method.