### PR TITLE
FIX: close link in shared conversation model

### DIFF
--- a/app/models/shared_ai_conversation.rb
+++ b/app/models/shared_ai_conversation.rb
@@ -103,7 +103,7 @@ class SharedAiConversation < ActiveRecord::Base
         break
       end
     end
-    html << "<a href='#{url}'>#{I18n.t("discourse_ai.share_ai.read_more")}<a>"
+    html << "<a href='#{url}'>#{I18n.t("discourse_ai.share_ai.read_more")}</a>"
     html
   end
 


### PR DESCRIPTION
This link should be closed

`html << "<a href='#{url}'>#{I18n.t("discourse_ai.share_ai.read_more")}<a>"`