### PR TITLE
UX: minor improvements to LLM page and admin tables

### DIFF
--- a/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
@@ -119,14 +119,17 @@ export default class AiLlmsListEditor extends Component {
           @llmTemplate={{@llmTemplate}}
         />
       {{else}}
+        <DPageSubheader
+          @titleLabel={{i18n "discourse_ai.llms.short_title"}}
+          @descriptionLabel={{i18n
+            "discourse_ai.llms.preconfigured.description"
+          }}
+          @learnMoreUrl="https://meta.discourse.org/t/discourse-ai-large-language-model-llm-settings-page/319903"
+        />
         {{#if this.hasLlmElements}}
           <section class="ai-llms-list-editor__configured">
             <DPageSubheader
               @titleLabel={{i18n "discourse_ai.llms.configured.title"}}
-              @descriptionLabel={{i18n
-                "discourse_ai.llms.preconfigured.description"
-              }}
-              @learnMoreUrl="https://meta.discourse.org/t/discourse-ai-large-language-model-llm-settings-page/319903"
             />
             <table class="d-admin-table">
               <thead>
@@ -185,18 +188,7 @@ export default class AiLlmsListEditor extends Component {
           </section>
         {{/if}}
         <section class="ai-llms-list-editor__templates">
-          <DPageSubheader
-            @titleLabel={{i18n this.preconfiguredTitle}}
-            @descriptionLabel={{unless
-              this.hasLlmElements
-              (i18n "discourse_ai.llms.preconfigured.description")
-            }}
-            @learnMoreUrl={{unless
-              this.hasLlmElements
-              "https://meta.discourse.org/t/discourse-ai-large-language-model-llm-settings-page/319903"
-            }}
-          />
-
+          <DPageSubheader @titleLabel={{i18n this.preconfiguredTitle}} />
           <AdminSectionLandingWrapper
             class="ai-llms-list-editor__templates-list"
           >

--- a/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
+++ b/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
@@ -6,8 +6,9 @@
     margin: 0 0 1em 0;
   }
 
-  &__configured + &__templates {
-    margin-top: 3em;
+  &__configured,
+  &__templates {
+    margin-top: 2em;
   }
 }
 
@@ -66,9 +67,38 @@
   }
 }
 
+.ai-llms-list-editor__configured,
+.ai-llms-list-editor__templates {
+  h2 {
+    font-size: var(--font-up-1);
+  }
+}
+
 .ai-llms-list-editor__configured {
   .d-toggle-switch {
     justify-content: center;
+  }
+}
+
+.ai-tool-list-editor__current,
+.ai-persona-list-editor__current,
+.ai-llms-list-editor__configured {
+  .d-admin-table {
+    tr:hover {
+      background: inherit;
+    }
+    th,
+    td {
+      &:first-child {
+        padding-left: 0;
+      }
+    }
+    th,
+    td {
+      &:last-child {
+        padding-right: 0;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The heading w/ description feels like it should be a level above the tables here.

I also adjusted the tables themselves, they're not clickable so they shouldn't highlight on hover... and the left/right padding has been removed to better align with content above/below

Before:
![image](https://github.com/user-attachments/assets/f198b0aa-80a5-4c5b-89ea-311ebe1c3b7c)

After:
![image](https://github.com/user-attachments/assets/b2eae8ce-2807-41ea-981f-9c2ef6b1468a)


