### PR TITLE
FIX: Suggestion menus not showing in mobile

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -234,6 +234,14 @@
   z-index: z("composer", "dropdown");
 }
 
+.mobile-view {
+  .ai-category-suggester-content,
+  .ai-tag-suggester-content,
+  .ai-title-suggester-content {
+    z-index: z("modal", "dropdown");
+  }
+}
+
 .ai-category-suggester-content {
   .category-row {
     padding: 0.25em 0.5em;


### PR DESCRIPTION
The suggestion menu z-index was not enough for mobile so it isn't being shown when it's used in `modalForMobile` bottom menus.