### PR TITLE
UX: minor gist optimizations for readability

### DIFF
--- a/assets/stylesheets/modules/summarization/common/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/common/ai-summary.scss
@@ -217,10 +217,12 @@
 }
 
 .ai-topic-gist {
+  width: 100%;
   .mobile-view & {
     position: relative;
     top: -0.33em;
     line-height: 1.4;
+    width: 90%;
   }
   .desktop-view & {
     margin-top: 0.15em;
@@ -231,6 +233,7 @@
     text-wrap: pretty;
     word-wrap: break-word;
     font-size: var(--font-down-1);
+    max-width: 70ch;
     .visited & {
       color: var(--primary-medium);
     }


### PR DESCRIPTION
This ensures that erroneous short gists will still occupy a full row in the topic list... avoiding something like:

![image](https://github.com/user-attachments/assets/8b967a6d-029f-433b-ae2a-07eec5793f14)


This also: 

* limits text width to 70 characters, which is on the high end of the general rule of thumb for optimal line length (45-75 characters) 
* reduces mobile gist width to better match limited topic title width