### PR TITLE
DEV: Remove the short-lived prompt for locale detection

### DIFF
--- a/app/models/completion_prompt.rb
+++ b/app/models/completion_prompt.rb
@@ -8,7 +8,6 @@ class CompletionPrompt < ActiveRecord::Base
   CUSTOM_PROMPT = -305
   EXPLAIN = -306
   ILLUSTRATE_POST = -308
-  DETECT_TEXT_LOCALE = -309
 
   enum :prompt_type, { text: 0, list: 1, diff: 2 }
 

--- a/db/fixtures/ai_helper/603_completion_prompts.rb
+++ b/db/fixtures/ai_helper/603_completion_prompts.rb
@@ -200,20 +200,3 @@ CompletionPrompt.seed do |cp|
   cp.prompt_type = CompletionPrompt.prompt_types[:list]
   cp.messages = {}
 end
-
-CompletionPrompt.seed do |cp|
-  cp.id = -309
-  cp.name = "detect_text_locale"
-  cp.prompt_type = CompletionPrompt.prompt_types[:text]
-  cp.messages = {
-    insts: <<~TEXT,
-      I want you to act as a language expert, determining the locale for a set of text.
-      The locale is a language identifier, such as "en" for English, "de" for German, etc,
-      and can also include a region identifier, such as "en-GB" for British English, or "zh-Hans" for Simplified Chinese.
-      I will provide you with text, and you will determine the locale of the text.
-      You will find the text between <input></input> XML tags.
-      Include your locale between <output></output> XML tags.
-    TEXT
-    examples: [["<input>Hello my favourite colour is red</input>", "<output>en-GB</output>"]],
-  }
-end

--- a/db/migrate/20241128121329_remove_detect_text_locale_prompt.rb
+++ b/db/migrate/20241128121329_remove_detect_text_locale_prompt.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveDetectTextLocalePrompt < ActiveRecord::Migration[7.0]
+  def up
+    execute "DELETE FROM completion_prompts WHERE id = -309"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
It was originally introduced in https://github.com/discourse/discourse-ai/pull/946 for https://github.com/discourse/discourse-translator/pull/181. 

But since then, discourse-translator will be using its own custom prompt, so there is no need for this seeded prompt any more. This keeps things neater.