### PR TITLE
FIX: Misc fixes for sentiment in the admin dashboard

### DIFF
--- a/assets/javascripts/discourse/components/admin-report-emotion.hbs
+++ b/assets/javascripts/discourse/components/admin-report-emotion.hbs
@@ -6,7 +6,9 @@
 </div>
 
 <div class="cell value today-count">
-  <a href="{{this.filterURL}}activity-after%3A{{this.today}}%20order%3A{{this.model.type}}">
+  <a
+    href="{{this.filterURL}}activity-after%3A{{this.today}}%20order%3A{{this.model.type}}"
+  >
     {{number this.model.todayCount}}
   </a>
 </div>
@@ -15,7 +17,9 @@
   class="cell value yesterday-count {{this.model.yesterdayTrend}}"
   title={{this.model.yesterdayCountTitle}}
 >
-  <a href="{{this.filterURL}}activity-after%3A{{this.yesterday}}%20order%3A{{this.model.type}}">
+  <a
+    href="{{this.filterURL}}activity-after%3A{{this.yesterday}}%20order%3A{{this.model.type}}"
+  >
     {{number this.model.yesterdayCount}}
   </a>
   {{d-icon this.model.yesterdayTrendIcon}}
@@ -25,7 +29,9 @@
   class="cell value sevendays-count {{this.model.sevenDaysTrend}}"
   title={{this.model.sevenDaysCountTitle}}
 >
-  <a href="{{this.filterURL}}activity-after%3A{{this.lastWeek}}%20order%3A{{this.model.type}}">
+  <a
+    href="{{this.filterURL}}activity-after%3A{{this.lastWeek}}%20order%3A{{this.model.type}}"
+  >
     {{number this.model.lastSevenDaysCount}}
   </a>
   {{d-icon this.model.sevenDaysTrendIcon}}
@@ -35,7 +41,9 @@
   class="cell value thirty-days-count {{this.model.thirtyDaysTrend}}"
   title={{this.model.thirtyDaysCountTitle}}
 >
-  <a href="{{this.filterURL}}activity-after%3A{{this.lastMonth}}%20order%3A{{this.model.type}}">
+  <a
+    href="{{this.filterURL}}activity-after%3A{{this.lastMonth}}%20order%3A{{this.model.type}}"
+  >
     {{number this.model.lastThirtyDaysCount}}
   </a>
 

--- a/assets/javascripts/discourse/components/admin-report-emotion.hbs
+++ b/assets/javascripts/discourse/components/admin-report-emotion.hbs
@@ -2,16 +2,22 @@
   {{#if this.model.icon}}
     {{d-icon this.model.icon}}
   {{/if}}
-  <a href="{{this.filterURL}}{{this.model.type}}">{{this.model.title}}</a>
+  {{this.model.title}}
 </div>
 
-<div class="cell value today-count">{{number this.model.todayCount}}</div>
+<div class="cell value today-count">
+  <a href="{{this.filterURL}}activity-after%3A{{this.today}}%20order%3A{{this.model.type}}">
+    {{number this.model.todayCount}}
+  </a>
+</div>
 
 <div
   class="cell value yesterday-count {{this.model.yesterdayTrend}}"
   title={{this.model.yesterdayCountTitle}}
 >
-  {{number this.model.yesterdayCount}}
+  <a href="{{this.filterURL}}activity-after%3A{{this.yesterday}}%20order%3A{{this.model.type}}">
+    {{number this.model.yesterdayCount}}
+  </a>
   {{d-icon this.model.yesterdayTrendIcon}}
 </div>
 
@@ -19,7 +25,9 @@
   class="cell value sevendays-count {{this.model.sevenDaysTrend}}"
   title={{this.model.sevenDaysCountTitle}}
 >
-  {{number this.model.lastSevenDaysCount}}
+  <a href="{{this.filterURL}}activity-after%3A{{this.lastWeek}}%20order%3A{{this.model.type}}">
+    {{number this.model.lastSevenDaysCount}}
+  </a>
   {{d-icon this.model.sevenDaysTrendIcon}}
 </div>
 
@@ -27,7 +35,9 @@
   class="cell value thirty-days-count {{this.model.thirtyDaysTrend}}"
   title={{this.model.thirtyDaysCountTitle}}
 >
-  {{number this.model.lastThirtyDaysCount}}
+  <a href="{{this.filterURL}}activity-after%3A{{this.lastMonth}}%20order%3A{{this.model.type}}">
+    {{number this.model.lastThirtyDaysCount}}
+  </a>
 
   {{#if this.model.canDisplayTrendIcon}}
     {{d-icon this.model.thirtyDaysTrendIcon}}

--- a/assets/javascripts/discourse/components/admin-report-emotion.js
+++ b/assets/javascripts/discourse/components/admin-report-emotion.js
@@ -6,7 +6,22 @@ import getURL from "discourse-common/lib/get-url";
 @attributeBindings("model.description:title")
 export default class AdminReportEmotion extends Component {
   get filterURL() {
-    let aMonthAgo = moment().subtract(1, "month").format("YYYY-MM-DD");
-    return getURL(`/filter?q=activity-after%3A${aMonthAgo}%20order%3A`);
+    return getURL(`/filter?q=`);
+  }
+
+  get today() {
+    return moment().format("YYYY-MM-DD");
+  }
+
+  get yesterday() {
+    return moment().subtract(1, "day").format("YYYY-MM-DD");
+  }
+
+  get lastWeek() {
+    return moment().subtract(1, "week").format("YYYY-MM-DD");
+  }
+
+  get lastMonth() {
+    return moment().subtract(1, "month").format("YYYY-MM-DD");
   }
 }

--- a/assets/javascripts/discourse/controllers/admin-dashboard-sentiment.js
+++ b/assets/javascripts/discourse/controllers/admin-dashboard-sentiment.js
@@ -1,6 +1,12 @@
+import { computed } from "@ember/object";
 import AdminDashboardTabController from "admin/controllers/admin-dashboard-tab";
 
 export default class AdminDashboardSentiment extends AdminDashboardTabController {
+  @computed("startDate", "endDate")
+  get filters() {
+    return { startDate: this.startDate, endDate: this.endDate };
+  }
+
   get emotions() {
     const emotions = [
       "admiration",

--- a/lib/sentiment/emotion_dashboard_report.rb
+++ b/lib/sentiment/emotion_dashboard_report.rb
@@ -9,7 +9,7 @@ module DiscourseAi
             query_results = DiscourseAi::Sentiment::EmotionDashboardReport.fetch_data
             report.data = query_results.pop(30).map { |row| { x: row.day, y: row.send(emotion) } }
             report.prev30Days =
-              query_results.take(30).map { |row| { x: row.day, y: row.send(emotion) } }
+              query_results.take(30).reduce(0) { |sum, row| sum + row.send(emotion) }.to_i
           end
         end
 


### PR DESCRIPTION
- Fixes missing filters for the main graph

- Fixes previous 30 days trend in emotion table

Also moves links to individual cells in emotion table, so admins can
drill down to the specific time period on their reports.
