### PR TITLE
DEV: Better control what prompts can appear in post/composer

### DIFF
--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -233,10 +233,8 @@ module DiscourseAi
           %w[post]
         when "illustrate_post"
           %w[composer]
-        when "detect_text_locale"
-          %w[]
         else
-          %w[composer post]
+          %w[]
         end
       end
 

--- a/spec/lib/modules/ai_helper/assistant_spec.rb
+++ b/spec/lib/modules/ai_helper/assistant_spec.rb
@@ -60,6 +60,31 @@ RSpec.describe DiscourseAi::AiHelper::Assistant do
       )
     end
 
+    it "returns all prompts to be shown in the composer" do
+      prompts = subject.available_prompts(user)
+      filtered_prompts = prompts.select { |prompt| prompt[:location].include?("composer") }
+      expect(filtered_prompts.length).to eq(5)
+      expect(filtered_prompts.map { |p| p[:name] }).to contain_exactly(
+        "translate",
+        "generate_titles",
+        "proofread",
+        "markdown_table",
+        "custom_prompt",
+      )
+    end
+
+    it "returns all prompts to be shown in the post menu" do
+      prompts = subject.available_prompts(user)
+      filtered_prompts = prompts.select { |prompt| prompt[:location].include?("post") }
+      expect(filtered_prompts.length).to eq(4)
+      expect(filtered_prompts.map { |p| p[:name] }).to contain_exactly(
+        "translate",
+        "explain",
+        "proofread",
+        "custom_prompt",
+      )
+    end
+
     it "does not raise an error when effective_locale does not exactly match keys in LocaleSiteSetting" do
       SiteSetting.default_locale = "zh_CN"
       expect { subject.available_prompts(user) }.not_to raise_error


### PR DESCRIPTION
This PR updates the logic for the location map so it permits only the desired prompts through to the composer/post menu. Anything else won't be shown by default.

This PR also adds relevant tests to prevent regression.