### PR TITLE
FIX: keep track of silence reason when spam detection flags user

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -253,6 +253,7 @@ en:
         conversation_deleted: "Conversation share deleted successfully"
     spam_detection:
       flag_reason: "Flagged as spam by <a href='%{url}'>Discourse AI</a>"
+      silence_reason: "User silenced automatically by <a href='%{url}'>Discourse AI</a>"
     ai_bot:
       reply_error: "Sorry, it looks like our system encountered an unexpected issue while trying to reply.\n\n[details='Error details']\n%{details}\n[/details]"
       default_pm_prefix: "[Untitled AI bot PM]"

--- a/spec/lib/modules/ai_moderation/spam_scanner_spec.rb
+++ b/spec/lib/modules/ai_moderation/spam_scanner_spec.rb
@@ -215,6 +215,15 @@ RSpec.describe DiscourseAi::AiModeration::SpamScanner do
       expect(post.user.reload.silenced_till).to be_present
       expect(post.topic.reload.visible).to eq(false)
 
+      history = UserHistory.where(action: UserHistory.actions[:silence_user]).order(:id).last
+
+      url = "#{Discourse.base_url}/admin/plugins/discourse-ai/ai-spam"
+
+      expect(history.target_user_id).to eq(post.user_id)
+      expect(history.details).to include(
+        I18n.t("discourse_ai.spam_detection.silence_reason", url: url),
+      )
+
       expect(log.reviewable).to be_present
       expect(log.reviewable.created_by_id).to eq(described_class.flagging_user.id)
     end


### PR DESCRIPTION
Previously reason was blank for silencing user
