### PR TITLE
FIX: Unnecessary complex preloading accidentally filters some topics.

### DIFF
--- a/lib/summarization/entry_point.rb
+++ b/lib/summarization/entry_point.rb
@@ -17,20 +17,14 @@ module DiscourseAi
           scope.can_see_summary?(object.topic)
         end
 
-        # plugin.register_modifier(:topic_query_create_list_topics) do |topics, options|
-        #   if Discourse.filters.include?(options[:filter]) && SiteSetting.ai_summarization_enabled &&
-        #        SiteSetting.ai_summarize_max_hot_topics_gists_per_batch > 0
-        #     topics
-        #       .includes(:ai_summaries)
-        #       .where(
-        #         "ai_summaries.id IS NULL OR ai_summaries.summary_type = ?",
-        #         AiSummary.summary_types[:gist],
-        #       )
-        #       .references(:ai_summaries)
-        #   else
-        #     topics
-        #   end
-        # end
+        plugin.register_modifier(:topic_query_create_list_topics) do |topics, options|
+          if Discourse.filters.include?(options[:filter]) && SiteSetting.ai_summarization_enabled &&
+               SiteSetting.ai_summarize_max_hot_topics_gists_per_batch > 0
+            topics.includes(:ai_summaries)
+          else
+            topics
+          end
+        end
 
         plugin.add_to_serializer(
           :topic_list_item,


### PR DESCRIPTION
The `topic_query_create_list_topics` modifier we append was always meant to avoid an N+1 situation when serializing gists. However, I tried to be too smart and only preload these, which resulted in some topics with *only* regular summaries getting removed from the list. This issue became apparent now we are adding gists to other lists besides hot.

Let's simplify the preloading, which still solves the N+1 issue, and let the serializer get the needed summary.