### PR TITLE
FEATURE: LLM mentions and auto silence

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,6 +4,7 @@ en:
       flag_types:
         review: "Add post to review queue"
         spam: "Flag as spam and hide post"
+        spam_silence: "Flag as spam, hide post and silence user"
     scriptables:
       llm_triage:
         title: Triage posts using AI

--- a/lib/automation.rb
+++ b/lib/automation.rb
@@ -6,6 +6,10 @@ module DiscourseAi
       [
         { id: "review", translated_name: I18n.t("discourse_automation.ai.flag_types.review") },
         { id: "spam", translated_name: I18n.t("discourse_automation.ai.flag_types.spam") },
+        {
+          id: "spam_silence",
+          translated_name: I18n.t("discourse_automation.ai.flag_types.spam_silence"),
+        },
       ]
     end
     def self.available_models

--- a/lib/automation/llm_triage.rb
+++ b/lib/automation/llm_triage.rb
@@ -83,7 +83,7 @@ module DiscourseAi
                 .sub("%%AUTOMATION_ID%%", automation&.id.to_s)
                 .sub("%%AUTOMATION_NAME%%", automation&.name.to_s)
 
-            if flag_type == :spam
+            if flag_type == :spam || flag_type == :spam_silence
               PostActionCreator.new(
                 Discourse.system_user,
                 post,
@@ -91,6 +91,8 @@ module DiscourseAi
                 message: score_reason,
                 queue_for_review: true,
               ).perform
+
+              SpamRule::AutoSilence.new(post.user, post).silence_user if flag_type == :spam_silence
             else
               reviewable =
                 ReviewablePost.needs_review!(target: post, created_by: Discourse.system_user)


### PR DESCRIPTION
This PR contains 2 features: 

1. The ability to @mention an LLM after a conversation started, this allows you to switch LLMs mid stream

2. The ability to automatically silence a user that was triaged as a spammer 