### PR TITLE
FIX: ensure replies are never double streamed

### DIFF
--- a/app/controllers/discourse_ai/admin/ai_personas_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_personas_controller.rb
@@ -128,7 +128,9 @@ module DiscourseAi
               topic_id: topic_id,
               raw: params[:query],
               skip_validations: true,
-              custom_fields: { DiscourseAi::AiBot::Playground::BYPASS_AI_REPLY_CUSTOM_FIELD => true },
+              custom_fields: {
+                DiscourseAi::AiBot::Playground::BYPASS_AI_REPLY_CUSTOM_FIELD => true,
+              },
             )
         else
           post =
@@ -139,7 +141,9 @@ module DiscourseAi
               archetype: Archetype.private_message,
               target_usernames: "#{user.username},#{persona.user.username}",
               skip_validations: true,
-              custom_fields: { DiscourseAi::AiBot::Playground::BYPASS_AI_REPLY_CUSTOM_FIELD => true },
+              custom_fields: {
+                DiscourseAi::AiBot::Playground::BYPASS_AI_REPLY_CUSTOM_FIELD => true,
+              },
             )
 
           topic = post.topic
@@ -150,7 +154,13 @@ module DiscourseAi
 
         user = current_user
 
-        DiscourseAi::AiBot::ResponseHttpStreamer.queue_streamed_reply(io, persona, user, topic, post)
+        DiscourseAi::AiBot::ResponseHttpStreamer.queue_streamed_reply(
+          io,
+          persona,
+          user,
+          topic,
+          post,
+        )
       end
 
       private

--- a/app/controllers/discourse_ai/admin/ai_personas_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_personas_controller.rb
@@ -74,33 +74,6 @@ module DiscourseAi
         end
       end
 
-      class << self
-        POOL_SIZE = 10
-        def thread_pool
-          @thread_pool ||=
-            Concurrent::CachedThreadPool.new(min_threads: 0, max_threads: POOL_SIZE, idletime: 30)
-        end
-
-        def schedule_block(&block)
-          # think about a better way to handle cross thread connections
-          if Rails.env.test?
-            block.call
-            return
-          end
-
-          db = RailsMultisite::ConnectionManagement.current_db
-          thread_pool.post do
-            begin
-              RailsMultisite::ConnectionManagement.with_connection(db) { block.call }
-            rescue StandardError => e
-              Discourse.warn_exception(e, message: "Discourse AI: Unable to stream reply")
-            end
-          end
-        end
-      end
-
-      CRLF = "\r\n"
-
       def stream_reply
         persona =
           AiPersona.find_by(name: params[:persona_name]) ||
@@ -155,6 +128,7 @@ module DiscourseAi
               topic_id: topic_id,
               raw: params[:query],
               skip_validations: true,
+              custom_fields: { DiscourseAi::AiBot::Playground::BYPASS_AI_REPLY_CUSTOM_FIELD => true },
             )
         else
           post =
@@ -165,6 +139,7 @@ module DiscourseAi
               archetype: Archetype.private_message,
               target_usernames: "#{user.username},#{persona.user.username}",
               skip_validations: true,
+              custom_fields: { DiscourseAi::AiBot::Playground::BYPASS_AI_REPLY_CUSTOM_FIELD => true },
             )
 
           topic = post.topic
@@ -175,80 +150,12 @@ module DiscourseAi
 
         user = current_user
 
-        self.class.queue_streamed_reply(io, persona, user, topic, post)
+        DiscourseAi::AiBot::ResponseHttpStreamer.queue_streamed_reply(io, persona, user, topic, post)
       end
 
       private
 
       AI_STREAM_CONVERSATION_UNIQUE_ID = "ai-stream-conversation-unique-id"
-
-      # keeping this in a static method so we don't capture ENV and other bits
-      # this allows us to release memory earlier
-      def self.queue_streamed_reply(io, persona, user, topic, post)
-        schedule_block do
-          begin
-            io.write "HTTP/1.1 200 OK"
-            io.write CRLF
-            io.write "Content-Type: text/plain; charset=utf-8"
-            io.write CRLF
-            io.write "Transfer-Encoding: chunked"
-            io.write CRLF
-            io.write "Cache-Control: no-cache, no-store, must-revalidate"
-            io.write CRLF
-            io.write "Connection: close"
-            io.write CRLF
-            io.write "X-Accel-Buffering: no"
-            io.write CRLF
-            io.write "X-Content-Type-Options: nosniff"
-            io.write CRLF
-            io.write CRLF
-            io.flush
-
-            persona_class =
-              DiscourseAi::AiBot::Personas::Persona.find_by(id: persona.id, user: user)
-            bot = DiscourseAi::AiBot::Bot.as(persona.user, persona: persona_class.new)
-
-            data =
-              { topic_id: topic.id, bot_user_id: persona.user.id, persona_id: persona.id }.to_json +
-                "\n\n"
-
-            io.write data.bytesize.to_s(16)
-            io.write CRLF
-            io.write data
-            io.write CRLF
-
-            DiscourseAi::AiBot::Playground
-              .new(bot)
-              .reply_to(post) do |partial|
-                next if partial.length == 0
-
-                data = { partial: partial }.to_json + "\n\n"
-
-                data.force_encoding("UTF-8")
-
-                io.write data.bytesize.to_s(16)
-                io.write CRLF
-                io.write data
-                io.write CRLF
-                io.flush
-              end
-
-            io.write "0"
-            io.write CRLF
-            io.write CRLF
-
-            io.flush
-            io.done
-          rescue StandardError => e
-            # make it a tiny bit easier to debug in dev, this is tricky
-            # multi-threaded code that exhibits various limitations in rails
-            p e if Rails.env.development?
-            Discourse.warn_exception(e, message: "Discourse AI: Unable to stream reply")
-          ensure
-            io.close
-          end
-        end
-      end
 
       def stage_user
         unique_id = params[:user_unique_id].to_s

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -3,7 +3,6 @@
 module DiscourseAi
   module AiBot
     class Playground
