### PR TITLE
FIX: add viewport so artifacts render correctly on mobile

### DIFF
--- a/app/controllers/discourse_ai/ai_bot/artifacts_controller.rb
+++ b/app/controllers/discourse_ai/ai_bot/artifacts_controller.rb
@@ -57,6 +57,7 @@ module DiscourseAi
             <head>
               <meta charset="UTF-8">
               <title>#{ERB::Util.html_escape(name)}</title>
+              <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=yes, viewport-fit=cover, interactive-widget=resizes-content">
               <style>
                 html, body, iframe {
                   margin: 0;

--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -32,6 +32,7 @@ class LlmModel < ActiveRecord::Base
       open_ai: {
         organization: :text,
         disable_native_tools: :checkbox,
+        disable_streaming: :checkbox,
       },
       mistral: {
         disable_native_tools: :checkbox,
@@ -51,11 +52,13 @@ class LlmModel < ActiveRecord::Base
       ollama: {
         disable_system_prompt: :checkbox,
         enable_native_tool: :checkbox,
+        disable_streaming: :checkbox,
       },
       open_router: {
         disable_native_tools: :checkbox,
         provider_order: :text,
         provider_quantizations: :text,
+        disable_streaming: :checkbox,
       },
     }
   end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -420,6 +420,7 @@ en:
           disable_native_tools: "Disable native tool support (use XML based tools)"
           provider_order: "Provider order (comma delimited list)"
           provider_quantizations: "Order of provider quantizations (comma delimited list eg: fp16,fp8)"
+          disable_streaming: "Disable streaming completions (convert streaming to non streaming requests)"
 
       related_topics:
         title: "Related topics"

--- a/lib/completions/endpoints/base.rb
+++ b/lib/completions/endpoints/base.rb
@@ -283,7 +283,7 @@ module DiscourseAi
         end
 
         def disable_streaming?
-          @disable_streaming = llm_model.lookup_custom_param("disable_streaming")
+          @disable_streaming = !!llm_model.lookup_custom_param("disable_streaming")
         end
 
         private

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -42,6 +42,10 @@ module DiscourseAi
 
         private
 
+        def disable_streaming?
+          @disable_streaming = llm_model.lookup_custom_param("disable_streaming")
+        end
+
         def model_uri
           if llm_model.url.to_s.starts_with?("srv://")
             service = DiscourseAi::Utils::DnsSrv.lookup(llm_model.url.sub("srv://", ""))


### PR DESCRIPTION
When sharing artifacts on mobile we had no viewport tag so
text would be TINY

