### PR TITLE
FIX: Tag suggester is suggesting already assigned tags

### DIFF
--- a/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
+++ b/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
@@ -112,7 +112,9 @@ export default class AiTagSuggester extends Component {
   }
 
   #tagSelectorHasValues() {
-    return this.args.composer?.tags && this.args.composer?.tags.length > 0;
+    const model = this.args.composer ? this.args.composer : this.args.buffered;
+
+    return model.get("tags") && model.get("tags").length > 0;
   }
 
   #removedAppliedTag(suggestion) {

--- a/lib/ai_helper/semantic_categorizer.rb
+++ b/lib/ai_helper/semantic_categorizer.rb
@@ -78,7 +78,7 @@ module DiscourseAi
           .group_by { |c| c[:name] }
           .map { |name, scores| { name: name, score: scores.sum { |s| s[:score] } } }
           .sort_by { |c| -c[:score] }
-          .take(5)
+          .take(7)
           .then do |tags|
             models = Tag.where(name: tags.map { _1[:name] }).index_by(&:name)
             tags.map do |tag|


### PR DESCRIPTION
This PR fixes an issue where the tag suggester for edit title topic area was suggesting tags that are already assigned on a post. It also updates the amount of suggested tags to 7 so that there is still a decent amount of tags suggested when tags are already assigned.