### PR TITLE
UX: Ensure suggestions are left aligned

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -234,6 +234,10 @@
   z-index: z("composer", "dropdown");
 }
 
+.ai-suggestions-menu .btn {
+  text-align: left;
+}
+
 .mobile-view {
   .ai-category-suggester-content,
   .ai-tag-suggester-content,


### PR DESCRIPTION
## :mag: Overview
This PR ensures that suggestions are aligned to the left. By default, they are center aligned which looks odd when there are long lines of text.

## 📸 Screenshots
### Before
<img width="414" alt="Screenshot 2024-11-27 at 19 53 29" src="https://github.com/user-attachments/assets/8c217970-306a-4353-bf67-3b2a585249d7">

### After
<img width="420" alt="Screenshot 2024-11-27 at 19 53 35" src="https://github.com/user-attachments/assets/be237e5b-1ffd-4ea1-aec3-f0a7670f1c4b">
