### PR TITLE
FIX: Correctly register 'info' icon

### DIFF
--- a/lib/ai_bot/entry_point.rb
+++ b/lib/ai_bot/entry_point.rb
@@ -167,6 +167,7 @@ module DiscourseAi
         end
 
         plugin.register_svg_icon("robot")
+        plugin.register_svg_icon("info")
 
         plugin.add_to_serializer(
           :topic_view,


### PR DESCRIPTION
This icon is not part of the core set. Previously, d-ai was relying on other installed plugins (e.g. data-explorer) to include the icon