### PR TITLE
FIX: Transform Sentiment classification before saving

### DIFF
--- a/db/migrate/20241129190708_fix_classification_data.rb
+++ b/db/migrate/20241129190708_fix_classification_data.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class FixClassificationData < ActiveRecord::Migration[7.2]
+  def up
+    classifications = DB.query(<<~SQL)
+      SELECT id, classification
+      FROM classification_results
+      WHERE classification_type = 'sentiment'
+        AND SUBSTRING(LTRIM(classification::text), 1, 1) = '['
+    SQL
+
+    transformed =
+      classifications.reduce([]) do |memo, c|
+        hash_result = {}
+        c.classification.each { |r| hash_result[r["label"]] = r["score"] }
+
+        memo << { id: c.id, fixed_classification: hash_result }
+      end
+
+    transformed_json = transformed.to_json
+
+    DB.exec(<<~SQL, values: transformed_json)
+      UPDATE classification_results
+      SET classification = N.fixed_classification
+      FROM (
+        SELECT (value::jsonb->'id')::integer AS id, (value::jsonb->'fixed_classification')::jsonb AS fixed_classification
+        FROM jsonb_array_elements(:values::jsonb)
+      ) N
+      WHERE classification_results.id = N.id
+        AND classification_type = 'sentiment'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/sentiment/post_classification.rb
+++ b/lib/sentiment/post_classification.rb
@@ -83,7 +83,15 @@ module DiscourseAi
       end
 
       def request_with(content, config, base_url = Discourse.base_url)
-        DiscourseAi::Inference::HuggingFaceTextEmbeddings.classify(content, config, base_url)
+        result =
+          DiscourseAi::Inference::HuggingFaceTextEmbeddings.classify(content, config, base_url)
+        transform_result(result)
+      end
+
+      def transform_result(result)
+        hash_result = {}
+        result.each { |r| hash_result[r[:label]] = r[:score] }
+        hash_result
       end
 
       def store_classification(target, classification)


### PR DESCRIPTION
We were storing the classification result in a slightly different format:

```ruby
[{"label"=>"positive", "score"=>0.830914}, {"label"=>"neutral", "score"=>0.16409673}, {"label"=>"negative", "score"=>0.0049892818}]
```

when it should be:

```ruby
{"neutral"=>0.52367204, "negative"=>0.014189002, "positive"=>0.46213892}
```