### PR TITLE
UX: in share, use native image dimensions and hide filename

### DIFF
--- a/public/ai-share/share.css
+++ b/public/ai-share/share.css
@@ -413,7 +413,7 @@ li, p {
 }
 
 .lightbox-wrapper img {
-  width: 100%;
+  width: auto;
   height: auto;
 }
 
@@ -440,8 +440,9 @@ aside .title .avatar {
   margin-right: 0.5em;
 }
 
-
-.lightbox-wrapper .meta svg, .lightbox-wrapper .meta .informations {
+.lightbox-wrapper .meta .filename,
+.lightbox-wrapper .meta svg, 
+.lightbox-wrapper .meta .informations {
   display: none;
 }
 


### PR DESCRIPTION
This makes things a little more reasonable for small images 


Before:
![image](https://github.com/user-attachments/assets/90e23e70-3540-417b-ab8e-d13aca580b3f)


After: 
![image](https://github.com/user-attachments/assets/790ce026-6ed3-433b-a921-ad84153fb7b4)
