### PR TITLE
FIX/REFACTOR: FoldContent revamp

### DIFF
--- a/app/controllers/discourse_ai/summarization/chat_summary_controller.rb
+++ b/app/controllers/discourse_ai/summarization/chat_summary_controller.rb
@@ -26,7 +26,7 @@ module DiscourseAi
           strategy = DiscourseAi::Summarization::Strategies::ChatMessages.new(channel, since)
 
           summarized_text =
-            if strategy.targets_data[:contents].empty?
+            if strategy.targets_data.empty?
               I18n.t("discourse_ai.summarization.chat.no_targets")
             else
               summarizer.summarize(current_user)&.summarized_text

--- a/lib/summarization/fold_content.rb
+++ b/lib/summarization/fold_content.rb
@@ -90,10 +90,10 @@ module DiscourseAi
       # Note: The block is only called with results of the final summary, not intermediate summaries.
       #
       # The summarization algorithm.
-      # The idea is to build an initial summary packing as much content as we can. Once we have the initial summary, we'll keep extending using the lefover
+      # The idea is to build an initial summary packing as much content as we can. Once we have the initial summary, we'll keep extending using the leftover
       # content until there is nothing left.
       #
-      # @returns { AiSummary } - Resulting summary.
+      # @returns { String } - Resulting summary.
       def fold(items, summary, cursor, user, &on_partial_blk)
         tokenizer = llm_model.tokenizer_class
         tokens_left = available_tokens - tokenizer.size(summary)

--- a/lib/summarization/strategies/base.rb
+++ b/lib/summarization/strategies/base.rb
@@ -11,7 +11,7 @@ module DiscourseAi
           @target = target
         end
 
-        attr_reader :target
+        attr_reader :target, :opts
 
         # The summary type differentiates instances of `AiSummary` pointing to a single target.
         # See the `summary_type` enum for available options.
@@ -19,11 +19,9 @@ module DiscourseAi
           raise NotImplementedError
         end
 
-        # @returns { Hash } - Content to summarize.
+        # @returns { Array<Hash> } - Content to summarize.
         #
-        # This method returns a hash with the content to summarize and additional information.
-        # The only mandatory key is `contents`, which must be an array of hashes with
-        # the following structure:
+        # This method returns an array of hashes with the content to summarize using the following structure:
         #
         # {
         #  poster: A way to tell who write the content,
@@ -31,26 +29,17 @@ module DiscourseAi
         #  text: Text to summarize
         # }
         #
-        # Additionally, you could add more context, which will be available in the prompt. e.g.:
-        #
-        # {
-        #   resource_path: "#{Discourse.base_path}/t/-/#{target.id}",
-        #   content_title: target.title,
-        #   contents: [...]
-        # }
-        #
         def targets_data
           raise NotImplementedError
         end
 
-        # @returns { DiscourseAi::Completions::Prompt } - Prompt passed to the LLM when concatenating multiple chunks.
-        def contatenation_prompt(_texts_to_summarize)
+        # @returns { DiscourseAi::Completions::Prompt } - Prompt passed to the LLM when extending an existing summary.
+        def summary_extension_prompt(_summary, _texts_to_summarize)
           raise NotImplementedError
         end
 
-        # @returns { DiscourseAi::Completions::Prompt } - Prompt passed to the LLM on each chunk,
-        # and when the whole content fits in one call.
-        def summarize_single_prompt(_input, _opts)
+        # @returns { DiscourseAi::Completions::Prompt } - Prompt passed to the LLM for summarizing a single chunk of content.
+        def first_summary_prompt(_input)
           raise NotImplementedError
         end
       end

--- a/lib/summarization/strategies/chat_messages.rb
+++ b/lib/summarization/strategies/chat_messages.rb
@@ -14,38 +14,60 @@ module DiscourseAi
         end
 
         def targets_data
-          content = { content_title: target.name }
-
-          content[:contents] = target
+          target
             .chat_messages
             .where("chat_messages.created_at > ?", since.hours.ago)
             .includes(:user)
             .order(created_at: :asc)
             .pluck(:id, :username_lower, :message)
             .map { { id: _1, poster: _2, text: _3 } }
-
-          content
         end
 
-        def contatenation_prompt(texts_to_summarize)
+        def summary_extension_prompt(summary, contents)
+          input =
+            contents
+              .map { |item| "(#{item[:id]} #{item[:poster]} said: #{item[:text]} " }
+              .join("\n")
+
           prompt = DiscourseAi::Completions::Prompt.new(<<~TEXT.strip)
