### PR TITLE
changed "contact this model to "use this model"  server.en.yml

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -435,7 +435,7 @@ en:
 
     llm_models:
       missing_provider_param: "%{param} can't be blank"
-      bedrock_invalid_url: "Please complete all the fields to contact this model."
+      bedrock_invalid_url: "Please complete all the fields to use this model."
 
     errors:
       no_query_specified: The query parameter is required, please specify it.


### PR DESCRIPTION
translators gave feedback that the phrase "contact this model" is confusing. changed it to "use this model".