### PR TITLE
REFACTOR: Tidy-up embedding endpoints config.

### DIFF
--- a/lib/embeddings/vector_representations/all_mpnet_base_v2.rb
+++ b/lib/embeddings/vector_representations/all_mpnet_base_v2.rb
@@ -24,12 +24,7 @@ module DiscourseAi
         end
 
         def vector_from(text, asymetric: false)
-          DiscourseAi::Inference::DiscourseClassifier.perform!(
-            "#{discourse_embeddings_endpoint}/api/v1/classify",
-            self.class.name,
-            text,
-            SiteSetting.ai_embeddings_discourse_service_api_key,
-          )
+          inference_client.perform!(text)
         end
 
         def dimensions
@@ -58,6 +53,10 @@ module DiscourseAi
 
         def tokenizer
           DiscourseAi::Tokenizer::AllMpnetBaseV2Tokenizer
+        end
+
+        def inference_client
+          DiscourseAi::Inference::DiscourseClassifier.instance(self.class.name)
         end
       end
     end

--- a/lib/embeddings/vector_representations/base.rb
+++ b/lib/embeddings/vector_representations/base.rb
@@ -426,16 +426,8 @@ module DiscourseAi
           end
         end
 
-        def discourse_embeddings_endpoint
-          if SiteSetting.ai_embeddings_discourse_service_api_endpoint_srv.present?
-            service =
-              DiscourseAi::Utils::DnsSrv.lookup(
-                SiteSetting.ai_embeddings_discourse_service_api_endpoint_srv,
-              )
-            "https://#{service.target}:#{service.port}"
-          else
-            SiteSetting.ai_embeddings_discourse_service_api_endpoint
-          end
+        def inference_client
+          raise NotImplementedError
         end
       end
     end

--- a/lib/embeddings/vector_representations/bge_m3.rb
+++ b/lib/embeddings/vector_representations/bge_m3.rb
@@ -20,7 +20,7 @@ module DiscourseAi
 
         def vector_from(text, asymetric: false)
           truncated_text = tokenizer.truncate(text, max_sequence_length - 2)
-          DiscourseAi::Inference::HuggingFaceTextEmbeddings.perform!(truncated_text).first
+          inference_client.perform!(truncated_text)
         end
 
         def dimensions
@@ -49,6 +49,10 @@ module DiscourseAi
 
         def tokenizer
           DiscourseAi::Tokenizer::BgeM3Tokenizer
+        end
+
+        def inference_client
+          DiscourseAi::Inference::HuggingFaceTextEmbeddings.instance
         end
       end
     end

--- a/lib/embeddings/vector_representations/gemini.rb
+++ b/lib/embeddings/vector_representations/gemini.rb
@@ -43,8 +43,7 @@ module DiscourseAi
         end
 
         def vector_from(text, asymetric: false)
-          response = DiscourseAi::Inference::GeminiEmbeddings.perform!(text)
-          response[:embedding][:values]
+          inference_client.perform!(text).dig(:embedding, :values)
         end
 
         # There is no public tokenizer for Gemini, and from the ones we already ship in the plugin
@@ -52,6 +51,10 @@ module DiscourseAi
         # to use OpenAI tokenizer since it will overestimate the number of tokens.
         def tokenizer
           DiscourseAi::Tokenizer::OpenAiTokenizer
+        end
+
+        def inference_client
+          DiscourseAi::Inference::GeminiEmbeddings.instance
         end
       end
     end

--- a/lib/embeddings/vector_representations/text_embedding_3_large.rb
+++ b/lib/embeddings/vector_representations/text_embedding_3_large.rb
@@ -45,17 +45,18 @@ module DiscourseAi
         end
 
         def vector_from(text, asymetric: false)
-          response =
-            DiscourseAi::Inference::OpenAiEmbeddings.perform!(
-              text,
-              model: self.class.name,
-              dimensions: dimensions,
-            )
-          response[:data].first[:embedding]
+          inference_client.perform!(text)
         end
 
         def tokenizer
           DiscourseAi::Tokenizer::OpenAiTokenizer
+        end
+
+        def inference_client
+          DiscourseAi::Inference::OpenAiEmbeddings.instance(
+            model: self.class.name,
+            dimensions: dimensions,
+          )
         end
       end
     end

--- a/lib/embeddings/vector_representations/text_embedding_3_small.rb
+++ b/lib/embeddings/vector_representations/text_embedding_3_small.rb
@@ -43,12 +43,15 @@ module DiscourseAi
         end
 
         def vector_from(text, asymetric: false)
-          response = DiscourseAi::Inference::OpenAiEmbeddings.perform!(text, model: self.class.name)
-          response[:data].first[:embedding]
+          inference_client.perform!(text)
         end
 
         def tokenizer
           DiscourseAi::Tokenizer::OpenAiTokenizer
+        end
+
+        def inference_client
+          DiscourseAi::Inference::OpenAiEmbeddings.instance(model: self.class.name)
         end
       end
     end

