### PR TITLE
FIX: we must properly encode objects prior to escaping

### DIFF
--- a/lib/completions/anthropic_message_processor.rb
+++ b/lib/completions/anthropic_message_processor.rb
@@ -39,7 +39,7 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
         )
 
       params = JSON.parse(tool_call.raw_json, symbolize_names: true)
-      xml = params.map { |name, value| "<#{name}>#{CGI.escapeHTML(value)}</#{name}>" }.join("\n")
+      xml = params.map { |name, value| "<#{name}>#{CGI.escapeHTML(value.to_s)}</#{name}>" }.join("\n")
 
       node.at("tool_name").content = tool_call.name
       node.at("tool_id").content = tool_call.id

--- a/lib/completions/anthropic_message_processor.rb
+++ b/lib/completions/anthropic_message_processor.rb
@@ -39,7 +39,8 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
         )
 
       params = JSON.parse(tool_call.raw_json, symbolize_names: true)
-      xml = params.map { |name, value| "<#{name}>#{CGI.escapeHTML(value.to_s)}</#{name}>" }.join("\n")
+      xml =
+        params.map { |name, value| "<#{name}>#{CGI.escapeHTML(value.to_s)}</#{name}>" }.join("\n")
 
       node.at("tool_name").content = tool_call.name
       node.at("tool_id").content = tool_call.id

--- a/lib/completions/endpoints/gemini.rb
+++ b/lib/completions/endpoints/gemini.rb
@@ -179,7 +179,7 @@ module DiscourseAi
           if partial[:args]
             argument_fragments =
               partial[:args].reduce(+"") do |memo, (arg_name, value)|
-                memo << "\n<#{arg_name}>#{CGI.escapeHTML(value)}</#{arg_name}>"
+                memo << "\n<#{arg_name}>#{CGI.escapeHTML(value.to_s)}</#{arg_name}>"
               end
             argument_fragments << "\n"
 

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -173,7 +173,7 @@ module DiscourseAi
 
               argument_fragments =
                 json_args.reduce(+"") do |memo, (arg_name, value)|
-                  memo << "\n<#{arg_name}>#{CGI.escapeHTML(value)}</#{arg_name}>"
+                  memo << "\n<#{arg_name}>#{CGI.escapeHTML(value.to_s)}</#{arg_name}>"
                 end
               argument_fragments << "\n"
 


### PR DESCRIPTION
(in cases of arrays escapeHTML will not work)
