### PR TITLE
FIX: Double render error with thumbnail suggestions

### DIFF
--- a/app/controllers/discourse_ai/ai_helper/assistant_controller.rb
+++ b/app/controllers/discourse_ai/ai_helper/assistant_controller.rb
@@ -35,7 +35,7 @@ module DiscourseAi
           prompt.custom_instruction = params[:custom_prompt]
         end
 
-        suggest_thumbnails(input) if prompt.id == CompletionPrompt::ILLUSTRATE_POST
+        return suggest_thumbnails(input) if prompt.id == CompletionPrompt::ILLUSTRATE_POST
 
         hijack do
           render json:

--- a/spec/requests/ai_helper/assistant_controller_spec.rb
+++ b/spec/requests/ai_helper/assistant_controller_spec.rb
@@ -101,6 +101,20 @@ RSpec.describe DiscourseAi::AiHelper::AssistantController do
         end
       end
 
+      it "prevents double render when mode is ILLUSTRATE_POST" do
+        DiscourseAi::Completions::Llm.with_prepared_responses([proofread_text]) do
+          expect {
+            post "/discourse-ai/ai-helper/suggest",
+                 params: {
+                   mode: CompletionPrompt::ILLUSTRATE_POST,
+                   text: text_to_proofread,
+                   force_default_locale: true,
+                 }
+          }.not_to raise_error
+          expect(response.status).to eq(200)
+        end
+      end
+
       context "when performing numerous requests" do
         it "rate limits" do
           RateLimiter.enable


### PR DESCRIPTION
This PR fixes a bug where a double render error appears in the logs when thumbnails are suggested