### PR TITLE
UX: improve layout of inline title editing buttons

### DIFF
--- a/assets/javascripts/discourse/components/suggestion-menus/ai-category-suggester.gjs
+++ b/assets/javascripts/discourse/components/suggestion-menus/ai-category-suggester.gjs
@@ -115,7 +115,7 @@ export default class AiCategorySuggester extends Component {
         @icon={{this.triggerIcon}}
         @identifier="ai-category-suggester"
         @onClose={{this.onClose}}
-        @triggerClass="suggestion-button suggest-category-button {{if
+        @triggerClass="btn-transparent suggestion-button suggest-category-button {{if
           this.loading
           'is-loading'
         }}"

--- a/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
+++ b/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
@@ -180,7 +180,7 @@ export default class AiTagSuggester extends Component {
         @icon={{this.triggerIcon}}
         @identifier="ai-tag-suggester"
         @onClose={{this.onClose}}
-        @triggerClass="suggestion-button suggest-tags-button {{if
+        @triggerClass="btn-transparent suggestion-button suggest-tags-button {{if
           this.loading
           'is-loading'
         }}"

--- a/assets/javascripts/discourse/components/suggestion-menus/ai-title-suggester.gjs
+++ b/assets/javascripts/discourse/components/suggestion-menus/ai-title-suggester.gjs
@@ -117,7 +117,7 @@ export default class AiTitleSuggester extends Component {
         @icon={{this.triggerIcon}}
         @identifier="ai-title-suggester"
         @onClose={{this.onClose}}
-        @triggerClass="suggestion-button suggest-titles-button {{if
+        @triggerClass="btn-transparent suggestion-button suggest-titles-button {{if
           this.loading
           'is-loading'
         }}"

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -245,7 +245,7 @@
   position: absolute;
   right: 0;
   top: 1px; // container border width
-  z-index: z("dropdown") + 1;
+  z-index: z("composer", "dropdown") + 1;
 }
 
 .ai-category-suggester-content,

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -209,6 +209,22 @@
       border-bottom-right-radius: 0;
     }
   }
+
+  #edit-title {
+    padding-right: 2em;
+  }
+
+  .category-chooser {
+    .select-kit-header-wrapper {
+      padding-right: 1.5em;
+    }
+  }
+
+  .mini-tag-chooser {
+    .multi-select-header {
+      padding-right: 2em;
+    }
+  }
 }
 
 .suggestion-button {
@@ -217,15 +233,19 @@
   }
 }
 
+.edit-title__wrapper,
+.edit-category__wrapper,
+.edit-tags__wrapper {
+  position: relative;
+}
+
 .suggest-titles-button,
 .suggest-tags-button,
 .suggest-category-button {
-  align-self: baseline;
-  border: 1px solid var(--primary-400);
-  border-left: none;
-  background: none;
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
+  position: absolute;
+  right: 0;
+  top: 1px; // container border width
+  z-index: z("dropdown") + 1;
 }
 
 .ai-category-suggester-content,

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -339,6 +339,12 @@
       }
     }
   }
+
+  .showing-ai-suggestions {
+    #reply-title {
+      padding-right: 2em;
+    }
+  }
 }
 
 .suggest-tags-button + .ai-suggestions-menu {

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -263,7 +263,7 @@
 .ai-category-suggester-content,
 .ai-tag-suggester-content,
 .ai-title-suggester-content {
-  z-index: z("header");
+  z-index: z("composer", "dropdown");
 }
 
 .ai-suggestions-menu .btn {

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -225,6 +225,14 @@
       padding-right: 2em;
     }
   }
+
+  .select-kit.is-expanded {
+    // need to raise the z-index so the sibling input buttons don't cover the dropdown
+    z-index: z("dropdown") + 1;
+    + button {
+      z-index: z("dropdown") + 1;
+    }
+  }
 }
 
 .suggestion-button {

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -263,7 +263,7 @@
 .ai-category-suggester-content,
 .ai-tag-suggester-content,
 .ai-title-suggester-content {
-  z-index: z("composer", "dropdown");
+  z-index: z("header");
 }
 
 .ai-suggestions-menu .btn {

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -245,7 +245,11 @@
   position: absolute;
   right: 0;
   top: 1px; // container border width
-  z-index: z("composer", "dropdown") + 1;
+  z-index: z("dropdown");
+
+  #reply-control & {
+    z-index: z("composer", "dropdown") + 1;
+  }
 }
 
 .ai-category-suggester-content,


### PR DESCRIPTION
Along with this core PR https://github.com/discourse/discourse/pull/30109 this improves the layout of AI buttons in the inline title editing and composer


Before:

![image](https://github.com/user-attachments/assets/495f5631-7b76-40e9-877b-f130380baa0d)
![image](https://github.com/user-attachments/assets/c62111fe-f9fc-4f75-a3e9-322389bbf907)

![image](https://github.com/user-attachments/assets/6cd7638f-b460-4bfd-a785-d09ae9e18312)


After:

![image](https://github.com/user-attachments/assets/7ef9882c-2b95-4527-98e0-5fe7eb48fc3c)
![image](https://github.com/user-attachments/assets/643be598-2b66-4347-b731-c58ee39c5dd9)
 
 
 
![image](https://github.com/user-attachments/assets/fdb2fdd7-10b1-42d8-92e2-47b4a2f965aa)