-          You are a summarization bot tasked with creating a cohesive narrative by intelligently merging multiple disjointed summaries. 
-          Your response should consist of well-structured paragraphs that combines these summaries into a clear and comprehensive overview. 
-          Avoid adding any additional text or commentary. Format your output using Discourse forum Markdown.
+            You are a summarization bot tasked with expanding on an existing summary by incorporating new chat messages.
+            Your goal is to seamlessly integrate the additional information into the existing summary, preserving the clarity and insights of the original while reflecting any new developments, themes, or conclusions.
+            Analyze the new messages to identify key themes, participants' intentions, and any significant decisions or resolutions.
+            Update the summary to include these aspects in a way that remains concise, comprehensive, and accessible to someone with no prior context of the conversation.
+
+            ### Guidelines:
+
+            - Merge the new information naturally with the existing summary without redundancy.
+            - Only include the updated summary, WITHOUT additional commentary.
+            - Don't mention the channel title. Avoid extraneous details or subjective opinions.
+            - Maintain the original language of the text being summarized.
+            - The same user could write multiple messages in a row, don't treat them as different persons.
+            - Aim for summaries to be extended by a reasonable amount, but strive to maintain a total length of 400 words or less, unless absolutely necessary for comprehensiveness.
+
         TEXT
 
           prompt.push(type: :user, content: <<~TEXT.strip)
-          THESE are the summaries, each one separated by a newline, all of them inside <input></input> XML tags:
+          ### Context:
 
-          <input>
-            #{texts_to_summarize.join("\n")}
-          </input>
+          This is the existing summary:
+
+          #{summary}
+
+          These are the new chat messages:
+
+          #{input}
+
+          Intengrate the new messages into the existing summary.
         TEXT
 
           prompt
         end
 
-        def summarize_single_prompt(input, opts)
+        def first_summary_prompt(contents)
+          content_title = target.name
+          input =
+            contents.map { |item| "(#{item[:id]} #{item[:poster]} said: #{item[:text]} " }.join
+
           prompt = DiscourseAi::Completions::Prompt.new(<<~TEXT.strip)
             You are a summarization bot designed to generate clear and insightful paragraphs that conveys the main topics 
             and developments from a series of chat messages within a user-selected time window. 
@@ -62,7 +84,7 @@ module DiscourseAi
           TEXT
 
           prompt.push(type: :user, content: <<~TEXT.strip)
-            #{opts[:content_title].present? ? "The name of the channel is: " + opts[:content_title] + ".\n" : ""}
+            #{content_title.present? ? "The name of the channel is: " + content_title + ".\n" : ""}
             
             Here are the messages, inside <input></input> XML tags:
 

--- a/lib/summarization/strategies/hot_topic_gists.rb
+++ b/lib/summarization/strategies/hot_topic_gists.rb
@@ -122,7 +122,7 @@ module DiscourseAi
             
             The conversation began with the following statement:
         
-            #{statements.pop}\n
+            #{statements.shift}\n
           TEXT
 
           if statements.present?

--- a/lib/tokenizer/basic_tokenizer.rb
+++ b/lib/tokenizer/basic_tokenizer.rb
@@ -40,14 +40,12 @@ module DiscourseAi
           tokenizer.decode(tokenizer.encode(text).ids.take(max_length))
         end
 
-        def can_expand_tokens?(text, addition, max_length)
+        def below_limit?(text, limit)
           # fast track common case, /2 to handle unicode chars
           # than can take more than 1 token per char
-          if !SiteSetting.ai_strict_token_counting && text.size + addition.size < max_length / 2
-            return true
-          end
+          return true if !SiteSetting.ai_strict_token_counting && text.size < limit / 2
 
-          tokenizer.encode(text).ids.length + tokenizer.encode(addition).ids.length < max_length
+          tokenizer.encode(text).ids.length < limit
         end
       end
     end

--- a/lib/tokenizer/open_ai_tokenizer.rb
+++ b/lib/tokenizer/open_ai_tokenizer.rb
@@ -31,14 +31,12 @@ module DiscourseAi
           retry
         end
 
-        def can_expand_tokens?(text, addition, max_length)
+        def below_limit?(text, limit)
           # fast track common case, /2 to handle unicode chars
           # than can take more than 1 token per char
-          if !SiteSetting.ai_strict_token_counting && text.size + addition.size < max_length / 2
-            return true
-          end
+          return true if !SiteSetting.ai_strict_token_counting && text.size < limit / 2
 
-          tokenizer.encode(text).length + tokenizer.encode(addition).length < max_length
+          tokenizer.encode(text).length < limit
         end
       end
     end

--- a/spec/lib/modules/summarization/strategies/hot_topic_gists_spec.rb
+++ b/spec/lib/modules/summarization/strategies/hot_topic_gists_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DiscourseAi::Summarization::Strategies::HotTopicGists do
       post_2.update(created_at: (SiteSetting.hot_topics_recent_days + 1).days.ago)
       Fabricate(:post, topic: topic, post_number: 3)
 
-      post_numbers = gist.targets_data[:contents].map { |c| c[:id] }
+      post_numbers = gist.targets_data.map { |c| c[:id] }
 
       expect(post_numbers).to contain_exactly(1, 3)
     end
@@ -20,7 +20,7 @@ RSpec.describe DiscourseAi::Summarization::Strategies::HotTopicGists do
     it "only includes visible posts" do
       post_2.update!(hidden: true)
 
-      post_numbers = gist.targets_data[:contents].map { |c| c[:id] }
+      post_numbers = gist.targets_data.map { |c| c[:id] }
 
       expect(post_numbers).to contain_exactly(1)
     end
