### PR TITLE
UX: reduce topic list title size when gists are enabled

### DIFF
--- a/assets/stylesheets/modules/summarization/common/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/common/ai-summary.scss
@@ -240,14 +240,10 @@
 .--topic-list-with-gist {
   .topic-list-item {
     .main-link {
-      .desktop-view & {
-        padding: 1em 1em 1em 0.67em;
-      }
-      font-size: var(--font-up-2);
       line-height: var(--line-height-medium);
     }
     .link-bottom-line {
-      font-size: var(--font-down-2);
+      font-size: var(--font-down-1);
       margin-top: 0.25em;
     }
     .ai-topic-gist {


### PR DESCRIPTION
In https://github.com/discourse/discourse-ai/commit/893fa624e40944d7c4a8e3a31bd006d8ca14c6b7 I increased the title size when gists are enabled, but this seems too large to some people so let's try the default size again 

before:

![image](https://github.com/user-attachments/assets/875f608d-adf1-4d86-a316-9f4e507c1076)


after: 

![image](https://github.com/user-attachments/assets/cab26a8d-a467-46a9-b2e3-653b6f030a70)
