### PR TITLE
FIX: regression, no longer sending examples to AI helper

### DIFF
--- a/app/models/completion_prompt.rb
+++ b/app/models/completion_prompt.rb
@@ -37,7 +37,7 @@ class CompletionPrompt < ActiveRecord::Base
 
     prompt = DiscourseAi::Completions::Prompt.new(instructions)
 
-    messages_hash[:examples].to_a do |example_pair|
+    messages_hash[:examples].to_a.each do |example_pair|
       prompt.push(type: :user, content: example_pair.first)
       prompt.push(type: :model, content: example_pair.second)
     end

--- a/spec/models/completion_prompt_spec.rb
+++ b/spec/models/completion_prompt_spec.rb
@@ -22,6 +22,30 @@ RSpec.describe CompletionPrompt do
   describe "messages_with_input" do
     let(:user_input) { "A user wrote this." }
 
+    context "when mapping to a prompt" do
+      it "correctly maps everything to the prompt" do
+        cp =
+          CompletionPrompt.new(
+            messages: {
+              insts: "Instructions",
+              post_insts: "Post Instructions",
+              examples: [["Request 1", "Response 1"]],
+            },
+          )
+
+        prompt = cp.messages_with_input("hello")
+
+        expected = [
+          { type: :system, content: "Instructions\nPost Instructions" },
+          { type: :user, content: "Request 1" },
+          { type: :model, content: "Response 1" },
+          { type: :user, content: "<input>hello</input>" },
+        ]
+
+        expect(prompt.messages).to eq(expected)
+      end
+    end
+
     context "when the record has the custom_prompt type" do
       let(:custom_prompt) { described_class.find(described_class::CUSTOM_PROMPT) }
 


### PR DESCRIPTION
For a while now we have not been sending the examples to AI
helper, which can lead to inconsistent results.

Note: this also means that in non English we did not send
English results, so this may end up reducing performance

That said first thing we need to do is fix the regression.
