### PR TITLE
FIX: Regenerate summary button still shows cached summary

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-box.gjs
@@ -123,6 +123,8 @@ export default class AiSummaryBox extends Component {
       }
     }
 
+    // ensure summary is reset before requesting a new one:
+    this.resetSummary();
     return this._requestSummary(fetchURL);
   }
 

--- a/lib/summarization/fold_content.rb
+++ b/lib/summarization/fold_content.rb
@@ -48,7 +48,7 @@ module DiscourseAi
 
       # @returns { AiSummary } - Resulting summary.
       #
-      # Finds a summary matching the target and strategy. Marks it as outdates if the strategy found newer content
+      # Finds a summary matching the target and strategy. Marks it as outdated if the strategy found newer content
       def existing_summary
         if !defined?(@existing_summary)
           summary = AiSummary.find_by(target: strategy.target, summary_type: strategy.type)

--- a/spec/system/page_objects/components/ai_summary_box.rb
+++ b/spec/system/page_objects/components/ai_summary_box.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class AiSummaryBox < PageObjects::Components::Base
+      SUMMARY_BUTTON_SELECTOR = ".ai-summarization-button button"
+      SUMMARY_CONTAINER_SELECTOR = ".ai-summary-container"
+
+      def click_summarize
+        find(SUMMARY_BUTTON_SELECTOR).click
+      end
+
+      def click_regenerate_summary
+        find("#{SUMMARY_CONTAINER_SELECTOR} .outdated-summary button").click
+      end
+
+      def has_summary?(summary)
+        find("#{SUMMARY_CONTAINER_SELECTOR} .generated-summary p").text == summary
+      end
+
+      def has_generating_summary_indicator?
+        find("#{SUMMARY_CONTAINER_SELECTOR} .ai-summary__generating-text").present?
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes an issue where clicking to regenerate a summary was still showing the cached summary. To resolve this we call `resetSummary()` to reset all the summarization related properties before creating a new request.