### PR TITLE
FIX: allow scanning of trashed posts and deleted users for test

### DIFF
--- a/spec/requests/admin/ai_spam_controller_spec.rb
+++ b/spec/requests/admin/ai_spam_controller_spec.rb
@@ -120,7 +120,11 @@ RSpec.describe DiscourseAi::Admin::AiSpamController do
 
     before { sign_in(admin) }
 
-    it "can scan using post url" do
+    it "can scan using post url (even when trashed and user deleted)" do
+      User.where(id: spam_post2.user_id).delete_all
+      spam_post2.topic.trash!
+      spam_post2.trash!
+
       llm2 = Fabricate(:llm_model, name: "DiffLLM")
 
       DiscourseAi::Completions::Llm.with_prepared_responses(["spam", "just because"]) do


### PR DESCRIPTION
When a post is trashed we should still be allowed to scan it
post.topic will be nil for a trashed topic even if post is trashed
