### PR TITLE
UX: ensure gists occupy full row

### DIFF
--- a/assets/javascripts/discourse/components/ai-topic-gist.gjs
+++ b/assets/javascripts/discourse/components/ai-topic-gist.gjs
@@ -25,12 +25,14 @@ export default class AiTopicGist extends Component {
     {{#if this.shouldShow}}
       {{#if this.hasGist}}
         <div class="excerpt">
-          <div>{{this.gist}}</div>
+          <div class="excerpt__contents">{{this.gist}}</div>
         </div>
       {{else}}
         {{#if this.esacpedExceprt}}
           <div class="excerpt">
-            <div>{{htmlSafe this.escapedExceprt}}</div>
+            <div class="excerpt__contents">
+              {{htmlSafe this.escapedExceprt}}
+            </div>
           </div>
         {{/if}}
       {{/if}}

--- a/assets/stylesheets/modules/summarization/common/ai-gists.scss
+++ b/assets/stylesheets/modules/summarization/common/ai-gists.scss
@@ -39,7 +39,9 @@
       line-height: var(--line-height-large);
       margin-top: 0.15em;
       margin-bottom: 0.15em;
-      max-width: 70ch;
+      &__contents {
+        max-width: 70ch;
+      }
     }
     &:not(.visited) {
       .excerpt {


### PR DESCRIPTION
This makes the summaries occupy the full width, so short category names won't wrap after them 

before:
![image](https://github.com/user-attachments/assets/3f24690d-a7ee-45f5-86c5-3c0ae8880d07)


after:
![image](https://github.com/user-attachments/assets/e763a313-891e-4787-aa3f-820eb491045d)
