### PR TITLE
DEV: Check for presence of currentRoute.attributes

### DIFF
--- a/assets/javascripts/discourse/components/ai-gist-disclosure.gjs
+++ b/assets/javascripts/discourse/components/ai-gist-disclosure.gjs
@@ -7,7 +7,7 @@ export default class AiGistDisclosure extends Component {
   @service router;
 
   get shouldShow() {
-    return this.router.currentRoute.attributes.list?.topics?.some(
+    return this.router.currentRoute.attributes?.list?.topics?.some(
       (topic) => topic.ai_topic_gist
     );
   }


### PR DESCRIPTION
It appears that the `discovery.custom` route may not (always?) have attributes set, which can cause an error here.