### PR TITLE
FIX: Keep related topics data cached when a user scrolls up

### DIFF
--- a/assets/javascripts/initializers/related-topics.gjs
+++ b/assets/javascripts/initializers/related-topics.gjs
@@ -47,10 +47,16 @@ export default {
         (Superclass) =>
           class extends Superclass {
             @tracked related_topics;
+            relatedTopicsCache = [];
 
             @cached
             get relatedTopics() {
-              return this.related_topics?.map((topic) =>
+              // Used to keep related topics when a user scrolls up from the
+              // bottom of the topic and then scrolls back down
+              if (this.related_topics) {
+                  this.relatedTopicsCache = this.related_topics;
+              }
+              return this.relatedTopicsCache?.map((topic) =>
                 this.store.createRecord("topic", topic)
               );
             }

--- a/assets/javascripts/initializers/related-topics.gjs
+++ b/assets/javascripts/initializers/related-topics.gjs
@@ -54,7 +54,7 @@ export default {
               // Used to keep related topics when a user scrolls up from the
               // bottom of the topic and then scrolls back down
               if (this.related_topics) {
-                  this.relatedTopicsCache = this.related_topics;
+                this.relatedTopicsCache = this.related_topics;
               }
               return this.relatedTopicsCache?.map((topic) =>
                 this.store.createRecord("topic", topic)


### PR DESCRIPTION
See https://meta.discourse.org/t/related-topics-missing-after-rereading-a-topic-with-more-than-20-posts/306147/6