### PR TITLE
FEATURE: Add locale detection prompt from translator

### DIFF
--- a/app/models/completion_prompt.rb
+++ b/app/models/completion_prompt.rb
@@ -8,6 +8,7 @@ class CompletionPrompt < ActiveRecord::Base
   CUSTOM_PROMPT = -305
   EXPLAIN = -306
   ILLUSTRATE_POST = -308
+  DETECT_TEXT_LOCALE = -309
 
   enum :prompt_type, { text: 0, list: 1, diff: 2 }
 

--- a/db/fixtures/ai_helper/603_completion_prompts.rb
+++ b/db/fixtures/ai_helper/603_completion_prompts.rb
@@ -200,3 +200,20 @@ CompletionPrompt.seed do |cp|
   cp.prompt_type = CompletionPrompt.prompt_types[:list]
   cp.messages = {}
 end
+
+CompletionPrompt.seed do |cp|
+  cp.id = -309
+  cp.name = "detect_text_locale"
+  cp.prompt_type = CompletionPrompt.prompt_types[:text]
+  cp.messages = {
+    insts: <<~TEXT,
+      I want you to act as a language expert, determining the locale for a set of text.
+      The locale is a language identifier, such as "en" for English, "de" for German, etc,
+      and can also include a region identifier, such as "en-GB" for British English, or "zh-Hans" for Simplified Chinese.
+      I will provide you with text, and you will determine the locale of the text.
+      You will find the text between <input></input> XML tags.
+      Include your locale between <output></output> XML tags.
+    TEXT
+    examples: [["<input>Hello my favourite colour is red</input>", "<output>en-GB</output>"]],
+  }
+end

--- a/spec/lib/modules/ai_helper/assistant_spec.rb
+++ b/spec/lib/modules/ai_helper/assistant_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe DiscourseAi::AiHelper::Assistant do
     it "returns all available prompts" do
       prompts = subject.available_prompts(user)
 
-      expect(prompts.length).to eq(6)
+      expect(prompts.length).to eq(7)
       expect(prompts.map { |p| p[:name] }).to contain_exactly(
         "translate",
         "generate_titles",
@@ -56,6 +56,7 @@ RSpec.describe DiscourseAi::AiHelper::Assistant do
         "markdown_table",
         "custom_prompt",
         "explain",
+        "detect_text_locale",
       )
     end
 
@@ -73,7 +74,7 @@ RSpec.describe DiscourseAi::AiHelper::Assistant do
       it "returns the illustrate_post prompt in the list of all prompts" do
         prompts = subject.available_prompts(user)
 
-        expect(prompts.length).to eq(7)
+        expect(prompts.length).to eq(8)
         expect(prompts.map { |p| p[:name] }).to contain_exactly(
           "translate",
           "generate_titles",
@@ -82,6 +83,7 @@ RSpec.describe DiscourseAi::AiHelper::Assistant do
           "custom_prompt",
           "explain",
           "illustrate_post",
+          "detect_text_locale",
         )
       end
     end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -43,7 +43,7 @@ describe Plugin::Instance do
 
     it "returns the available prompts" do
       expect(serializer.ai_helper_prompts).to be_present
-      expect(serializer.ai_helper_prompts.object.count).to eq(6)
+      expect(serializer.ai_helper_prompts.object.count).to eq(7)
     end
   end
 end


### PR DESCRIPTION
To allow https://github.com/discourse/discourse-translator/pull/181 to work, we're adding a `detect_text_locale` prompt which will return locales like "en", "de", "en-GB", "pt-PT".