### PR TITLE
UX: add sparkle icon to related topics for anons

### DIFF
--- a/assets/javascripts/initializers/related-topics.gjs
+++ b/assets/javascripts/initializers/related-topics.gjs
@@ -1,6 +1,7 @@
 import { cached, tracked } from "@glimmer/tracking";
 import BasicTopicList from "discourse/components/basic-topic-list";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 
 const RelatedTopics = <template>
@@ -11,7 +12,7 @@ const RelatedTopics = <template>
     class="more-topics__list"
   >
     <h3 id="related-topics-title" class="more-topics__list-title">
-      {{i18n "discourse_ai.related_topics.title"}}
+      {{icon "discourse-sparkles"}}{{i18n "discourse_ai.related_topics.title"}}
     </h3>
     <div class="topics">
       <BasicTopicList @topics={{@topic.relatedTopics}} />

--- a/assets/stylesheets/modules/embeddings/common/semantic-related-topics.scss
+++ b/assets/stylesheets/modules/embeddings/common/semantic-related-topics.scss
@@ -2,15 +2,13 @@
   margin: 4.5em 0 1em;
 }
 
-.more-topics__list {
+.more-topics__container {
   h3 .d-icon {
     margin-right: 0.25em;
     color: var(--primary-high);
     font-size: var(--font-down-1);
   }
-}
 
-.more-topics__container {
   .nav-pills .d-icon {
     font-size: var(--font-down-1);
   }

--- a/assets/stylesheets/modules/embeddings/common/semantic-related-topics.scss
+++ b/assets/stylesheets/modules/embeddings/common/semantic-related-topics.scss
@@ -1,3 +1,17 @@
 .related-topics {
   margin: 4.5em 0 1em;
 }
+
+.more-topics__list {
+  h3 .d-icon {
+    margin-right: 0.25em;
+    color: var(--primary-high);
+    font-size: var(--font-down-1);
+  }
+}
+
+.more-topics__container {
+  .nav-pills .d-icon {
+    font-size: var(--font-down-1);
+  }
+}


### PR DESCRIPTION
This adds the sparkles icon to semantic related topics for anon visitors... 

Before:
![image](https://github.com/user-attachments/assets/25756bc6-f29e-47a1-98f3-bfe8b43c874f)

After:
![image](https://github.com/user-attachments/assets/4ecebdb9-de1e-4342-ae69-92d184f0d69a)

I also slightly scaled down the icon in the nav-pills for logged-in visitors:

Before:

![image](https://github.com/user-attachments/assets/e37c5fc2-bc6c-42c7-91db-b96569fc5ab4)

After:

![image](https://github.com/user-attachments/assets/f7e6a134-215a-4c18-9397-fcdf2d88160a)
