### PR TITLE
DEV: ensure far-copy icon is included in subset

### DIFF
--- a/lib/ai_helper/entry_point.rb
+++ b/lib/ai_helper/entry_point.rb
@@ -7,7 +7,7 @@ module DiscourseAi
           Rails.root.join("plugins", "discourse-ai", "db", "fixtures", "ai_helper"),
         )
 
-        additional_icons = %w[spell-check language images]
+        additional_icons = %w[spell-check language images far-copy]
         additional_icons.each { |icon| plugin.register_svg_icon(icon) }
 
         plugin.add_to_serializer(:current_user, :can_use_assistant) do


### PR DESCRIPTION
This ensures the icon added in 62ba2fa4d7a0a51008a070f3079f485c61bc8694 is included in the subset