--- a/lib/embeddings/vector_representations/text_embedding_ada_002.rb
+++ b/lib/embeddings/vector_representations/text_embedding_ada_002.rb
@@ -43,12 +43,15 @@ module DiscourseAi
         end
 
         def vector_from(text, asymetric: false)
-          response = DiscourseAi::Inference::OpenAiEmbeddings.perform!(text, model: self.class.name)
-          response[:data].first[:embedding]
+          inference_client.perform!(text)
         end
 
         def tokenizer
           DiscourseAi::Tokenizer::OpenAiTokenizer
+        end
+
+        def inference_client
+          DiscourseAi::Inference::OpenAiEmbeddings.instance(model: self.class.name)
         end
       end
     end

--- a/lib/inference/discourse_classifier.rb
+++ b/lib/inference/discourse_classifier.rb
@@ -3,9 +3,36 @@
 module ::DiscourseAi
   module Inference
     class DiscourseClassifier
-      def self.perform!(endpoint, model, content, api_key)
-        headers = { "Referer" => Discourse.base_url, "Content-Type" => "application/json" }
+      def initialize(endpoint, api_key, model, referer = Discourse.base_url)
+        @endpoint = endpoint
+        @api_key = api_key
+        @model = model
+        @referer = referer
+      end
 
+      def self.instance(model)
+        endpoint =
+          if SiteSetting.ai_embeddings_discourse_service_api_endpoint_srv.present?
+            service =
+              DiscourseAi::Utils::DnsSrv.lookup(
+                SiteSetting.ai_embeddings_discourse_service_api_endpoint_srv,
+              )
+            "https://#{service.target}:#{service.port}"
+          else
+            SiteSetting.ai_embeddings_discourse_service_api_endpoint
+          end
+
+        new(
+          "#{endpoint}/api/v1/classify",
+          SiteSetting.ai_embeddings_discourse_service_api_key,
+          model,
+        )
+      end
+
+      attr_reader :endpoint, :api_key, :model, :referer
+
+      def perform!(content)
+        headers = { "Referer" => referer, "Content-Type" => "application/json" }
         headers["X-API-KEY"] = api_key if api_key.present?
 
         conn = Faraday.new { |f| f.adapter FinalDestination::FaradayAdapter }

--- a/lib/inference/gemini_embeddings.rb
+++ b/lib/inference/gemini_embeddings.rb
@@ -3,12 +3,17 @@
 module ::DiscourseAi
   module Inference
     class GeminiEmbeddings
-      def self.perform!(content)
-        headers = { "Referer" => Discourse.base_url, "Content-Type" => "application/json" }
+      def initialize(api_key, referer = Discourse.base_url)
+        @api_key = api_key
+        @referer = referer
+      end
 
+      attr_reader :api_key, :referer
+
+      def perform!(content)
+        headers = { "Referer" => referer, "Content-Type" => "application/json" }
         url =
-          "https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent\?key\=#{SiteSetting.ai_gemini_api_key}"
-
+          "https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent\?key\=#{api_key}"
         body = { content: { parts: [{ text: content }] } }
 
         conn = Faraday.new { |f| f.adapter FinalDestination::FaradayAdapter }

--- a/lib/inference/hugging_face_text_embeddings.rb
+++ b/lib/inference/hugging_face_text_embeddings.rb
@@ -3,30 +3,36 @@
 module ::DiscourseAi
   module Inference
     class HuggingFaceTextEmbeddings
+      def initialize(endpoint, key, referer = Discourse.base_url)
+        @endpoint = endpoint
+        @key = key
+        @referer = referer
+      end
+
+      attr_reader :endpoint, :key, :referer
+
       class << self
-        def perform!(content)
-          headers = { "Referer" => Discourse.base_url, "Content-Type" => "application/json" }
-          body = { inputs: content, truncate: true }.to_json
+        def instance
+          endpoint =
+            if SiteSetting.ai_hugging_face_tei_endpoint_srv.present?
+              service =
+                DiscourseAi::Utils::DnsSrv.lookup(SiteSetting.ai_hugging_face_tei_endpoint_srv)
+              "https://#{service.target}:#{service.port}"
+            else
+              SiteSetting.ai_hugging_face_tei_endpoint
+            end
 
-          if SiteSetting.ai_hugging_face_tei_endpoint_srv.present?
-            service =
-              DiscourseAi::Utils::DnsSrv.lookup(SiteSetting.ai_hugging_face_tei_endpoint_srv)
-            api_endpoint = "https://#{service.target}:#{service.port}"
-          else
-            api_endpoint = SiteSetting.ai_hugging_face_tei_endpoint
-          end
+          new(endpoint, SiteSetting.ai_hugging_face_tei_api_key)
+        end
 
-          if SiteSetting.ai_hugging_face_tei_api_key.present?
-            headers["X-API-KEY"] = SiteSetting.ai_hugging_face_tei_api_key
-            headers["Authorization"] = "Bearer #{SiteSetting.ai_hugging_face_tei_api_key}"
-          end
+        def configured?
+          SiteSetting.ai_hugging_face_tei_endpoint.present? ||
+            SiteSetting.ai_hugging_face_tei_endpoint_srv.present?
+        end
 
