### PR TITLE
DEV: Prevent `detect_text_locale` from appearing in menus

### DIFF
--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -233,6 +233,8 @@ module DiscourseAi
           %w[post]
         when "illustrate_post"
           %w[composer]
+        when "detect_text_locale"
+          %w[]
         else
           %w[composer post]
         end


### PR DESCRIPTION
## :mag: Overview
With the recent changes to allow Discourse AI in the translator plugin (https://github.com/discourse/discourse-ai/pull/946), `detect_text_locale` was needed as a `CompletionPrompt`. However, it is leaking into composer/post helper menus. This PR ensures we don't not show it in those menus.

## 📸 Screenshots

### Before
<img width="309" alt="Screenshot 2024-11-27 at 14 21 29" src="https://github.com/user-attachments/assets/c15e6bdd-0d8f-491e-a966-2df40ebcae5d">


### After
<img width="309" alt="Screenshot 2024-11-27 at 14 21 38" src="https://github.com/user-attachments/assets/aec7ccec-df5e-488b-9e59-d4839a4eaa34">
