### PR TITLE
FIX: results not being reset when appending to query param

### DIFF
--- a/assets/javascripts/initializers/ai-semantic-search.js
+++ b/assets/javascripts/initializers/ai-semantic-search.js
@@ -4,6 +4,6 @@ export default apiInitializer("1.15.0", (api) => {
   api.modifyClass("component:search-result-entry", {
     pluginId: "discourse-ai",
 
-    classNameBindings: ["bulkSelectEnabled", "post.generatedByAI:ai-result"],
+    classNameBindings: ["bulkSelectEnabled", "post.generatedByAi:ai-result"],
   });
 });


### PR DESCRIPTION
This PR fixes an issue where the AI search results were not being reset when you append your search to an existing query param (typically when you've come from quick search). This is because `handleSearch()` doesn't get called in this situation. So here we explicitly check for query params, trigger a reset and search for those occasions. Testing needs to be improved quite a bit here so I will address it in a follow-up PR.