### PR TITLE
FEATURE: allow scoping of google tool queries

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -208,7 +208,7 @@ en:
         google:
           base_query:
             name: "Base Search Query"
-            description: "Base query to use when searching. Example: 'site:example.com' will only include results from example.com."
+            description: "Base query to use when searching. Examples: 'site:example.com' will only include results from example.com, before:2022-01-01 will only includes results from 2021 and earlier. This text is prepended to the search query."
         read:
           read_private:
             name: "Read Private"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -205,6 +205,10 @@ en:
       summarizing: "Summarizing topic"
       searching: "Searching for: '%{query}'"
       tool_options:
+        google:
+          base_query:
+            name: "Base Search Query"
+            description: "Base query to use when searching. Example: 'site:example.com' will only include results from example.com."
         read:
           read_private:
             name: "Read Private"

--- a/lib/ai_bot/tools/google.rb
+++ b/lib/ai_bot/tools/google.rb
@@ -23,15 +23,26 @@ module DiscourseAi
           "google"
         end
 
+        def self.accepted_options
+          [option(:base_query, type: :string)]
+        end
+
         def query
           parameters[:query].to_s.strip
         end
 
         def invoke
+          query = self.query
+
           yield(query)
 
           api_key = SiteSetting.ai_google_custom_search_api_key
           cx = SiteSetting.ai_google_custom_search_cx
+
+          if options[:base_query].present?
+            query = "#{options[:base_query]} #{query}"
+          end
+
           escaped_query = CGI.escape(query)
           uri =
             URI(

--- a/lib/ai_bot/tools/google.rb
+++ b/lib/ai_bot/tools/google.rb
@@ -39,9 +39,7 @@ module DiscourseAi
           api_key = SiteSetting.ai_google_custom_search_api_key
           cx = SiteSetting.ai_google_custom_search_cx
 
-          if options[:base_query].present?
-            query = "#{options[:base_query]} #{query}"
-          end
+          query = "#{options[:base_query]} #{query}" if options[:base_query].present?
 
           escaped_query = CGI.escape(query)
           uri =


### PR DESCRIPTION
This allows to simply scope search results to specific domains, so you can filter to results for example.com using `site:example.com`

![image](https://github.com/user-attachments/assets/abc16fdf-58cc-4a91-82d0-ab20a5274707)
