### PR TITLE
DEV: Fix mismatched column types

### DIFF
--- a/db/migrate/20241025135522_alter_ai_ids_to_bigint.rb
+++ b/db/migrate/20241025135522_alter_ai_ids_to_bigint.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AlterAiIdsToBigint < ActiveRecord::Migration[7.1]
+  def up
+    change_column :ai_document_fragment_embeddings, :rag_document_fragment_id, :bigint
+    change_column :classification_results, :target_id, :bigint
+    change_column :rag_document_fragments, :target_id, :bigint
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -17,14 +17,4 @@ module DiscourseAi::ChatBotHelper
   end
 end
 
-RSpec.configure do |config|
-  config.include DiscourseAi::ChatBotHelper
-
-  config.before(:suite) do
-    if defined?(migrate_column_to_bigint)
-      migrate_column_to_bigint(RagDocumentFragment, :target_id)
-      migrate_column_to_bigint("ai_document_fragment_embeddings", "rag_document_fragment_id")
-      migrate_column_to_bigint(ClassificationResult, :target_id)
-    end
-  end
-end
+RSpec.configure { |config| config.include DiscourseAi::ChatBotHelper }


### PR DESCRIPTION
The primary key is usually a bigint column, but the foreign key columns are usually of integer type. This can lead to issues when joining these columns due to mismatched types and different value ranges.

This was using a temporary plugin / test API to make tests pass, but it is safe to alter "ai_document_fragment_embeddings" and "rag_document_fragments" tables because they usually have less than 1M rows and migration is going to be fast.

Depending on the size of the community, "classification_results" table may have more than 1M rows and the migration will lock the table for a longer time. However, classification runs in background jobs and they will be automatically retried if they fail due to the lock, which makes it acceptable.