### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/app/models/reviewable_ai_chat_message.rb
+++ b/app/models/reviewable_ai_chat_message.rb
@@ -69,7 +69,7 @@ class ReviewableAiChatMessage < Reviewable
 
     build_action(actions, :ignore, icon: "external-link-alt")
 
-    build_action(actions, :delete_and_agree, icon: "far-trash-alt") unless chat_message.deleted_at?
+    build_action(actions, :delete_and_agree, icon: "far-trash-can") unless chat_message.deleted_at?
   end
 
   def perform_agree_and_keep_message(performed_by, args)

--- a/app/models/reviewable_ai_post.rb
+++ b/app/models/reviewable_ai_post.rb
@@ -58,7 +58,7 @@ class ReviewableAiPost < Reviewable
       delete =
         actions.add_bundle(
           "#{id}-delete",
-          icon: "far-trash-alt",
+          icon: "far-trash-can",
           label: "reviewables.actions.delete.title",
         )
       build_action(actions, :delete_and_ignore, icon: "external-link-alt", bundle: delete)

--- a/assets/javascripts/discourse/components/ai-helper-loading.gjs
+++ b/assets/javascripts/discourse/components/ai-helper-loading.gjs
@@ -8,7 +8,7 @@ const AiHelperLoading = <template>
       {{i18n "discourse_ai.ai_helper.context_menu.loading"}}
     </span>
     <DButton
-      @icon="times"
+      @icon="xmark"
       @title="discourse_ai.ai_helper.context_menu.cancel"
       @action={{@cancel}}
       class="btn-flat cancel-request"

