### PR TITLE
UX: increase gist size, and adjust surrounding elements to accommodate

### DIFF
--- a/assets/javascripts/discourse/components/ai-topic-gist.gjs
+++ b/assets/javascripts/discourse/components/ai-topic-gist.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import bodyClass from "discourse/helpers/body-class";
 
 export default class AiTopicGist extends Component {
   @service router;
@@ -21,6 +22,7 @@ export default class AiTopicGist extends Component {
 
   <template>
     {{#if this.showGist}}
+      {{bodyClass "--topic-list-with-gist"}}
       <div class="ai-topic-gist">
         <div class="ai-topic-gist__text">
           {{@topic.ai_topic_gist}}

--- a/assets/stylesheets/modules/summarization/common/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/common/ai-summary.scss
@@ -224,18 +224,58 @@
     line-height: 1.4;
     width: 90%;
   }
-  .desktop-view & {
-    margin-top: 0.15em;
-    margin-bottom: -0.15em;
-  }
+
   &__text {
     color: var(--primary-high);
     text-wrap: pretty;
     word-wrap: break-word;
     font-size: var(--font-down-1);
-    max-width: 70ch;
+    max-width: 65ch;
     .visited & {
       color: var(--primary-medium);
+    }
+  }
+}
+
+.--topic-list-with-gist {
+  .topic-list-item {
+    .main-link {
+      .desktop-view & {
+        padding: 1em 1em 1em 0.67em;
+      }
+      font-size: var(--font-up-2);
+      line-height: var(--line-height-medium);
+    }
+    .link-bottom-line {
+      font-size: var(--font-down-2);
+      margin-top: 0.25em;
+    }
+    .ai-topic-gist {
+      font-size: var(--font-up-1);
+      line-height: var(--line-height-large);
+      margin-top: 0.25em;
+      margin-bottom: 0.15em;
+    }
+    .topic-post-badges {
+      font-size: var(--font-down-1);
+    }
+  }
+
+  .mobile-view & {
+    .topic-list {
+      .topic-list-item > .topic-list-data {
+        padding: 1em 0;
+      }
+      .topic-item-stats .num.activity {
+        align-self: end;
+        margin-bottom: -0.15em; // vertical alignment
+      }
+      .pull-left {
+        padding-top: 0.25em;
+      }
+      .right {
+        margin-left: 3.75em;
+      }
     }
   }
 }


### PR DESCRIPTION
Since we've made gists longer, they feel harder to read with the small font size — this increases the font size of gists and the surrounding elements when gists are enabled on the topic list. 


Before:
![image](https://github.com/user-attachments/assets/9caa9857-c9a3-4884-a9a9-5135b59c35f7)


After: 
![image](https://github.com/user-attachments/assets/3b855fe2-fbd6-46b7-a9fb-84a4a3b3d857)


Before:
![image](https://github.com/user-attachments/assets/f3289188-9dc1-44fe-a1ec-65d4aa4da55d)


After:
![image](https://github.com/user-attachments/assets/66248943-361e-4d25-9b9c-277fd6779b45)

