### PR TITLE
FEATURE: new endpoint for directly accessing a persona

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -347,3 +347,13 @@ en:
     llm_models:
       missing_provider_param: "%{param} can't be blank"
       bedrock_invalid_url: "Please complete all the fields to contact this model."
+
+    errors:
+      no_query_specified: The query parameter is required, please specify it.
+      no_user_for_persona: The persona specified does not have a user associated with it.
+      persona_not_found: The persona specified does not exist. Check the persona_name or persona_id params.
+      no_user_specified: The username or the user_unique_id parameter is required, please specify it.
+      user_not_found: The user specified does not exist. Check the username param.
+      persona_disabled: The persona specified is disabled. Check the persona_name or persona_id params.
+      no_default_llm: The persona must have a default_llm defined.
+      user_not_allowed: The user is not allowed to participate in the topic.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,8 @@ Discourse::Application.routes.draw do
               path: "ai-personas",
               controller: "discourse_ai/admin/ai_personas"
 
+    post "/ai-personas/stream-reply" => "discourse_ai/admin/ai_personas#stream_reply"
+
     resources(
       :ai_tools,
       only: %i[index create show update destroy],

--- a/db/migrate/20241028034232_add_unique_ai_stream_conversation_user_id_index.rb
+++ b/db/migrate/20241028034232_add_unique_ai_stream_conversation_user_id_index.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddUniqueAiStreamConversationUserIdIndex < ActiveRecord::Migration[7.1]
+  def change
+    add_index :user_custom_fields, [:value], unique: true, where: "name = 'ai-stream-conversation-unique-id'"
+  end
+end

--- a/lib/ai_bot/bot.rb
+++ b/lib/ai_bot/bot.rb
@@ -113,7 +113,7 @@ module DiscourseAi
                 tool_found = true
                 # a bit hacky, but extra newlines do no harm
                 if needs_newlines
-                  update_blk.call("\n\n", cancel, nil)
+                  update_blk.call("\n\n", cancel)
                   needs_newlines = false
                 end
 
@@ -123,7 +123,7 @@ module DiscourseAi
                 end
               else
                 needs_newlines = true
-                update_blk.call(partial, cancel, nil)
+                update_blk.call(partial, cancel)
               end
             end
 
@@ -191,9 +191,9 @@ module DiscourseAi
         tool_details = build_placeholder(tool.summary, tool.details, custom_raw: tool.custom_raw)
 
         if context[:skip_tool_details] && tool.custom_raw.present?
-          update_blk.call(tool.custom_raw, cancel, nil)
+          update_blk.call(tool.custom_raw, cancel, nil, :custom_raw)
         elsif !context[:skip_tool_details]
-          update_blk.call(tool_details, cancel, nil)
+          update_blk.call(tool_details, cancel, nil, :tool_details)
         end
 
         result

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -390,7 +390,7 @@ module DiscourseAi
         result
       end
 
-      def reply_to(post)
+      def reply_to(post, &blk)
         reply = +""
         start = Time.now
 
@@ -441,10 +441,14 @@ module DiscourseAi
         context[:skip_tool_details] ||= !bot.persona.class.tool_details
 
         new_custom_prompts =
-          bot.reply(context) do |partial, cancel, placeholder|
+          bot.reply(context) do |partial, cancel, placeholder, type|
             reply << partial
             raw = reply.dup
             raw << "\n\n" << placeholder if placeholder.present? && !context[:skip_tool_details]
+
+            if blk && type != :tool_details
+              blk.call(partial)
+            end
 
             if stream_reply && !Discourse.redis.get(redis_stream_key)
               cancel&.call

--- a/lib/completions/endpoints/fake.rb
+++ b/lib/completions/endpoints/fake.rb
@@ -72,6 +72,10 @@ module DiscourseAi
           @fake_content = nil
         end
 
+        def self.fake_content=(content)
+          @fake_content = content
+        end
+
         def self.fake_content
           @fake_content || STOCK_CONTENT
         end
@@ -100,6 +104,13 @@ module DiscourseAi
           @last_call = params
         end
 
+        def self.reset!
+          @last_call = nil
+          @fake_content = nil
+          @delays = nil
+          @chunk_count = nil
+        end
+
         def perform_completion!(
           dialect,
           user,
@@ -110,6 +121,8 @@ module DiscourseAi
           self.class.last_call = { dialect: dialect, user: user, model_params: model_params }
 
           content = self.class.fake_content
+
+          content = content.shift if content.is_a?(Array)
 
           if block_given?
             split_indices = (1...content.length).to_a.sample(self.class.chunk_count - 1).sort


### PR DESCRIPTION
The new `/admin/plugins/discourse-ai/ai-personas/stream-reply.json` was added.

This endpoint streams data direct from a persona and can be used
to access a persona from remote systems leaving a paper trail in
PMs about the conversation that happened

This endpoint is only accessible to admins.
