### PR TITLE
FIX: disables temporarily ai_summaries filtering

### DIFF
--- a/lib/summarization/entry_point.rb
+++ b/lib/summarization/entry_point.rb
@@ -17,20 +17,20 @@ module DiscourseAi
           scope.can_see_summary?(object.topic)
         end
 
-        plugin.register_modifier(:topic_query_create_list_topics) do |topics, options|
-          if Discourse.filters.include?(options[:filter]) && SiteSetting.ai_summarization_enabled &&
-               SiteSetting.ai_summarize_max_hot_topics_gists_per_batch > 0
-            topics
-              .includes(:ai_summaries)
-              .where(
-                "ai_summaries.id IS NULL OR ai_summaries.summary_type = ?",
-                AiSummary.summary_types[:gist],
-              )
-              .references(:ai_summaries)
-          else
-            topics
-          end
-        end
+        # plugin.register_modifier(:topic_query_create_list_topics) do |topics, options|
+        #   if Discourse.filters.include?(options[:filter]) && SiteSetting.ai_summarization_enabled &&
+        #        SiteSetting.ai_summarize_max_hot_topics_gists_per_batch > 0
+        #     topics
+        #       .includes(:ai_summaries)
+        #       .where(
+        #         "ai_summaries.id IS NULL OR ai_summaries.summary_type = ?",
+        #         AiSummary.summary_types[:gist],
+        #       )
+        #       .references(:ai_summaries)
+        #   else
+        #     topics
+        #   end
+        # end
 
         plugin.add_to_serializer(
           :topic_list_item,

--- a/spec/lib/modules/summarization/entry_point_spec.rb
+++ b/spec/lib/modules/summarization/entry_point_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DiscourseAi::Summarization::EntryPoint do
         context "when hot topic summarization is enabled" do
           before { SiteSetting.ai_summarize_max_hot_topics_gists_per_batch = 100 }
 
-          it "preloads only gist summaries" do
+          skip "preloads only gist summaries" do
             gist_topic = topic_query.list_hot.topics.find { |t| t.id == topic_ai_gist.target_id }
 
             expect(gist_topic.ai_summaries.size).to eq(1)


### PR DESCRIPTION
Topics with a summary that is not a gist are currently excluded from the topic list. This PR temporarily removes the bug while we investigate.