### PR TITLE
changed "automatic auto" to "auto" in client.en.yml

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -410,7 +410,7 @@ en:
           automatic_caption_setting: "Enable auto caption"
           automatic_caption_loading: "Captioning images..."
           automatic_caption_dialog:
-            prompt: "This post contains non-captioned images. Would you like to enable automatic auto captions on image uploads? (This can be changed in your preferences later)"
+            prompt: "This post contains non-captioned images. Would you like to enable automatic captions on image uploads? (This can be changed in your preferences later)"
             confirm: "Enable"
             cancel: "Don't ask again"
         no_content_error: "Add content first to perform AI actions on it"


### PR DESCRIPTION
The description of the automatic captions dialog prompt included "Would you like to enable automatic auto captions on image uploads." I removed the second "auto" at the suggestion of translators.