### PR TITLE
FEATURE: Skip PM scanning in LLM triage by default

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -113,6 +113,9 @@ en:
             flag_post:
               label: "Flag post"
               description: "Flags post (either as spam or for review)"
+            include_personal_messages:
+              label: "Include personal messages"
+              description: "Also scan and triage personal messages"
             model:
               label: "Model"
               description: "Language model used for triage"

--- a/discourse_automation/llm_triage.rb
+++ b/discourse_automation/llm_triage.rb
@@ -22,6 +22,7 @@ if defined?(DiscourseAutomation)
     field :tags, component: :tags
     field :hide_topic, component: :boolean
     field :flag_post, component: :boolean
+    field :include_personal_messages, component: :boolean
     field :flag_type,
           component: :choices,
           required: false,
@@ -53,6 +54,11 @@ if defined?(DiscourseAutomation)
       max_post_tokens = fields.dig("max_post_tokens", "value").to_i
 
       max_post_tokens = nil if max_post_tokens <= 0
+
+      if post.topic.private_message?
+        include_personal_messages = fields.dig("include_personal_messages", "value")
+        next if !include_personal_messages
+      end
 
       begin
         RateLimiter.new(


### PR DESCRIPTION
Usually people do not want to scan personal messages. Sometimes
they may. In that case they can enable triage on personal messages.
