### PR TITLE
FIX: Final summary sometimes missing

### DIFF
--- a/assets/javascripts/discourse/lib/ai-streamer/progress-handlers.js
+++ b/assets/javascripts/discourse/lib/ai-streamer/progress-handlers.js
@@ -113,6 +113,10 @@ export async function applyProgress(status, updater) {
     if (status.cooked) {
       await updater.setCooked(status.cooked);
     }
+    // Ensure the final summary is set
+    if (status.raw !== undefined) {
+      await updater.setRaw(status.raw, true);
+    }
     updater.streaming = false;
   }
 


### PR DESCRIPTION
### :mag: Overview
This PR fixes an issue where the summary updater sometimes doesn't show the last update. Due to some timing issues with the summary updater and the component this seems to happen. When the status.done flag is set but the final setRaw call is not completed, the final summary might not be displayed. By explicitly calling set raw after the cooked, we ensure the final summary will always be set.

### 📄 Other notes

No tests as this timing issue is difficult to test.