### PR TITLE
UX: force long words to break in topic list gists

### DIFF
--- a/assets/stylesheets/modules/summarization/common/ai-gists.scss
+++ b/assets/stylesheets/modules/summarization/common/ai-gists.scss
@@ -41,6 +41,7 @@
       margin-bottom: 0.15em;
       &__contents {
         max-width: 70ch;
+        word-break: break-all;
       }
     }
     &:not(.visited) {

--- a/assets/stylesheets/modules/summarization/common/ai-gists.scss
+++ b/assets/stylesheets/modules/summarization/common/ai-gists.scss
@@ -41,7 +41,7 @@
       margin-bottom: 0.15em;
       &__contents {
         max-width: 70ch;
-        word-break: break-all;
+        overflow-wrap: break-word;
       }
     }
     &:not(.visited) {


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/fb0ae12e-1e38-47d9-88b2-5cfdc16f926f)


After: 

![image](https://github.com/user-attachments/assets/5ed45fbb-e078-4c91-8050-9e7df1e1d13a)
