### PR TITLE
FIX: Llm selector / forced tools / search tool

### DIFF
--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -19,6 +19,10 @@ class LlmModel < ActiveRecord::Base
       aws_bedrock: {
         access_key_id: :text,
         region: :text,
+        disable_native_tools: :checkbox,
+      },
+      anthropic: {
+        disable_native_tools: :checkbox,
       },
       open_ai: {
         organization: :text,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -329,6 +329,7 @@ en:
           organization: "Optional OpenAI Organization ID"
           disable_system_prompt: "Disable system message in prompts"
           enable_native_tool: "Enable native tool support"
+          disable_native_tools: "Disable native tool support (use XML based tools)"
 
       related_topics:
         title: "Related Topics"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -49,7 +49,6 @@ en:
 
     ai_openai_embeddings_url: "Custom URL used for the OpenAI embeddings API. (in the case of Azure it can be: https://COMPANY.openai.azure.com/openai/deployments/DEPLOYMENT/embeddings?api-version=2023-05-15)"
     ai_openai_api_key: "API key for OpenAI API. ONLY used for embeddings and Dall-E. For GPT use the LLM config tab"
-    ai_anthropic_native_tool_call_models: "List of models that will use native tool calls vs legacy XML based tools."
     ai_hugging_face_tei_endpoint: URL where the API is running for the Hugging Face text embeddings inference
     ai_hugging_face_tei_api_key: API key for Hugging Face text embeddings inference
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -125,16 +125,6 @@ discourse_ai:
   ai_anthropic_api_key:
     default: ""
     hidden: true
-  ai_anthropic_native_tool_call_models:
-    type: list
-    list_type: compact
-    default: "claude-3-sonnet|claude-3-haiku"
-    allow_any: false
-    choices:
-      - claude-3-opus
-      - claude-3-sonnet
-      - claude-3-haiku
-      - claude-3-5-sonnet
   ai_cohere_api_key:
     default: ""
     hidden: true

--- a/lib/ai_bot/entry_point.rb
+++ b/lib/ai_bot/entry_point.rb
@@ -145,6 +145,8 @@ module DiscourseAi
 
           persona_users = AiPersona.persona_users(user: scope.user)
           if persona_users.present?
+            persona_users.filter! { |persona_user| persona_user[:username].present? }
+
             bots_map.concat(
               persona_users.map do |persona_user|
                 {

--- a/lib/completions/dialects/claude.rb
+++ b/lib/completions/dialects/claude.rb
@@ -61,7 +61,7 @@ module DiscourseAi
         end
 
         def native_tool_support?
-          SiteSetting.ai_anthropic_native_tool_call_models_map.include?(llm_model.name)
+          !llm_model.lookup_custom_param("disable_native_tools")
         end
 
         private

--- a/lib/completions/endpoints/anthropic.rb
+++ b/lib/completions/endpoints/anthropic.rb
@@ -27,7 +27,7 @@ module DiscourseAi
             when "claude-3-opus"
               "claude-3-opus-20240229"
             when "claude-3-5-sonnet"
-              "claude-3-5-sonnet-20240620"
+              "claude-3-5-sonnet-latest"
             else
               llm_model.name
             end
@@ -70,7 +70,12 @@ module DiscourseAi
 
           payload[:system] = prompt.system_prompt if prompt.system_prompt.present?
           payload[:stream] = true if @streaming_mode
-          payload[:tools] = prompt.tools if prompt.has_tools?
+          if prompt.has_tools?
+            payload[:tools] = prompt.tools
+            if dialect.tool_choice.present?
+              payload[:tool_choice] = { type: "tool", name: dialect.tool_choice }
+            end
+          end
 
           payload
         end

--- a/lib/completions/endpoints/aws_bedrock.rb
+++ b/lib/completions/endpoints/aws_bedrock.rb
@@ -61,7 +61,7 @@ module DiscourseAi
             when "claude-3-opus"
               "anthropic.claude-3-opus-20240229-v1:0"
             when "claude-3-5-sonnet"
-              "anthropic.claude-3-5-sonnet-20240620-v1:0"
+              "anthropic.claude-3-5-sonnet-20241022-v2:0"
             else
               llm_model.name
             end
@@ -83,7 +83,13 @@ module DiscourseAi
 
           payload = default_options(dialect).merge(model_params).merge(messages: prompt.messages)
           payload[:system] = prompt.system_prompt if prompt.system_prompt.present?
-          payload[:tools] = prompt.tools if prompt.has_tools?
+
+          if prompt.has_tools?
+            payload[:tools] = prompt.tools
+            if dialect.tool_choice.present?
+              payload[:tool_choice] = { type: "tool", name: dialect.tool_choice }
+            end
+          end
 
           payload
         end

--- a/lib/embeddings/semantic_search.rb
+++ b/lib/embeddings/semantic_search.rb
@@ -79,7 +79,7 @@ module DiscourseAi
         search = Search.new(query, { guardian: guardian })
         search_term = search.term
 
-        return [] if search_term.nil? || search_term.length < SiteSetting.min_search_term_length
+        return Post.none if search_term.nil? || search_term.length < SiteSetting.min_search_term_length
 
         search_embedding = hyde ? hyde_embedding(search_term) : embedding(search_term)
 

--- a/lib/embeddings/semantic_search.rb
+++ b/lib/embeddings/semantic_search.rb
@@ -79,7 +79,9 @@ module DiscourseAi
         search = Search.new(query, { guardian: guardian })
         search_term = search.term
 
-        return Post.none if search_term.nil? || search_term.length < SiteSetting.min_search_term_length
+        if search_term.nil? || search_term.length < SiteSetting.min_search_term_length
+          return Post.none
+        end
 
         search_embedding = hyde ? hyde_embedding(search_term) : embedding(search_term)
 

--- a/lib/embeddings/semantic_search.rb
+++ b/lib/embeddings/semantic_search.rb
@@ -79,7 +79,7 @@ module DiscourseAi
         search = Search.new(query, { guardian: guardian })
         search_term = search.term
 
-        if search_term.nil? || search_term.length < SiteSetting.min_search_term_length
+        if search_term.blank? || search_term.length < SiteSetting.min_search_term_length
           return Post.none
         end
 

--- a/spec/lib/completions/dialects/claude_spec.rb
+++ b/spec/lib/completions/dialects/claude_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe DiscourseAi::Completions::Dialects::Claude do
     end
 
     it "can properly translate a prompt (legacy tools)" do
-      SiteSetting.ai_anthropic_native_tool_call_models = ""
+      llm_model.provider_params["disable_native_tools"] = true
+      llm_model.save!
 
       tools = [
         {
@@ -88,8 +89,6 @@ RSpec.describe DiscourseAi::Completions::Dialects::Claude do
     end
 
     it "can properly translate a prompt (native tools)" do
-      SiteSetting.ai_anthropic_native_tool_call_models = "claude-3-opus"
-
       tools = [
         {
           name: "echo",

--- a/spec/lib/completions/endpoints/anthropic_spec.rb
+++ b/spec/lib/completions/endpoints/anthropic_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Anthropic do
   end
 
   it "does not eat spaces with tool calls" do
-    SiteSetting.ai_anthropic_native_tool_call_models = "claude-3-opus"
     body = <<~STRING
     event: message_start
     data: {"type":"message_start","message":{"id":"msg_01Ju4j2MiGQb9KV9EEQ522Y3","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1293,"output_tokens":1}}   }
@@ -195,8 +194,6 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Anthropic do
   end
 
   it "supports non streaming tool calls" do
-    SiteSetting.ai_anthropic_native_tool_call_models = "claude-3-opus"
-
     tool = {
       name: "calculate",
       description: "calculate something",

--- a/spec/lib/completions/endpoints/aws_bedrock_spec.rb
+++ b/spec/lib/completions/endpoints/aws_bedrock_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe DiscourseAi::Completions::Endpoints::AwsBedrock do
 
   describe "function calling" do
     it "supports old school xml function calls" do
-      SiteSetting.ai_anthropic_native_tool_call_models = ""
+      model.provider_params["disable_native_tools"] = true
+      model.save!
+
       proxy = DiscourseAi::Completions::Llm.proxy("custom:#{model.id}")
 
       incomplete_tool_call = <<~XML.strip

--- a/spec/lib/modules/ai_bot/tools/search_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/search_spec.rb
@@ -139,11 +139,10 @@ RSpec.describe DiscourseAi::AiBot::Tools::Search do
         expect(results[:args]).to eq({ search_query: "hello world, sam", status: "public" })
         expect(results[:rows].length).to eq(1)
 
-
         # it also works with no query
         search =
           described_class.new(
-            { order: "likes", user: "sam", status: "public", search_query: "a"},
+            { order: "likes", user: "sam", status: "public", search_query: "a" },
             llm: llm,
             bot_user: bot_user,
           )

--- a/spec/lib/modules/ai_bot/tools/search_spec.rb
+++ b/spec/lib/modules/ai_bot/tools/search_spec.rb
@@ -138,6 +138,23 @@ RSpec.describe DiscourseAi::AiBot::Tools::Search do
 
         expect(results[:args]).to eq({ search_query: "hello world, sam", status: "public" })
         expect(results[:rows].length).to eq(1)
+
+
+        # it also works with no query
+        search =
+          described_class.new(
+            { order: "likes", user: "sam", status: "public", search_query: "a"},
+            llm: llm,
+            bot_user: bot_user,
+          )
+
+        # results will be expanded by semantic search, but it will find nothing
+        results =
+          DiscourseAi::Completions::Llm.with_prepared_responses(["<ai>#{query}</ai>"]) do
+            search.invoke(&progress_blk)
+          end
+
+        expect(results[:rows].length).to eq(0)
       end
     end
 


### PR DESCRIPTION
This fixes a few issues:

1. When search was not finding any semantic results we would break the tool
2. Gemini / Anthropic models did not implement forced tools previously despite it being an API option
3. Mechanics around displaying llm selector were not right. If you disabled LLM selector server side persona PM did not work correctly.
4. Disabling native tools for anthropic model moved out of a site setting. This deliberately does not migrate cause this feature is really rare to need now, people who had it set probably did not need it.
5. Updates anthropic model names to latest release
