### PR TITLE
UX: disabled preseeded edit button, add description

### DIFF
--- a/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
@@ -193,7 +193,7 @@ export default class AiLlmsListEditor extends Component {
                         <DTooltip class="ai-llm-list__edit-disabled-tooltip">
                           <:trigger>
                             <DButton
-                              class="btn btn.default btn-small disabled"
+                              class="btn btn-default btn-small disabled"
                               @label="discourse_ai.llms.edit"
                             />
                           </:trigger>

--- a/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
@@ -1,15 +1,22 @@
 import Component from "@glimmer/component";
 import { concat, fn } from "@ember/helper";
 import { action } from "@ember/object";
-import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DButton from "discourse/components/d-button";
 import DPageSubheader from "discourse/components/d-page-subheader";
 import i18n from "discourse-common/helpers/i18n";
 import I18n from "discourse-i18n";
 import AdminSectionLandingItem from "admin/components/admin-section-landing-item";
 import AdminSectionLandingWrapper from "admin/components/admin-section-landing-wrapper";
+import DTooltip from "float-kit/components/d-tooltip";
 import AiLlmEditor from "./ai-llm-editor";
+
+function isPreseeded(llm) {
+  if (llm.id < 0) {
+    return true;
+  }
+}
 
 export default class AiLlmsListEditor extends Component {
   @service adminPluginNavManager;
@@ -34,6 +41,15 @@ export default class AiLlmsListEditor extends Component {
       return I18n.t(key);
     }
     return "";
+  }
+
+  @action
+  preseededDescription(llm) {
+    if (isPreseeded(llm)) {
+      return i18n("discourse_ai.llms.preseeded_model_description", {
+        model: llm.name,
+      });
+    }
   }
 
   sanitizedTranslationKey(id) {
@@ -146,6 +162,7 @@ export default class AiLlmsListEditor extends Component {
                     class="ai-llm-list__row d-admin-row__content"
                   >
                     <td class="d-admin-row__overview">
+
                       <div class="ai-llm-list__name">
                         <strong>
                           {{llm.display_name}}
@@ -153,6 +170,7 @@ export default class AiLlmsListEditor extends Component {
                       </div>
                       <div class="ai-llm-list__description">
                         {{this.modelDescription llm}}
+                        {{this.preseededDescription llm}}
                       </div>
                       {{#if llm.used_by}}
                         <ul class="ai-llm-list-editor__usages">
@@ -171,15 +189,26 @@ export default class AiLlmsListEditor extends Component {
                       }}
                     </td>
                     <td class="d-admin-row__controls">
-                      <LinkTo
-                        @route="adminPlugins.show.discourse-ai-llms.edit"
-                        class="btn btn-default btn-small ai-llm-list__edit-button"
-                        @model={{llm.id}}
-                      >
-                        <div class="d-button-label">
-                          {{i18n "discourse_ai.llms.edit"}}
-                        </div>
-                      </LinkTo>
+                      {{#if (isPreseeded llm)}}
+                        <DTooltip class="ai-llm-list__edit-disabled-tooltip">
+                          <:trigger>
+                            <DButton
+                              class="btn btn.default btn-small disabled"
+                              @label="discourse_ai.llms.edit"
+                            />
+                          </:trigger>
+                          <:content>
+                            {{i18n "discourse_ai.llms.seeded_warning"}}
+                          </:content>
+                        </DTooltip>
+                      {{else}}
+                        <DButton
+                          class="btn btn-default btn-small ai-llm-list__delete-button"
+                          @label="discourse_ai.llms.edit"
+                          @route="adminPlugins.show.discourse-ai-llms.edit"
+                          @routeModels={{llm.id}}
+                        />
+                      {{/if}}
                     </td>
                   </tr>
                 {{/each}}

--- a/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
+++ b/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
@@ -87,16 +87,18 @@
     tr:hover {
       background: inherit;
     }
-    th,
-    td {
-      &:first-child {
-        padding-left: 0;
+    @include breakpoint("tablet", min-width) {
+      th,
+      td {
+        &:first-child {
+          padding-left: 0;
+        }
       }
-    }
-    th,
-    td {
-      &:last-child {
-        padding-right: 0;
+      th,
+      td {
+        &:last-child {
+          padding-right: 0;
+        }
       }
     }
   }
@@ -156,5 +158,16 @@
     border: 1px solid var(--primary-low);
     padding: 1px 3px;
     margin-right: 0.5em;
+  }
+}
+
+.ai-llm-list__seeded-model {
+  color: var(--primary-high);
+  font-size: var(--font-down-1);
+}
+
+@include breakpoint("tablet") {
+  .ai-llm-list__description {
+    max-width: 80%;
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -365,6 +365,8 @@ en:
           mistral-mistral-large-latest: "Mistral's most powerful model"
           mistral-pixtral-large-latest: "Mistral's most powerful vision capable model"
 
+        preseeded_model_description: "Preconfigured open-source model utilizing %{model}"
+
         configured:
           title: "Configured LLMs"
         preconfigured_llms: "Select your LLM"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -365,7 +365,7 @@ en:
           mistral-mistral-large-latest: "Mistral's most powerful model"
           mistral-pixtral-large-latest: "Mistral's most powerful vision capable model"
 
-        preseeded_model_description: "Preconfigured open-source model utilizing %{model}"
+        preseeded_model_description: "Pre-configured open-source model utilizing %{model}"
 
         configured:
           title: "Configured LLMs"

--- a/spec/system/llms/ai_llm_spec.rb
+++ b/spec/system/llms/ai_llm_spec.rb
@@ -87,7 +87,8 @@ RSpec.describe "Managing LLM configurations", type: :system, js: true do
     it "seeded LLM has a description" do
       visit "/admin/plugins/discourse-ai/ai-llms"
 
-      description = I18n.t("discourse_ai.llms.preseeded_model_description", model: llm_model.name)
+      description =
+        I18n.t("js.discourse_ai.llms.preseeded_model_description", model: llm_model.name)
 
       expect(page).to have_css(
         "[data-llm-id='#{llm_model.name}'] .ai-llm-list__description",
@@ -97,9 +98,7 @@ RSpec.describe "Managing LLM configurations", type: :system, js: true do
 
     it "seeded LLM has a disabled edit button" do
       visit "/admin/plugins/discourse-ai/ai-llms"
-      expect(page).to have_css(
-        "[data-llm-id='#{llm_model.name}'] .ai-llm-list__edit-button.disabled",
-      )
+      expect(page).to have_css("[data-llm-id='cdck-hosted'] .ai-llm-list__edit-button.disabled")
     end
   end
 end

--- a/spec/system/llms/ai_llm_spec.rb
+++ b/spec/system/llms/ai_llm_spec.rb
@@ -84,21 +84,22 @@ RSpec.describe "Managing LLM configurations", type: :system, js: true do
       )
     end
 
-    it "shows an info alert to the user about the seeded LLM" do
+    it "seeded LLM has a description" do
       visit "/admin/plugins/discourse-ai/ai-llms"
-      find("[data-llm-id='#{llm_model.name}'] .ai-llm-list__edit-button").click()
+
+      description = I18n.t("discourse_ai.llms.preseeded_model_description", model: llm_model.name)
+
       expect(page).to have_css(
-        ".alert.alert-info",
-        text: I18n.t("js.discourse_ai.llms.seeded_warning"),
+        "[data-llm-id='#{llm_model.name}'] .ai-llm-list__description",
+        text: description,
       )
     end
 
-    it "limits and shows disabled inputs for the seeded LLM" do
+    it "seeded LLM has a disabled edit button" do
       visit "/admin/plugins/discourse-ai/ai-llms"
-      find("[data-llm-id='cdck-hosted'] .ai-llm-list__edit-button").click()
-      expect(page).to have_css(".ai-llm-editor__display-name[disabled]")
-      expect(page).to have_css(".ai-llm-editor__name[disabled]")
-      expect(page).to have_css(".ai-llm-editor__provider.is-disabled")
+      expect(page).to have_css(
+        "[data-llm-id='#{llm_model.name}'] .ai-llm-list__edit-button.disabled",
+      )
     end
   end
 end

--- a/spec/system/llms/ai_llm_spec.rb
+++ b/spec/system/llms/ai_llm_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "Managing LLM configurations", type: :system, js: true do
 
     it "seeded LLM has a disabled edit button" do
       visit "/admin/plugins/discourse-ai/ai-llms"
-      expect(page).to have_css("[data-llm-id='cdck-hosted'] .ai-llm-list__edit-button.disabled")
+      expect(page).to have_css("[data-llm-id='cdck-hosted'] .ai-llm-list__edit-disabled-tooltip")
     end
   end
 end

--- a/spec/system/llms/ai_llm_spec.rb
+++ b/spec/system/llms/ai_llm_spec.rb
@@ -87,12 +87,11 @@ RSpec.describe "Managing LLM configurations", type: :system, js: true do
     it "seeded LLM has a description" do
       visit "/admin/plugins/discourse-ai/ai-llms"
 
-      description =
-        I18n.t("js.discourse_ai.llms.preseeded_model_description", model: llm_model.name)
+      desc = I18n.t("js.discourse_ai.llms.preseeded_model_description", model: llm_model.name)
 
       expect(page).to have_css(
         "[data-llm-id='#{llm_model.name}'] .ai-llm-list__description",
-        text: description,
+        text: desc,
       )
     end
 


### PR DESCRIPTION
This adds a description for the CDCK preseeded LLMs so we can see the model, and also adds a disabled edit button with a tooltip explanation. 

Before:
![image](https://github.com/user-attachments/assets/bd317624-44b7-41fd-817d-e03b7dde4641)


After:
![image](https://github.com/user-attachments/assets/67da4200-e3df-43aa-ab03-73424ff9fd85)
