### PR TITLE
FIX: properly bypass CSP for artifacts

### DIFF
--- a/app/controllers/discourse_ai/ai_bot/artifacts_controller.rb
+++ b/app/controllers/discourse_ai/ai_bot/artifacts_controller.rb
@@ -40,7 +40,7 @@ module DiscourseAi
         HTML
 
         response.headers.delete("X-Frame-Options")
-        response.headers.delete("Content-Security-Policy")
+        response.headers["Content-Security-Policy"] = "script-src 'unsafe-inline';"
 
         # Render the content
         render html: html.html_safe, layout: false, content_type: "text/html"

--- a/spec/requests/ai_bot/artifacts_controller_spec.rb
+++ b/spec/requests/ai_bot/artifacts_controller_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe DiscourseAi::AiBot::ArtifactsController do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:topic) { Fabricate(:private_message_topic, user: user) }
+  fab!(:post) { Fabricate(:post, user: user, topic: topic) }
+  fab!(:artifact) do
+    AiArtifact.create!(
+      user: user,
+      post: post,
+      name: "Test Artifact",
+      html: "<div>Hello World</div>",
+      css: "div { color: blue; }",
+      js: "console.log('test');",
+      metadata: {
+        public: false,
+      },
+    )
+  end
+
+  before do
+    SiteSetting.discourse_ai_enabled = true
+    SiteSetting.ai_artifact_security = "strict"
+  end
+
+  describe "#show" do
+    it "returns 404 when discourse_ai is disabled" do
+      SiteSetting.discourse_ai_enabled = false
+      get "/discourse-ai/ai-bot/artifacts/#{artifact.id}"
+      expect(response.status).to eq(404)
+    end
+
+    it "returns 404 when ai_artifact_security disables it" do
+      SiteSetting.ai_artifact_security = "disabled"
+      get "/discourse-ai/ai-bot/artifacts/#{artifact.id}"
+      expect(response.status).to eq(404)
+    end
+
+    context "with private artifact" do
+      it "returns 404 when user cannot see the post" do
+        get "/discourse-ai/ai-bot/artifacts/#{artifact.id}"
+        expect(response.status).to eq(404)
+      end
+
+      it "shows artifact when user can see the post" do
+        sign_in(user)
+        get "/discourse-ai/ai-bot/artifacts/#{artifact.id}"
+        expect(response.status).to eq(200)
+        expect(response.body).to include(artifact.html)
+        expect(response.body).to include(artifact.css)
+        expect(response.body).to include(artifact.js)
+      end
+    end
+
+    context "with public artifact" do
+      before { artifact.update!(metadata: { public: true }) }
+
+      it "shows artifact without authentication" do
+        get "/discourse-ai/ai-bot/artifacts/#{artifact.id}"
+        expect(response.status).to eq(200)
+        expect(response.body).to include(artifact.html)
+      end
+    end
+
+    it "removes security headers" do
+      sign_in(user)
+      get "/discourse-ai/ai-bot/artifacts/#{artifact.id}"
+      expect(response.headers["X-Frame-Options"]).to eq(nil)
+      expect(response.headers["Content-Security-Policy"]).to eq("script-src 'unsafe-inline';")
+    end
+  end
+end

--- a/spec/requests/ai_bot/artifacts_controller_spec.rb
+++ b/spec/requests/ai_bot/artifacts_controller_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.describe DiscourseAi::AiBot::ArtifactsController do
-  fab!(:user) { Fabricate(:user) }
+  fab!(:user)
   fab!(:topic) { Fabricate(:private_message_topic, user: user) }
   fab!(:post) { Fabricate(:post, user: user, topic: topic) }
   fab!(:artifact) do


### PR DESCRIPTION
The intent was always to bypass CSP we have no choice with an artifact system and it is sandboxed 