### PR TITLE
FIX: typo in topic gist for escapedExcerpt

### DIFF
--- a/assets/javascripts/discourse/components/ai-topic-gist.gjs
+++ b/assets/javascripts/discourse/components/ai-topic-gist.gjs
@@ -28,7 +28,7 @@ export default class AiTopicGist extends Component {
           <div class="excerpt__contents">{{this.gist}}</div>
         </div>
       {{else}}
-        {{#if this.escapedExceprt}}
+        {{#if this.escapedExcerpt}}
           <div class="excerpt">
             <div class="excerpt__contents">
               {{htmlSafe this.escapedExceprt}}

--- a/assets/javascripts/discourse/components/ai-topic-gist.gjs
+++ b/assets/javascripts/discourse/components/ai-topic-gist.gjs
@@ -28,7 +28,7 @@ export default class AiTopicGist extends Component {
           <div class="excerpt__contents">{{this.gist}}</div>
         </div>
       {{else}}
-        {{#if this.esacpedExceprt}}
+        {{#if this.escapedExceprt}}
           <div class="excerpt">
             <div class="excerpt__contents">
               {{htmlSafe this.escapedExceprt}}

--- a/assets/javascripts/discourse/components/ai-topic-gist.gjs
+++ b/assets/javascripts/discourse/components/ai-topic-gist.gjs
@@ -17,7 +17,7 @@ export default class AiTopicGist extends Component {
     return this.args.topic.get("ai_topic_gist");
   }
 
-  get escapedExceprt() {
+  get escapedExcerpt() {
     return this.args.topic.get("escapedExcerpt");
   }
 

--- a/assets/javascripts/discourse/components/ai-topic-gist.gjs
+++ b/assets/javascripts/discourse/components/ai-topic-gist.gjs
@@ -31,7 +31,7 @@ export default class AiTopicGist extends Component {
         {{#if this.escapedExcerpt}}
           <div class="excerpt">
             <div class="excerpt__contents">
-              {{htmlSafe this.escapedExceprt}}
+              {{htmlSafe this.escapedExcerpt}}
             </div>
           </div>
         {{/if}}


### PR DESCRIPTION
`esacpedExceprt !== escapedExcerpt` 🤦🏻‍♂️ 