@@ -28,7 +28,7 @@ RSpec.describe DiscourseAi::Summarization::Strategies::HotTopicGists do
     it "doesn't include posts without users" do
       post_2.update!(user_id: nil)
 
-      post_numbers = gist.targets_data[:contents].map { |c| c[:id] }
+      post_numbers = gist.targets_data.map { |c| c[:id] }
 
       expect(post_numbers).to contain_exactly(1)
     end
@@ -36,7 +36,7 @@ RSpec.describe DiscourseAi::Summarization::Strategies::HotTopicGists do
     it "doesn't include whispers" do
       post_2.update!(post_type: Post.types[:whisper])
 
-      post_numbers = gist.targets_data[:contents].map { |c| c[:id] }
+      post_numbers = gist.targets_data.map { |c| c[:id] }
 
       expect(post_numbers).to contain_exactly(1)
     end
@@ -51,8 +51,7 @@ RSpec.describe DiscourseAi::Summarization::Strategies::HotTopicGists do
           )
 
         content = gist.targets_data
-
-        op_content = content[:contents].first[:text]
+        op_content = content.first[:text]
 
         expect(op_content).to include(topic_embed.embed_content_cache)
       end

--- a/spec/lib/modules/summarization/strategies/topic_summary_spec.rb
+++ b/spec/lib/modules/summarization/strategies/topic_summary_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DiscourseAi::Summarization::Strategies::TopicSummary do
       it "only includes visible posts" do
         post_2.update!(hidden: true)
 
-        post_numbers = topic_summary.targets_data[:contents].map { |c| c[:id] }
+        post_numbers = topic_summary.targets_data.map { |c| c[:id] }
 
         expect(post_numbers).to contain_exactly(1)
       end
@@ -20,7 +20,7 @@ RSpec.describe DiscourseAi::Summarization::Strategies::TopicSummary do
       it "doesn't include posts without users" do
         post_2.update!(user_id: nil)
 
-        post_numbers = topic_summary.targets_data[:contents].map { |c| c[:id] }
+        post_numbers = topic_summary.targets_data.map { |c| c[:id] }
 
         expect(post_numbers).to contain_exactly(1)
       end
@@ -28,7 +28,7 @@ RSpec.describe DiscourseAi::Summarization::Strategies::TopicSummary do
       it "doesn't include whispers" do
         post_2.update!(post_type: Post.types[:whisper])
 
-        post_numbers = topic_summary.targets_data[:contents].map { |c| c[:id] }
+        post_numbers = topic_summary.targets_data.map { |c| c[:id] }
 
         expect(post_numbers).to contain_exactly(1)
       end
@@ -56,8 +56,7 @@ RSpec.describe DiscourseAi::Summarization::Strategies::TopicSummary do
           )
 
         content = topic_summary.targets_data
-
-        op_content = content[:contents].first[:text]
+        op_content = content.first[:text]
 
         expect(op_content).to include(topic_embed.embed_content_cache)
       end

--- a/spec/shared/tokenizer_spec.rb
+++ b/spec/shared/tokenizer_spec.rb
@@ -90,21 +90,21 @@ describe DiscourseAi::Tokenizer::OpenAiTokenizer do
     end
   end
 
-  describe "#can_expand_tokens?" do
+  describe "#below_limit?" do
     it "returns true when the tokens can be expanded" do
-      expect(described_class.can_expand_tokens?("foo bar", "baz qux", 6)).to eq(true)
+      expect(described_class.below_limit?("foo bar baz qux", 6)).to eq(true)
     end
 
     it "returns false when the tokens cannot be expanded" do
-      expect(described_class.can_expand_tokens?("foo bar", "baz qux", 3)).to eq(false)
+      expect(described_class.below_limit?("foo bar baz qux", 3)).to eq(false)
     end
 
     it "returns false when the tokens cannot be expanded due to multibyte unicode characters" do
-      expect(described_class.can_expand_tokens?("foo bar 👨🏿", "baz qux", 6)).to eq(false)
+      expect(described_class.below_limit?("foo bar 👨🏿 baz qux", 6)).to eq(false)
     end
 
     it "handles unicode characters properly when they use more than one token per char" do
-      expect(described_class.can_expand_tokens?("我喜欢吃比萨", "萨", 10)).to eq(false)
+      expect(described_class.below_limit?("我喜欢吃比萨萨", 10)).to eq(false)
     end
   end
 end


### PR DESCRIPTION
We hit a snag with our hot topic gist strategy: the regex we used to split the content didn't work, so we cannot send the original post separately. This was important for letting the model focus on what's new in the topic.

The algorithm doesn’t give us full control over how prompts are written, and figuring out how to format the content isn't straightforward. This means we're having to use more complicated workarounds, like regex.

To tackle this, I'm suggesting we simplify the approach a bit. Let's focus on summarizing as much as we can upfront, then gradually add new content until there's nothing left to summarize.

Also, the "extend" part is mostly for models with small context windows, which shouldn't pose a problem 99% of the time with the content volume we're dealing with.