### PR TITLE
FEATURE: Unavailable state for semantic search when sort is not Relevant

### DIFF
--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
@@ -4,7 +4,6 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
-import { not } from "truth-helpers";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
 import { SEARCH_TYPE_DEFAULT } from "discourse/controllers/full-page-search";
 import { ajax } from "discourse/lib/ajax";
@@ -212,7 +211,7 @@ export default class SemanticSearch extends Component {
 
           <AiIndicatorWave @loading={{this.searching}} />
 
-          {{#if (not this.validSearchOrder)}}
+          {{#unless this.validSearchOrder}}
 
             <DTooltip
               @identifier="semantic-search-unavailable-tooltip"
@@ -228,7 +227,7 @@ export default class SemanticSearch extends Component {
                 }}
               </:content>
             </DTooltip>
-          {{/if}}
+          {{/unless}}
         </div>
       </div>
     </div>

--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/semantic-search.gjs
@@ -2,15 +2,16 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
+import { not } from "truth-helpers";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
 import { SEARCH_TYPE_DEFAULT } from "discourse/controllers/full-page-search";
 import { ajax } from "discourse/lib/ajax";
-import { withPluginApi } from "discourse/lib/plugin-api";
 import { isValidSearchTerm, translateResults } from "discourse/lib/search";
 import icon from "discourse-common/helpers/d-icon";
-import I18n from "I18n";
+import I18n, { i18n } from "discourse-i18n";
+import DTooltip from "float-kit/components/d-tooltip";
 import AiIndicatorWave from "../../components/ai-indicator-wave";
 
 export default class SemanticSearch extends Component {
@@ -18,27 +19,57 @@ export default class SemanticSearch extends Component {
     return siteSettings.ai_embeddings_semantic_search_enabled;
   }
 
-  @service router;
   @service appEvents;
+  @service router;
   @service siteSettings;
   @service searchPreferencesManager;
 
-  @tracked searching = false;
+  @tracked searching;
   @tracked AiResults = [];
   @tracked showingAiResults = false;
+  @tracked sortOrder = this.args.outletArgs.sortOrder;
   initialSearchTerm = this.args.outletArgs.search;
+
+  constructor() {
+    super(...arguments);
+    this.appEvents.on("full-page-search:trigger-search", this, this.onSearch);
+    this.handleSearch();
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.appEvents.off("full-page-search:trigger-search", this, this.onSearch);
+  }
+
+  @action
+  onSearch() {
+    if (!this.searching) {
+      this.resetAiResults();
+      return this.performHyDESearch();
+    }
+  }
 
   get disableToggleSwitch() {
     if (
       this.searching ||
       this.AiResults.length === 0 ||
-      this.args.outletArgs.sortOrder !== 0
+      !this.validSearchOrder
     ) {
       return true;
     }
   }
 
+  get validSearchOrder() {
+    return this.sortOrder === 0;
+  }
+
   get searchStateText() {
+    if (!this.validSearchOrder) {
+      return I18n.t(
+        "discourse_ai.embeddings.semantic_search_results.unavailable"
+      );
+    }
+
     // Search results:
     if (this.AiResults.length > 0) {
       if (this.showingAiResults) {
@@ -89,7 +120,7 @@ export default class SemanticSearch extends Component {
     return (
       this.args.outletArgs.type === SEARCH_TYPE_DEFAULT &&
       isValidSearchTerm(this.searchTerm, this.siteSettings) &&
-      this.args.outletArgs.sortOrder === 0
+      this.validSearchOrder
     );
   }
 
@@ -116,15 +147,13 @@ export default class SemanticSearch extends Component {
       return;
     }
 
-    if (this.initialSearchTerm && !this.searching) {
+    if (this.initialSearchTerm) {
+      this.searching = true;
       return this.performHyDESearch();
     }
-
-    this.#resetAndSearchOnEvent();
   }
 
   performHyDESearch() {
-    this.searching = true;
     this.resetAiResults();
 
     ajax("/discourse-ai/embeddings/semantic-search", {
@@ -134,7 +163,6 @@ export default class SemanticSearch extends Component {
         const model = (await translateResults(results)) || {};
 
         if (model.posts?.length === 0) {
-          this.searching = false;
           return;
         }
 
@@ -144,56 +172,65 @@ export default class SemanticSearch extends Component {
 
         this.AiResults = model.posts;
       })
-      .finally(() => (this.searching = false));
-  }
-
-  #resetAndSearchOnEvent() {
-    return withPluginApi("1.15.0", (api) => {
-      api.onAppEvent("full-page-search:trigger-search", () => {
-        if (!this.searching) {
-          this.resetAiResults();
-          return this.performHyDESearch();
-        }
+      .finally(() => {
+        this.searching = false;
       });
-    });
   }
 
   @action
-  checkQueryParamsAndSearch() {
-    // This check is necessary because handleSearch() isn't called
-    // if query params are present and a new search has appended text.
-    // It ensures AiResults are reset and searched for properly
-    const searchQueryParam = this.router.currentRoute?.queryParams?.q;
-    if (searchQueryParam) {
-      this.#resetAndSearchOnEvent();
+  sortChanged() {
+    if (this.sortOrder !== this.args.outletArgs.sortOrder) {
+      this.sortOrder = this.args.outletArgs.sortOrder;
+
+      if (this.validSearchOrder) {
+        this.handleSearch();
+      } else {
+        this.showingAiResults = false;
+        this.resetAiResults();
+      }
     }
   }
 
   <template>
-    <span {{didInsert this.checkQueryParamsAndSearch}}></span>
-    {{#if this.searchEnabled}}
-      <div class="semantic-search__container search-results" role="region">
-        <div class="semantic-search__results" {{didInsert this.handleSearch}}>
-          <div
-            class="semantic-search__searching
-              {{if this.searching 'in-progress'}}"
-          >
-            <DToggleSwitch
-              disabled={{this.disableToggleSwitch}}
-              @state={{this.showingAiResults}}
-              class="semantic-search__results-toggle"
-              {{on "click" this.toggleAiResults}}
-            />
+    <span {{didUpdate this.sortChanged @outletArgs.sortOrder}}></span>
+    <div class="semantic-search__container search-results" role="region">
+      <div class="semantic-search__results">
+        <div
+          class="semantic-search__searching {{if this.searching 'in-progress'}}"
+        >
+          <DToggleSwitch
+            disabled={{this.disableToggleSwitch}}
+            @state={{this.showingAiResults}}
+            class="semantic-search__results-toggle"
+            {{on "click" this.toggleAiResults}}
+          />
 
-            <div class="semantic-search__searching-text">
-              {{icon "discourse-sparkles"}}
-              {{this.searchStateText}}
-            </div>
-
-            <AiIndicatorWave @loading={{this.searching}} />
+          <div class="semantic-search__searching-text">
+            {{icon "discourse-sparkles"}}
+            {{this.searchStateText}}
           </div>
+
+          <AiIndicatorWave @loading={{this.searching}} />
+
+          {{#if (not this.validSearchOrder)}}
+
+            <DTooltip
+              @identifier="semantic-search-unavailable-tooltip"
+              class="semantic-search__unavailable-tooltip"
+              ...attributes
+            >
+              <:trigger>
+                {{icon "far-circle-question"}}
+              </:trigger>
+              <:content>
+                {{i18n
+                  "discourse_ai.embeddings.semantic_search_unavailable_tooltip"
+                }}
+              </:content>
+            </DTooltip>
+          {{/if}}
         </div>
       </div>
-    {{/if}}
+    </div>
   </template>
 }

--- a/assets/stylesheets/modules/embeddings/common/semantic-search.scss
+++ b/assets/stylesheets/modules/embeddings/common/semantic-search.scss
@@ -16,7 +16,8 @@
         display: flex;
         align-items: center;
 
-        &.in-progress {
+        &.in-progress,
+        &.unavailable {
           .semantic-search__searching-text {
             color: var(--primary-medium);
           }

--- a/assets/stylesheets/modules/embeddings/common/semantic-search.scss
+++ b/assets/stylesheets/modules/embeddings/common/semantic-search.scss
@@ -25,7 +25,11 @@
 
       &__searching-text {
         display: inline-block;
-        margin-left: 3px;
+        margin-left: 8px;
+      }
+
+      &__unavailable-tooltip {
+        margin-left: 4px;
       }
     }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -483,6 +483,8 @@ en:
           toggle_hidden: "Hiding %{count} results found using AI"
           none: "Sorry, our AI search found no matching topics"
           new: "Press 'search' to begin looking for new results with AI"
+          unavailable: "AI results unavailable"
+        semantic_search_unavailable_tooltip: "Search results must be sorted by Relevance to display AI results."
         ai_generated_result: "Search result found using AI"
         quick_search:
           suffix: "in all topics and posts with AI"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -484,7 +484,7 @@ en:
           none: "Sorry, our AI search found no matching topics"
           new: "Press 'search' to begin looking for new results with AI"
           unavailable: "AI results unavailable"
-        semantic_search_unavailable_tooltip: "Search results must be sorted by Relevance to display AI results."
+        semantic_search_unavailable_tooltip: "Search results must be sorted by Relevance to display AI results"
         ai_generated_result: "Search result found using AI"
         quick_search:
           suffix: "in all topics and posts with AI"

--- a/lib/embeddings/entry_point.rb
+++ b/lib/embeddings/entry_point.rb
@@ -5,7 +5,7 @@ module DiscourseAi
     class EntryPoint
       def inject_into(plugin)
         # far-circle-question used by semantic search unavailable tooltip
-        register_svg_icon "far-circle-question" if respond_to?(:register_svg_icon)
+        plugin.register_svg_icon "far-circle-question" if plugin.respond_to?(:register_svg_icon)
 
         # Include random topics in the suggested list *only* if there are no related topics.
         plugin.register_modifier(

--- a/lib/embeddings/entry_point.rb
+++ b/lib/embeddings/entry_point.rb
@@ -4,6 +4,9 @@ module DiscourseAi
   module Embeddings
     class EntryPoint
       def inject_into(plugin)
+        # far-circle-question used by semantic search unavailable tooltip
+        register_svg_icon "far-circle-question" if respond_to?(:register_svg_icon)
+
         # Include random topics in the suggested list *only* if there are no related topics.
         plugin.register_modifier(
           :topic_view_suggested_topics_options,

--- a/plugin.rb
+++ b/plugin.rb
@@ -43,6 +43,8 @@ register_asset "stylesheets/modules/ai-bot/common/ai-tools.scss"
 
 register_asset "stylesheets/modules/ai-bot/common/ai-artifact.scss"
 
+register_svg_icon "far-circle-question" if respond_to?(:register_svg_icon)
+
 module ::DiscourseAi
   PLUGIN_NAME = "discourse-ai"
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -43,8 +43,6 @@ register_asset "stylesheets/modules/ai-bot/common/ai-tools.scss"
 
 register_asset "stylesheets/modules/ai-bot/common/ai-artifact.scss"
 
-register_svg_icon "far-circle-question" if respond_to?(:register_svg_icon)
-
 module ::DiscourseAi
   PLUGIN_NAME = "discourse-ai"
 


### PR DESCRIPTION
This PR adds an "unavailable" state for the AI semantic search toggle. Currently the AI toggle disappears when the sort by is anything but `Relevance` which makes the UI confusing for users looking for AI results. This should help!

Note there are no specs for this feature. I'm not sure what the LLM extraction mentioned here _is_, so I didn't touch it.
https://github.com/discourse/discourse-ai/blob/534b0df391ad6d1ae54c6674453aec5a6c69203f/spec/system/embeddings/semantic_search_spec.rb#L42-L48

No UI change for regular ol' searching
<img width="962" alt="Screenshot 2024-12-16 at 10 54 56 AM" src="https://github.com/user-attachments/assets/96dd6ad1-15be-48cd-a918-0bae3d2a0c48" />

But when a different sort order is selected, we now have an unavailable state with a tooltip explaining
![Screenshot 2024-12-16 at 2 14 41 PM](https://github.com/user-attachments/assets/714a08f1-b1cf-47ae-af6f-1ce62b262cfd)
![Screenshot 2024-12-16 at 2 14 37 PM](https://github.com/user-attachments/assets/e36662a2-7e6c-4ea8-ab15-28197ecc4ee8)

