### PR TITLE
DEV: Unreachable LLM error shouldn't prevent setting

### DIFF
--- a/lib/configuration/llm_validator.rb
+++ b/lib/configuration/llm_validator.rb
@@ -20,7 +20,6 @@ module DiscourseAi
         run_test(val).tap { |result| @unreachable = result }
       rescue StandardError => e
         raise e if Rails.env.test?
-        @unreachable = true
         true
       end
 


### PR DESCRIPTION
Previously we had the behaviour for model settings so that when you try and set a model, it runs a test and returns an error if it can't run the test successfully. The error then prevents you from setting the site setting.

This results in some issues when we try and automate things. This PR updates that so that the test runs and discreetly logs the changes, but doesn't prevent the setting from being set. Instead we rely on "run test" in the LLM config along with ProblemChecks to catch issues.