### PR TITLE
UX: move topic summary from DMenu to DModal

### DIFF
--- a/assets/javascripts/discourse/components/modal/ai-summary-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/ai-summary-modal.gjs
@@ -204,12 +204,6 @@ export default class AiSummaryModal extends Component {
   }
 
   @action
-  handleDidInsert() {
-    this.subscribe();
-    this.generateSummary();
-  }
-
-  @action
   handleClose() {
     this.modal.triggerElement = null; // prevent refocus of trigger, which changes scroll position
     this.args.closeModal();
@@ -221,14 +215,14 @@ export default class AiSummaryModal extends Component {
       @closeModal={{this.handleClose}}
       @bodyClass="ai-summary-modal__body"
       class="ai-summary-modal"
-      {{didInsert this.handleDidInsert}}
+      {{didInsert this.subscribe @model.topic.id}}
       {{didUpdate this.subscribe @model.topic.id}}
       {{willDestroy this.unsubscribe}}
       @hideFooter={{not this.summarizedOn}}
     >
       <:body>
         {{htmlClass "scrollable-modal"}}
-        <div class="ai-summary-container">
+        <div class="ai-summary-container" {{didInsert this.generateSummary}}>
           <article
             class={{concatClass
               "ai-summary-box"
@@ -251,7 +245,7 @@ export default class AiSummaryModal extends Component {
           {{i18n "summary.summarized_on" date=this.summarizedOn}}
           <DTooltip @placements={{array "top-end"}}>
             <:trigger>
-              {{dIcon "info-circle"}}
+              {{dIcon "circle-info"}}
             </:trigger>
             <:content>
               {{i18n "summary.model_used" model=this.summarizedBy}}

--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-trigger.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-trigger.gjs
@@ -1,0 +1,30 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import AiSummaryModal from "../../components/modal/ai-summary-modal";
+
+export default class AiSummaryTrigger extends Component {
+  @service modal;
+
+  @action
+  openAiSummaryModal() {
+    this.modal.show(AiSummaryModal, {
+      model: {
+        topic: this.args.outletArgs.topic,
+        postStream: this.args.outletArgs.postStream,
+      },
+    });
+  }
+
+  <template>
+    {{#if @outletArgs.topic.summarizable}}
+      <DButton
+        @label="summary.buttons.generate"
+        @icon="discourse-sparkles"
+        @action={{this.openAiSummaryModal}}
+        class="ai-summarization-button"
+      />
+    {{/if}}
+  </template>
+}

--- a/assets/stylesheets/modules/summarization/common/ai-gists.scss
+++ b/assets/stylesheets/modules/summarization/common/ai-gists.scss
@@ -41,6 +41,7 @@
       margin-bottom: 0.15em;
       &__contents {
         max-width: 70ch;
+        overflow-wrap: break-word;
       }
     }
     &:not(.visited) {

--- a/assets/stylesheets/modules/summarization/common/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/common/ai-summary.scss
@@ -24,25 +24,9 @@
       }
     }
   }
-
-  .topic-map__additional-contents {
-    .ai-summarization-button {
-      padding-block: 0.5em;
-      display: flex;
-      gap: 0.5em;
-
-      button span {
-        white-space: nowrap;
-      }
-    }
-  }
 }
 
-.topic-map__ai-summary-content {
-  .ai-summary-container {
-    width: 100vw;
-  }
-
+.ai-summary-modal {
   .ai-summary {
     &__list {
       list-style: none;
@@ -174,14 +158,6 @@
     margin: 0;
   }
 
-  .summarized-on p {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 0.25em;
-    margin-bottom: 0;
-  }
-
   .outdated-summary {
     display: flex;
     flex-direction: column;
@@ -191,6 +167,40 @@
     }
     p {
       color: var(--primary-medium);
+    }
+  }
+
+  .d-modal__footer {
+    display: grid;
+    gap: 0;
+    grid-template-areas: "summarized regenerate" " outdated regenerate";
+    grid-template-columns: 1fr auto;
+    @include breakpoint(mobile-large) {
+      gap: 0.25em 0.5em;
+      grid-template-areas: "summarized summarized" "regenerate outdated";
+    }
+
+    p {
+      margin: 0;
+    }
+
+    .fk-d-tooltip__trigger {
+      vertical-align: text-top;
+    }
+
+    .summary-outdated {
+      color: var(--primary-high);
+      font-size: var(--font-down-1);
+      line-height: var(--line-height-medium);
+    }
+
+    .summarized-on {
+      grid-area: summarized;
+    }
+
+    button {
+      grid-area: regenerate;
+      justify-self: start;
     }
   }
 }

--- a/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
@@ -1,39 +1,27 @@
-.topic-map {
-  .ai-summarization-button {
-    .fk-d-menu {
-      position: fixed;
-      top: calc(var(--header-offset) + 1rem) !important;
-      left: unset !important;
-      right: 1rem !important;
-      width: 470px;
-      max-width: 470px !important; //overruling JS
-      max-height: calc(
-        100vh - var(--header-offset) - 3rem - var(--composer-height, 0px)
-      );
+html.scrollable-modal {
+  overflow: auto; // overrides core .modal-open class scroll lock
+}
 
-      .ai-summary__header,
-      .ai-summary-box {
-        padding: 0.75em 1rem;
-        box-sizing: border-box;
-      }
+.ai-summary-modal {
+  .d-modal__container {
+    position: fixed;
+    top: var(--header-offset);
+    margin-top: 1em;
+    right: 1em;
+    width: 100vw;
+    max-width: 30em;
+    max-height: calc(
+      100vh - var(--header-offset) - 3rem - var(--composer-height, 0px)
+    );
 
-      .ai-summary {
-        &__header {
-          position: sticky;
-          top: 0;
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          padding-block: 0.5rem;
-          padding-right: 0.5rem;
-          background: var(--secondary);
-          border-bottom: 1px solid var(--primary-low);
-
-          h3 {
-            margin: 0;
-          }
-        }
-      }
-    }
+    box-shadow: var(--shadow-menu-panel);
   }
+
+  .fullscreen-composer & {
+    display: none;
+  }
+}
+
+.ai-summary-modal + .d-modal__backdrop {
+  display: none;
 }

--- a/assets/stylesheets/modules/summarization/mobile/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/mobile/ai-summary.scss
@@ -1,3 +1,0 @@
-.ai-summary-box {
-  padding: 0.75em 1rem;
-}

--- a/plugin.rb
+++ b/plugin.rb
@@ -20,7 +20,6 @@ register_asset "stylesheets/modules/ai-helper/common/ai-helper.scss"
 register_asset "stylesheets/modules/ai-helper/desktop/ai-helper-fk-modals.scss", :desktop
 register_asset "stylesheets/modules/ai-helper/mobile/ai-helper-fk-modals.scss", :mobile
 
-register_asset "stylesheets/modules/summarization/mobile/ai-summary.scss", :mobile
 register_asset "stylesheets/modules/summarization/common/ai-summary.scss"
 register_asset "stylesheets/modules/summarization/desktop/ai-summary.scss", :desktop
 

--- a/spec/system/page_objects/components/ai_summary_box.rb
+++ b/spec/system/page_objects/components/ai_summary_box.rb
@@ -4,14 +4,14 @@ module PageObjects
   module Components
     class AiSummaryTrigger < PageObjects::Components::Base
       SUMMARY_BUTTON_SELECTOR = ".ai-summarization-button"
-      SUMMARY_CONTAINER_SELECTOR = ".ai-summary-container"
+      SUMMARY_CONTAINER_SELECTOR = ".ai-summary-modal"
 
       def click_summarize
         find(SUMMARY_BUTTON_SELECTOR).click
       end
 
       def click_regenerate_summary
-        find("#{SUMMARY_CONTAINER_SELECTOR} .ai-summary-modal .d-modal__footer button").click
+        find("#{SUMMARY_CONTAINER_SELECTOR} .d-modal__footer button").click
       end
 
       def has_summary?(summary)

--- a/spec/system/page_objects/components/ai_summary_box.rb
+++ b/spec/system/page_objects/components/ai_summary_box.rb
@@ -2,7 +2,7 @@
 
 module PageObjects
   module Components
-    class AiSummaryBox < PageObjects::Components::Base
+    class AiSummaryTrigger < PageObjects::Components::Base
       SUMMARY_BUTTON_SELECTOR = ".ai-summarization-button button"
       SUMMARY_CONTAINER_SELECTOR = ".ai-summary-container"
 

--- a/spec/system/page_objects/components/ai_summary_box.rb
+++ b/spec/system/page_objects/components/ai_summary_box.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Components
     class AiSummaryTrigger < PageObjects::Components::Base
-      SUMMARY_BUTTON_SELECTOR = ".ai-summarization-button button"
+      SUMMARY_BUTTON_SELECTOR = ".ai-summarization-button"
       SUMMARY_CONTAINER_SELECTOR = ".ai-summary-container"
 
       def click_summarize
@@ -11,7 +11,7 @@ module PageObjects
       end
 
       def click_regenerate_summary
-        find("#{SUMMARY_CONTAINER_SELECTOR} .outdated-summary button").click
+        find("#{SUMMARY_CONTAINER_SELECTOR} .ai-summary-modal .d-modal__footer button").click
       end
 
       def has_summary?(summary)

--- a/spec/system/summarization/topic_summarization_spec.rb
+++ b/spec/system/summarization/topic_summarization_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Summarize a topic ", type: :system do
   end
   let(:summarization_result) { "This is a summary" }
   let(:topic_page) { PageObjects::Pages::Topic.new }
-  let(:summary_box) { PageObjects::Components::AiSummaryBox.new }
+  let(:summary_box) { PageObjects::Components::AiSummaryTrigger.new }
 
   before do
     group.add(current_user)

--- a/test/javascripts/acceptance/topic-summary-test.js
+++ b/test/javascripts/acceptance/topic-summary-test.js
@@ -22,7 +22,12 @@ acceptance("Topic - Summary", function (needs) {
     });
 
     server.get("/discourse-ai/summarization/t/1", () => {
-      return helper.response({});
+      return helper.response({
+        ai_topic_summary: {
+          summarized_text: "This a",
+        },
+        done: false,
+      });
     });
   });
 

--- a/test/javascripts/acceptance/topic-summary-test.js
+++ b/test/javascripts/acceptance/topic-summary-test.js
@@ -39,7 +39,7 @@ acceptance("Topic - Summary", function (needs) {
       ai_topic_summary: { summarized_text: partialSummary },
     });
 
-    await click(".ai-topic-summarization");
+    await click(".ai-summarization-button");
 
     assert
       .dom(".ai-summary-box .generated-summary p")
@@ -76,7 +76,7 @@ acceptance("Topic - Summary", function (needs) {
       ai_topic_summary: { summarized_text: partialSummary },
     });
 
-    await click(".ai-topic-summarization");
+    await click(".ai-summarization-button");
     const finalSummaryCooked =
       "In this post,  <a href='/t/-/1/1'>bianca</a> said some stuff.";
     const finalSummaryResult = "In this post, bianca said some stuff.";
@@ -128,7 +128,7 @@ acceptance("Topic - Summary - Anon", function (needs) {
   test("displays cached summary immediately", async function (assert) {
     await visit("/t/-/1");
 
-    await click(".ai-topic-summarization");
+    await click(".ai-summarization-button");
 
     assert
       .dom(".ai-summary-box .generated-summary p")
@@ -141,7 +141,7 @@ acceptance("Topic - Summary - Anon", function (needs) {
 
   test("clicking outside of summary should not close the summary box", async function (assert) {
     await visit("/t/-/1");
-    await click(".ai-topic-summarization");
+    await click(".ai-summarization-button");
     await click("#main-outlet-wrapper");
     assert.dom(".ai-summary-box").exists();
   });

--- a/test/javascripts/acceptance/topic-summary-test.js
+++ b/test/javascripts/acceptance/topic-summary-test.js
@@ -63,7 +63,7 @@ acceptance("Topic - Summary", function (needs) {
       .hasText(finalSummary, "Updates the summary with a final result");
 
     assert
-      .dom(".ai-summary-box .summarized-on")
+      .dom(".ai-summary-modal .summarized-on")
       .exists("summary metadata exists");
   });
 
@@ -135,7 +135,7 @@ acceptance("Topic - Summary - Anon", function (needs) {
       .hasText(finalSummary, "Updates the summary with the result");
 
     assert
-      .dom(".ai-summary-box .summarized-on")
+      .dom(".ai-summary-modal .summarized-on")
       .exists("summary metadata exists");
   });
 


### PR DESCRIPTION
This doesn't change the appearance much, but gets us some functionality for free that we don't get with DMenu, like a header and being able to keep the summary open along with infinite scroll within topics. 


Before:
![image](https://github.com/user-attachments/assets/5bd0b831-ff67-4837-82b1-113679c4d6ab)
![image](https://github.com/user-attachments/assets/f2d707d6-1282-41b6-bcae-4987270c08b0)

After:
![image](https://github.com/user-attachments/assets/cdc6f505-f373-46b3-9466-1e46f0e3d9ec)
![image](https://github.com/user-attachments/assets/a9364e47-3e8c-4167-9dc5-f6137318b6fe)

