### PR TITLE
FEATURE: Make emotion /filter ordering match the dashboard table

### DIFF
--- a/lib/sentiment/emotion_filter_order.rb
+++ b/lib/sentiment/emotion_filter_order.rb
@@ -6,21 +6,31 @@ module DiscourseAi
       def self.register!(plugin)
         Emotions::LIST.each do |emotion|
           filter_order_emotion = ->(scope, order_direction) do
+            scope_period =
+              scope
+                .arel
+                .constraints
+                .flat_map(&:children)
+                .find do |node|
+                  node.is_a?(Arel::Nodes::Grouping) &&
+                    node.expr.to_s.match?(/topics\.bumped_at\s*>=/)
+                end
+                &.expr
+                &.split(">=")
+                &.last
+
+            # Fallback in case we can't find the scope period
+            scope_period ||= "CURRENT_DATE - INTERVAL '1 year'"
+
             emotion_clause = <<~SQL
-              SUM(
-                CASE
-                  WHEN (classification_results.classification::jsonb->'#{emotion}')::float > 0.1
-                  THEN 1
-                  ELSE 0
-                END
-               )::float / COUNT(posts.id)
+              COUNT(*) FILTER (WHERE (classification_results.classification::jsonb->'#{emotion}')::float > 0.1) AS emotion_#{emotion}
             SQL
 
             # TODO: This is slow, we will need to materialize this in the future
             with_clause = <<~SQL
                 SELECT
                     topics.id,
-                    #{emotion_clause} AS emotion_#{emotion}
+                    #{emotion_clause}
                 FROM
                     topics
                 INNER JOIN
@@ -35,10 +45,9 @@ module DiscourseAi
                     AND topics.deleted_at IS NULL
                     AND posts.deleted_at IS NULL
                     AND posts.post_type = 1
+                    AND posts.created_at >= #{scope_period}
                 GROUP BY
                     1
-                HAVING
-                    #{emotion_clause} > 0.05
             SQL
 
             scope


### PR DESCRIPTION
This change makes the /filter endpoint use the same criteria we use
in the dashboard table for emotion, so it is not confusing for users.
It means that only posts made in the period with the emotion shall be
shown in the /filter, and the order is simply a count of posts that
match the emotion in the period.

It also uses a trick to extract the filter period, and apply it to
the CTE clause that calculates post emotion count on the period, making
it a bit more efficient. Downside is that /filter filters are evaluated
from left to right, so it will only get the speed-up if the emotion
order is last. As we do this on the dashboard table, it should cover
most uses of the ordering, kicking the need for materialized views
down the road.
