### PR TITLE
FIX: Custom prefix causing allowed seeded LLMs not to be shown

### DIFF
--- a/lib/configuration/llm_enumerator.rb
+++ b/lib/configuration/llm_enumerator.rb
@@ -59,7 +59,7 @@ module DiscourseAi
         if allowed_seeded_llms.is_a?(Array)
           values =
             values.filter do |value_h|
-              value_h[:value] > 0 || allowed_seeded_llms.include?("custom:#{value_h[:value]}")
+              value_h[:value] > 0 || allowed_seeded_llms.include?("#{value_h[:value]}")
             end
         end
 

--- a/spec/requests/admin/ai_spam_controller_spec.rb
+++ b/spec/requests/admin/ai_spam_controller_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe DiscourseAi::Admin::AiSpamController do
         # only includes fabricated model
         expect(json["available_llms"].length).to eq(1)
 
-        SiteSetting.ai_spam_detection_model_allowed_seeded_models = [seeded_llm.id.to_s]
+        SiteSetting.ai_spam_detection_model_allowed_seeded_models = seeded_llm.id.to_s
 
         get "/admin/plugins/discourse-ai/ai-spam.json"
         expect(response.status).to eq(200)

--- a/spec/requests/admin/ai_spam_controller_spec.rb
+++ b/spec/requests/admin/ai_spam_controller_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe DiscourseAi::Admin::AiSpamController do
 
       it "correctly filters seeded llms" do
         SiteSetting.ai_spam_detection_enabled = true
-        seeded_llm = Fabricate(:llm_model, id: -1, name: "seeded")
+        seeded_llm = Fabricate(:seeded_model)
 
         get "/admin/plugins/discourse-ai/ai-spam.json"
         expect(response.status).to eq(200)
@@ -202,7 +202,7 @@ RSpec.describe DiscourseAi::Admin::AiSpamController do
         # only includes fabricated model
         expect(json["available_llms"].length).to eq(1)
 
-        SiteSetting.ai_spam_detection_model_allowed_seeded_models = seeded_llm.identifier
+        SiteSetting.ai_spam_detection_model_allowed_seeded_models = [seeded_llm.id.to_s]
 
         get "/admin/plugins/discourse-ai/ai-spam.json"
         expect(response.status).to eq(200)


### PR DESCRIPTION
The `allowed_seeded_llms` array which is a map of a list type setting (`ai_spam_detection_model_allowed_seeded_models_map`) includes only a string of LLM IDs and not the `custom` prefix. However, our check in the LLM enumerator was comparing against it with the prefix, thus causing seeded LLMs to never be shown. 