### PR TITLE
UX: `no-text` style being incorrectly added to tag suggester

### DIFF
--- a/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
+++ b/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
@@ -198,6 +198,7 @@ export default class AiTagSuggester extends Component {
                     data-name={{suggestion.name}}
                     data-value={{index}}
                     title={{suggestion.name}}
+                    @translatedLabel={{suggestion.name}}
                     @disabled={{this.isDisabled suggestion}}
                     @action={{fn this.applySuggestion suggestion}}
                   >

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -266,6 +266,10 @@
     .discourse-tag-count {
       margin-left: 5px;
     }
+
+    .d-button-label {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
## :mag: Overview
In the tag suggester menu we use `DButton` as a wrapper element and use the `discourseTag` helper to render the text inside the element. So visually there is text content inside the button. However, since `DButton` assumes that no `label`/`translatedLabel` inside an element means `.no-text` CSS style should be applied to the button's element, it was resulting in some incorrect styling being applied to this menu. This PR resolves that by programmatically adding the tag as a `translatedLabel` and then visually hiding it with CSS.

## 📸 Screenshots

### Before:
Example incorrect styling being applied

![Screenshot 2024-12-02 at 09 52 30](https://github.com/user-attachments/assets/7815226b-e22a-42a0-92f1-b515cbdf72fb)

### After:
Example incorrect styling no longer being applied

![Screenshot 2024-12-02 at 09 52 18](https://github.com/user-attachments/assets/e4fc5f8f-185b-433a-8b04-eb10c4e40535)