-          conn = Faraday.new { |f| f.adapter FinalDestination::FaradayAdapter }
-          response = conn.post(api_endpoint, body, headers)
-
-          raise Net::HTTPBadResponse if ![200].include?(response.status)
-
-          JSON.parse(response.body, symbolize_names: true)
+        def reranker_configured?
+          SiteSetting.ai_hugging_face_tei_reranker_endpoint.present? ||
+            SiteSetting.ai_hugging_face_tei_reranker_endpoint_srv.present?
         end
 
         def rerank(content, candidates)
@@ -80,16 +86,23 @@ module ::DiscourseAi
 
           JSON.parse(response.body, symbolize_names: true)
         end
+      end
 
-        def reranker_configured?
-          SiteSetting.ai_hugging_face_tei_reranker_endpoint.present? ||
-            SiteSetting.ai_hugging_face_tei_reranker_endpoint_srv.present?
+      def perform!(content)
+        headers = { "Referer" => referer, "Content-Type" => "application/json" }
+        body = { inputs: content, truncate: true }.to_json
+
+        if key.present?
+          headers["X-API-KEY"] = key
+          headers["Authorization"] = "Bearer #{key}"
         end
 
-        def configured?
-          SiteSetting.ai_hugging_face_tei_endpoint.present? ||
-            SiteSetting.ai_hugging_face_tei_endpoint_srv.present?
-        end
+        conn = Faraday.new { |f| f.adapter FinalDestination::FaradayAdapter }
+        response = conn.post(endpoint, body, headers)
+
+        raise Net::HTTPBadResponse if ![200].include?(response.status)
+
+        JSON.parse(response.body, symbolize_names: true).first
       end
     end
   end

--- a/lib/nsfw/classification.rb
+++ b/lib/nsfw/classification.rb
@@ -54,12 +54,11 @@ module DiscourseAi
         upload_url = Discourse.store.cdn_url(upload.url)
         upload_url = "#{Discourse.base_url_no_prefix}#{upload_url}" if upload_url.starts_with?("/")
 
-        DiscourseAi::Inference::DiscourseClassifier.perform!(
+        DiscourseAi::Inference::DiscourseClassifier.new(
           "#{endpoint}/api/v1/classify",
-          model,
-          upload_url,
           SiteSetting.ai_nsfw_inference_service_api_key,
-        )
+          model,
+        ).perform!(upload_url)
       end
 
       def available_models

--- a/lib/toxicity/toxicity_classification.rb
+++ b/lib/toxicity/toxicity_classification.rb
@@ -42,12 +42,11 @@ module DiscourseAi
 
       def request(target_to_classify)
         data =
-          ::DiscourseAi::Inference::DiscourseClassifier.perform!(
+          ::DiscourseAi::Inference::DiscourseClassifier.new(
             "#{endpoint}/api/v1/classify",
-            SiteSetting.ai_toxicity_inference_service_api_model,
-            content_of(target_to_classify),
             SiteSetting.ai_toxicity_inference_service_api_key,
-          )
+            SiteSetting.ai_toxicity_inference_service_api_model,
+          ).perform!(content_of(target_to_classify))
 
         { available_model => data }
       end

--- a/spec/shared/inference/openai_embeddings_spec.rb
+++ b/spec/shared/inference/openai_embeddings_spec.rb
@@ -26,10 +26,11 @@ describe DiscourseAi::Inference::OpenAiEmbeddings do
     ).to_return(status: 200, body: body_json, headers: {})
 
     result =
-      DiscourseAi::Inference::OpenAiEmbeddings.perform!("hello", model: "text-embedding-ada-002")
+      DiscourseAi::Inference::OpenAiEmbeddings.instance(model: "text-embedding-ada-002").perform!(
+        "hello",
+      )
 
-    expect(result[:usage]).to eq({ prompt_tokens: 1, total_tokens: 1 })
-    expect(result[:data].first).to eq({ object: "embedding", embedding: [0.0, 0.1] })
+    expect(result).to eq([0.0, 0.1])
   end
 
   it "supports openai embeddings" do
@@ -54,13 +55,11 @@ describe DiscourseAi::Inference::OpenAiEmbeddings do
     ).to_return(status: 200, body: body_json, headers: {})
 
     result =
-      DiscourseAi::Inference::OpenAiEmbeddings.perform!(
-        "hello",
+      DiscourseAi::Inference::OpenAiEmbeddings.instance(
         model: "text-embedding-ada-002",
         dimensions: 1000,
-      )
+      ).perform!("hello")
 
-    expect(result[:usage]).to eq({ prompt_tokens: 1, total_tokens: 1 })
-    expect(result[:data].first).to eq({ object: "embedding", embedding: [0.0, 0.1] })
+    expect(result).to eq([0.0, 0.1])
   end
 end


### PR DESCRIPTION
Two changes worth mentioning:

1. `.instance` returns a fully configured embedding endpoint ready to use. 
2. All endpoints respond to the same method and have the same signature - `perform!(text)`. It's no longer a class method.

This makes it easier to reuse them when generating embeddings in bulk.