--- a/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
+++ b/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
@@ -201,7 +201,7 @@ export default class AiLlmEditorForm extends Component {
           disabled={{this.seeded}}
         />
         <DTooltip
-          @icon="question-circle"
+          @icon="circle-question"
           @content={{i18n "discourse_ai.llms.hints.name"}}
         />
       </div>
@@ -280,7 +280,7 @@ export default class AiLlmEditorForm extends Component {
             required="true"
           />
           <DTooltip
-            @icon="question-circle"
+            @icon="circle-question"
             @content={{i18n "discourse_ai.llms.hints.max_prompt_tokens"}}
           />
         </div>
@@ -288,7 +288,7 @@ export default class AiLlmEditorForm extends Component {
           <Input @type="checkbox" @checked={{@model.vision_enabled}} />
           <label>{{i18n "discourse_ai.llms.vision_enabled"}}</label>
           <DTooltip
-            @icon="question-circle"
+            @icon="circle-question"
             @content={{i18n "discourse_ai.llms.hints.vision_enabled"}}
           />
         </div>
@@ -296,7 +296,7 @@ export default class AiLlmEditorForm extends Component {
           <Input @type="checkbox" @checked={{@model.enabled_chat_bot}} />
           <label>{{i18n "discourse_ai.llms.enabled_chat_bot"}}</label>
           <DTooltip
-            @icon="question-circle"
+            @icon="circle-question"
             @content={{i18n "discourse_ai.llms.hints.enabled_chat_bot"}}
           />
         </div>

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -315,7 +315,7 @@ export default class PersonaEditor extends Component {
           {{on "click" this.togglePriority}}
         />
         <DTooltip
-          @icon="question-circle"
+          @icon="circle-question"
           @content={{I18n.t "discourse_ai.ai_persona.priority_help"}}
         />
       </div>
@@ -345,7 +345,7 @@ export default class PersonaEditor extends Component {
             @llms={{@personas.resultSetMeta.llms}}
           />
           <DTooltip
-            @icon="question-circle"
+            @icon="circle-question"
             @content={{I18n.t "discourse_ai.ai_persona.default_llm_help"}}
           />
         </div>
@@ -382,7 +382,7 @@ export default class PersonaEditor extends Component {
               {{I18n.t "discourse_ai.ai_persona.create_user"}}
             </DButton>
             <DTooltip
-              @icon="question-circle"
+              @icon="circle-question"
               @content={{I18n.t "discourse_ai.ai_persona.create_user_help"}}
             />
           {{/if}}
@@ -453,7 +453,7 @@ export default class PersonaEditor extends Component {
           />
           {{I18n.t "discourse_ai.ai_persona.allow_personal_messages"}}</label>
         <DTooltip
-          @icon="question-circle"
+          @icon="circle-question"
           @content={{I18n.t
             "discourse_ai.ai_persona.allow_personal_messages_help"
           }}
@@ -468,7 +468,7 @@ export default class PersonaEditor extends Component {
             />
             {{I18n.t "discourse_ai.ai_persona.allow_topic_mentions"}}</label>
           <DTooltip
-            @icon="question-circle"
+            @icon="circle-question"
             @content={{I18n.t
               "discourse_ai.ai_persona.allow_topic_mentions_help"
             }}
@@ -487,7 +487,7 @@ export default class PersonaEditor extends Component {
                 "discourse_ai.ai_persona.allow_chat_direct_messages"
               }}</label>
             <DTooltip
-              @icon="question-circle"
+              @icon="circle-question"
               @content={{I18n.t
                 "discourse_ai.ai_persona.allow_chat_direct_messages_help"
               }}
@@ -505,7 +505,7 @@ export default class PersonaEditor extends Component {
                 "discourse_ai.ai_persona.allow_chat_channel_mentions"
               }}</label>
             <DTooltip
-              @icon="question-circle"
+              @icon="circle-question"
               @content={{I18n.t
                 "discourse_ai.ai_persona.allow_chat_channel_mentions_help"
               }}
@@ -518,7 +518,7 @@ export default class PersonaEditor extends Component {
           <Input @type="checkbox" @checked={{this.editingModel.tool_details}} />
           {{I18n.t "discourse_ai.ai_persona.tool_details"}}</label>
         <DTooltip
-          @icon="question-circle"
+          @icon="circle-question"
           @content={{I18n.t "discourse_ai.ai_persona.tool_details_help"}}
         />
       </div>
@@ -530,7 +530,7 @@ export default class PersonaEditor extends Component {
           />
           {{I18n.t "discourse_ai.ai_persona.vision_enabled"}}</label>
         <DTooltip
-          @icon="question-circle"
+          @icon="circle-question"
           @content={{I18n.t "discourse_ai.ai_persona.vision_enabled_help"}}
         />
       </div>
@@ -553,7 +553,7 @@ export default class PersonaEditor extends Component {
           @value={{this.editingModel.max_context_posts}}
         />
         <DTooltip
-          @icon="question-circle"
+          @icon="circle-question"
           @content={{I18n.t "discourse_ai.ai_persona.max_context_posts_help"}}
         />
       </div>
@@ -569,7 +569,7 @@ export default class PersonaEditor extends Component {
             disabled={{this.editingModel.system}}
           />
           <DTooltip
-            @icon="question-circle"
+            @icon="circle-question"
             @content={{I18n.t "discourse_ai.ai_persona.temperature_help"}}
           />
         </div>
@@ -586,7 +586,7 @@ export default class PersonaEditor extends Component {
             disabled={{this.editingModel.system}}
           />
           <DTooltip
-            @icon="question-circle"
+            @icon="circle-question"
             @content={{I18n.t "discourse_ai.ai_persona.top_p_help"}}
           />
         </div>
@@ -612,7 +612,7 @@ export default class PersonaEditor extends Component {
               @value={{this.editingModel.rag_conversation_chunks}}
             />
             <DTooltip
-              @icon="question-circle"
+              @icon="circle-question"
               @content={{I18n.t
                 "discourse_ai.ai_persona.rag_conversation_chunks_help"
               }}
@@ -629,7 +629,7 @@ export default class PersonaEditor extends Component {
             />
 
             <DTooltip
-              @icon="question-circle"
+              @icon="circle-question"
               @content={{I18n.t
                 "discourse_ai.ai_persona.question_consolidator_llm_help"
               }}

--- a/assets/javascripts/discourse/components/ai-post-helper-menu.gjs
+++ b/assets/javascripts/discourse/components/ai-post-helper-menu.gjs
@@ -337,7 +337,7 @@ export default class AiPostHelperMenu extends Component {
               </div>
               <div class="ai-post-helper__suggestion__buttons">
                 <DButton
-                  @icon="times"
+                  @icon="xmark"
                   @label="discourse_ai.ai_helper.post_options_menu.cancel"
                   @action={{this.cancelAiAction}}
                   class="btn-flat ai-post-helper__suggestion__cancel"

--- a/assets/javascripts/discourse/components/ai-tool-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-tool-editor.gjs
@@ -173,7 +173,7 @@ export default class AiToolEditor extends Component {
             class="ai-tool-editor__name"
           />
           <DTooltip
-            @icon="question-circle"
+            @icon="circle-question"
             @content={{I18n.t "discourse_ai.tools.name_help"}}
           />
         </div>
@@ -199,7 +199,7 @@ export default class AiToolEditor extends Component {
             class="ai-tool-editor__summary input-xxlarge"
           />
           <DTooltip
-            @icon="question-circle"
+            @icon="circle-question"
             @content={{I18n.t "discourse_ai.tools.summary_help"}}
           />
         </div>

--- a/assets/javascripts/discourse/components/ai-tool-parameter-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-tool-parameter-editor.gjs
@@ -113,7 +113,7 @@ export default class AiToolParameterEditor extends Component {
 
           <DButton
             @action={{fn this.removeParameter parameter}}
-            @icon="trash-alt"
+            @icon="trash-can"
             class="btn-danger"
           />
         </div>
@@ -130,7 +130,7 @@ export default class AiToolParameterEditor extends Component {
                 />
                 <DButton
                   @action={{fn this.removeEnumValue parameter enumIndex}}
-                  @icon="trash-alt"
+                  @icon="trash-can"
                   class="btn-danger"
                 />
               </div>

--- a/assets/javascripts/discourse/components/modal/ai-summary-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/ai-summary-modal.gjs
@@ -260,7 +260,7 @@ export default class AiSummaryModal extends Component {
             @label="summary.buttons.regenerate"
             @title="summary.buttons.regenerate"
             @action={{this.regenerateSummary}}
-            @icon="sync"
+            @icon="arrows-rotate"
           />
         {{/if}}
       </:footer>

--- a/assets/javascripts/discourse/components/modal/share-full-topic-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/share-full-topic-modal.gjs
@@ -110,7 +110,7 @@ export default class ShareModal extends Component {
         {{#if this.shareKey}}
           <DButton
             class="btn-danger"
-            @icon="far-trash-alt"
+            @icon="far-trash-can"
             @action={{this.deleteLink}}
             @label="discourse_ai.ai_bot.share_full_topic_modal.delete"
           />

--- a/assets/javascripts/discourse/components/rag-options.gjs
+++ b/assets/javascripts/discourse/components/rag-options.gjs
@@ -42,7 +42,7 @@ export default class RagOptions extends Component {
           @value={{@model.rag_chunk_tokens}}
         />
         <DTooltip
-          @icon="question-circle"
+          @icon="circle-question"
           @content={{I18n.t "discourse_ai.rag.options.rag_chunk_tokens_help"}}
         />
       </div>
@@ -58,7 +58,7 @@ export default class RagOptions extends Component {
           @value={{@model.rag_chunk_overlap_tokens}}
         />
         <DTooltip
-          @icon="question-circle"
+          @icon="circle-question"
           @content={{I18n.t
             "discourse_ai.rag.options.rag_chunk_overlap_tokens_help"
           }}

--- a/assets/javascripts/discourse/components/rag-uploader.gjs
+++ b/assets/javascripts/discourse/components/rag-uploader.gjs
@@ -149,7 +149,7 @@ export default class RagUploader extends Component {
               />
               <td class="rag-uploader__remove-file">
                 <DButton
-                  @icon="times"
+                  @icon="xmark"
                   @title="discourse_ai.rag.uploads.remove"
                   @action={{fn this.removeUpload upload}}
                   class="btn-flat"
@@ -170,7 +170,7 @@ export default class RagUploader extends Component {
               </td>
               <td class="rag-uploader__remove-file">
                 <DButton
-                  @icon="times"
+                  @icon="xmark"
                   @title="discourse_ai.rag.uploads.remove"
                   @action={{fn this.cancelUploading upload}}
                   class="btn-flat"


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.