### PR TITLE
UX: close summary modal on click outside

### DIFF
--- a/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
@@ -23,5 +23,5 @@ html.scrollable-modal {
 }
 
 .ai-summary-modal + .d-modal__backdrop {
-  display: none;
+  opacity: 0; // allows for reading, but still triggers clickoutside event
 }

--- a/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
+++ b/assets/stylesheets/modules/summarization/desktop/ai-summary.scss
@@ -23,5 +23,5 @@ html.scrollable-modal {
 }
 
 .ai-summary-modal + .d-modal__backdrop {
-  opacity: 0; // allows for reading, but still triggers clickoutside event
+  background: transparent; // allows for reading, but still triggers clickoutside event
 }


### PR DESCRIPTION
Request to keep the clickoutside behavior here: https://meta.discourse.org/t/topic-ai-summary-box-closing/342745

This still hides the backdrop, but allows it to register clicks 