### PR TITLE
UX: ensure composer popup is always above AI icons

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -260,6 +260,15 @@
   }
 }
 
+#reply-control {
+  .composer-popup {
+    // need to raise the z-index here
+    // because we need another layer to put the AI icon above dropdowns
+    // while also keeping them below the composer tips
+    z-index: z("composer", "dropdown") + 2;
+  }
+}
+
 .ai-category-suggester-content,
 .ai-tag-suggester-content,
 .ai-title-suggester-content {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/bdcc5fe2-2ce2-4dae-836f-0892cd42556a)


After: 
![image](https://github.com/user-attachments/assets/31f7f68f-fbb0-46f2-9257-4d3e5af67119)