-
       BYPASS_AI_REPLY_CUSTOM_FIELD = "discourse_ai_bypass_ai_reply"
 
       attr_reader :bot

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -3,6 +3,9 @@
 module DiscourseAi
   module AiBot
     class Playground
+
+      BYPASS_AI_REPLY_CUSTOM_FIELD = "discourse_ai_bypass_ai_reply"
+
       attr_reader :bot
 
       # An abstraction to manage the bot and topic interactions.
@@ -550,6 +553,7 @@ module DiscourseAi
         return false if bot.bot_user.nil?
         return false if post.topic.private_message? && post.post_type != Post.types[:regular]
         return false if (SiteSetting.ai_bot_allowed_groups_map & post.user.group_ids).blank?
+        return false if post.custom_fields[BYPASS_AI_REPLY_CUSTOM_FIELD].present?
 
         true
       end

--- a/lib/ai_bot/response_http_streamer.rb
+++ b/lib/ai_bot/response_http_streamer.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module AiBot
+    class ResponseHttpStreamer
+      CRLF = "\r\n"
+      POOL_SIZE = 10
+
+      class << self
+        def thread_pool
+          @thread_pool ||=
+            Concurrent::CachedThreadPool.new(min_threads: 0, max_threads: POOL_SIZE, idletime: 30)
+        end
+
+        def schedule_block(&block)
+          # think about a better way to handle cross thread connections
+          if Rails.env.test?
+            block.call
+            return
+          end
+
+          db = RailsMultisite::ConnectionManagement.current_db
+          thread_pool.post do
+            begin
+              RailsMultisite::ConnectionManagement.with_connection(db) { block.call }
+            rescue StandardError => e
+              Discourse.warn_exception(e, message: "Discourse AI: Unable to stream reply")
+            end
+          end
+        end
+
+        # keeping this in a static method so we don't capture ENV and other bits
+        # this allows us to release memory earlier
+        def queue_streamed_reply(io, persona, user, topic, post)
+          schedule_block do
+            begin
+              io.write "HTTP/1.1 200 OK"
+              io.write CRLF
+              io.write "Content-Type: text/plain; charset=utf-8"
+              io.write CRLF
+              io.write "Transfer-Encoding: chunked"
+              io.write CRLF
+              io.write "Cache-Control: no-cache, no-store, must-revalidate"
+              io.write CRLF
+              io.write "Connection: close"
+              io.write CRLF
+              io.write "X-Accel-Buffering: no"
+              io.write CRLF
+              io.write "X-Content-Type-Options: nosniff"
+              io.write CRLF
+              io.write CRLF
+              io.flush
+
+              persona_class =
+                DiscourseAi::AiBot::Personas::Persona.find_by(id: persona.id, user: user)
+              bot = DiscourseAi::AiBot::Bot.as(persona.user, persona: persona_class.new)
+
+              data =
+                {
+                  topic_id: topic.id,
+                  bot_user_id: persona.user.id,
+                  persona_id: persona.id,
+                }.to_json + "\n\n"
+
+              io.write data.bytesize.to_s(16)
+              io.write CRLF
+              io.write data
+              io.write CRLF
+
+              DiscourseAi::AiBot::Playground
+                .new(bot)
+                .reply_to(post) do |partial|
+                  next if partial.length == 0
+
+                  data = { partial: partial }.to_json + "\n\n"
+
+                  data.force_encoding("UTF-8")
+
+                  io.write data.bytesize.to_s(16)
+                  io.write CRLF
+                  io.write data
+                  io.write CRLF
+                  io.flush
+                end
+
+              io.write "0"
+              io.write CRLF
+              io.write CRLF
+
+              io.flush
+              io.done
+            rescue StandardError => e
+              # make it a tiny bit easier to debug in dev, this is tricky
+              # multi-threaded code that exhibits various limitations in rails
+              p e if Rails.env.development?
+              Discourse.warn_exception(e, message: "Discourse AI: Unable to stream reply")
+            ensure
+              io.close
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The custom field "discourse_ai_bypass_ai_reply" was added so
we can signal the post created hook to bypass replying even
if it thinks it should.

Otherwise there are cases where we double answer user questions
leading to much confusion.

This also slightly refactors code making the controller smaller
