### PR TITLE
FIX: Basic cleanup of AI Caption to remove line breaks and pipes

### DIFF
--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -156,12 +156,15 @@ module DiscourseAi
             ],
           )
 
-        DiscourseAi::Completions::Llm.proxy(SiteSetting.ai_helper_image_caption_model).generate(
-          prompt,
-          user: user,
-          max_tokens: 1024,
-          feature_name: "image_caption",
-        )
+        raw_caption =
+          DiscourseAi::Completions::Llm.proxy(SiteSetting.ai_helper_image_caption_model).generate(
+            prompt,
+            user: user,
+            max_tokens: 1024,
+            feature_name: "image_caption",
+          )
+
+        raw_caption.delete("|").squish
       end
 
       private


### PR DESCRIPTION
After testing Llama 3.2 for AI Caption is can be quite chatty and go for multiple paragraphs.