### PR TITLE
FEATURE: exclude muted categories from category suggester

### DIFF
--- a/spec/lib/modules/ai_helper/semantic_categorizer_spec.rb
+++ b/spec/lib/modules/ai_helper/semantic_categorizer_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::AiHelper::SemanticCategorizer do
+  fab!(:user)
+  fab!(:muted_category) { Fabricate(:category) }
+  fab!(:category_mute) do
+    CategoryUser.create!(
+      user: user,
+      category: muted_category,
+      notification_level: CategoryUser.notification_levels[:muted],
+    )
+  end
+  fab!(:muted_topic) { Fabricate(:topic, category: muted_category) }
+  fab!(:category) { Fabricate(:category) }
+  fab!(:topic) { Fabricate(:topic, category: category) }
+
+  let(:truncation) { DiscourseAi::Embeddings::Strategies::Truncation.new }
+  let(:vector_rep) do
+    DiscourseAi::Embeddings::VectorRepresentations::Base.current_representation(truncation)
+  end
+  let(:categorizer) { DiscourseAi::AiHelper::SemanticCategorizer.new({ text: "hello" }, user) }
+  let(:expected_embedding) { [0.0038493] * vector_rep.dimensions }
+
+  before do
+    SiteSetting.ai_embeddings_enabled = true
+    SiteSetting.ai_embeddings_discourse_service_api_endpoint = "http://test.com"
+    SiteSetting.ai_embeddings_model = "bge-large-en"
+
+    WebMock.stub_request(
+      :post,
+      "#{SiteSetting.ai_embeddings_discourse_service_api_endpoint}/api/v1/classify",
+    ).to_return(status: 200, body: JSON.dump(expected_embedding))
+
+    vector_rep.generate_representation_from(topic)
+    vector_rep.generate_representation_from(muted_topic)
+  end
+
+  it "respects user muted categories when making suggestions" do
+    category_ids = categorizer.categories.map { |c| c[:id] }
+    expect(category_ids).not_to include(muted_category.id)
+    expect(category_ids).to include(category.id)
+  end
+end

--- a/spec/lib/modules/ai_helper/semantic_categorizer_spec.rb
+++ b/spec/lib/modules/ai_helper/semantic_categorizer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DiscourseAi::AiHelper::SemanticCategorizer do
     )
   end
   fab!(:muted_topic) { Fabricate(:topic, category: muted_category) }
-  fab!(:category) { Fabricate(:category) }
+  fab!(:category)
   fab!(:topic) { Fabricate(:topic, category: category) }
 
   let(:truncation) { DiscourseAi::Embeddings::Strategies::Truncation.new }

--- a/spec/lib/modules/embeddings/vector_representations/vector_rep_shared_examples.rb
+++ b/spec/lib/modules/embeddings/vector_representations/vector_rep_shared_examples.rb
@@ -104,5 +104,38 @@ RSpec.shared_examples "generates and store embedding using with vector represent
         vector_rep.asymmetric_topics_similarity_search(similar_vector, limit: 1, offset: 0),
       ).to contain_exactly(topic.id)
     end
+
+    it "can exclude categories" do
+      similar_vector = [0.0038494] * vector_rep.dimensions
+      text =
+        truncation.prepare_text_from(
+          topic,
+          vector_rep.tokenizer,
+          vector_rep.max_sequence_length - 2,
+        )
+      stub_vector_mapping(text, expected_embedding_1)
+      vector_rep.generate_representation_from(topic)
+
+      expect(
+        vector_rep.asymmetric_topics_similarity_search(
+          similar_vector,
+          limit: 1,
+          offset: 0,
+          exclude_category_ids: [topic.category_id],
+        ),
+      ).to be_empty
+
+      child_category = Fabricate(:category, parent_category_id: topic.category_id)
+      topic.update!(category_id: child_category.id)
+
+      expect(
+        vector_rep.asymmetric_topics_similarity_search(
+          similar_vector,
+          limit: 1,
+          offset: 0,
+          exclude_category_ids: [topic.category_id],
+        ),
+      ).to be_empty
+    end
   end
 end


### PR DESCRIPTION
The logic here is that users do not particularly care about
topics in the category so we can exclude them from tag
and category suggestions
