### PR TITLE
FIX: Reduce scope of topic gists inclusion.

### DIFF
--- a/lib/summarization/entry_point.rb
+++ b/lib/summarization/entry_point.rb
@@ -18,9 +18,7 @@ module DiscourseAi
         end
 
         plugin.register_modifier(:topic_query_create_list_topics) do |topics, options|
-          skipped_filters = %i[suggested semantic_related private_messages]
-
-          if !skipped_filters.include?(options[:filter]) && SiteSetting.ai_summarization_enabled &&
+          if Discourse.filters.include?(options[:filter]) && SiteSetting.ai_summarization_enabled &&
                SiteSetting.ai_summarize_max_hot_topics_gists_per_batch > 0
             topics.includes(:ai_summaries).where(
               "ai_summaries.id IS NULL OR ai_summaries.summary_type = ?",
@@ -36,7 +34,7 @@ module DiscourseAi
           :ai_topic_gist,
           include_condition: -> { scope.can_see_gists? },
         ) do
-          return if %i[suggested semantic_related private_messages].include?(options[:filter])
+          return if !Discourse.filters.include?(options[:filter])
           summaries = object.ai_summaries.to_a
 
           # Summaries should always have one or zero elements here.


### PR DESCRIPTION
The topic query is used differently, and we can't assume the modifier will always receive an AR relation. Let's scope it to `Discourse#filters` instead of most lists.