### PR TITLE
DEV: Add rake task to send topics or posts to spam scanner

### DIFF
--- a/lib/ai_moderation/spam_scanner.rb
+++ b/lib/ai_moderation/spam_scanner.rb
@@ -193,9 +193,13 @@ module DiscourseAi
       end
 
       def self.perform_scan(post)
-        return if !enabled?
         return if !should_scan_post?(post)
 
+        perform_scan!(post)
+      end
+
+      def self.perform_scan!(post)
+        return if !enabled?
         settings = AiModerationSetting.spam
         return if !settings || !settings.llm_model
 

--- a/lib/tasks/modules/ai_moderation/scan.rake
+++ b/lib/tasks/modules/ai_moderation/scan.rake
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+desc "Scan first posts of topics from a date, end date is optional. Usage: rake ai:spam:scan_topics[2024-01-01,2024-02-31]"
+task "ai:spam:scan_topics", %i[start_date end_date] => [:environment] do |_, args|
+  start_date = args[:start_date] ? DateTime.parse(args[:start_date]) : 1.day.ago
+  end_date = args[:end_date] ? DateTime.parse(args[:end_date]) : Time.current
+
+  scope = Topic.joins(:posts).where(created_at: start_date..end_date).where("posts.post_number = 1")
+  puts "Processing #{scope.count} topics from #{start_date} to #{end_date}"
+  scope
+    .select("topics.id, posts.id as post_id")
+    .find_each(batch_size: 500) do |record|
+      Jobs.enqueue(:ai_spam_scan, post_id: record.post_id)
+      print "."
+    end
+end
+
+desc "Scan posts from a date, end date is optional. Usage: rake ai:spam:scan_posts[2024-01-31,2024-02-01]"
+task "ai:spam:scan_posts", %i[start_date end_date] => [:environment] do |_, args|
+  start_date = args[:start_date] ? DateTime.parse(args[:start_date]) : 1.day.ago
+  end_date = args[:end_date] ? DateTime.parse(args[:end_date]) : Time.current
+
+  scope = Post.where(created_at: start_date..end_date).select(:id)
+  puts "Processing #{scope.count} posts from #{start_date} to #{end_date}"
+  scope.find_each(batch_size: 500) do |post|
+    Jobs.enqueue(:ai_spam_scan, post_id: post.id)
+    print "."
+  end
+end

--- a/spec/tasks/scan_spec.rb
+++ b/spec/tasks/scan_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe "ai:spam rake tasks" do
+  let!(:topic1) { Fabricate(:topic, created_at: 2.days.ago) }
+  let!(:post1) { Fabricate(:post, topic: topic1, created_at: 2.days.ago) }
+  let!(:topic2) { Fabricate(:topic, created_at: 1.hour.ago) }
+  let!(:post2) { Fabricate(:post, topic: topic2, created_at: 1.hour.ago) }
+
+  describe "ai:spam:scan_posts" do
+    it "enqueues posts within date range" do
+      freeze_time do
+        start_date = 1.day.ago.to_s
+        end_date = Time.now.to_s
+
+        expect_enqueued_with(job: :ai_spam_scan, args: { post_id: post2.id }) do
+          Rake::Task["ai:spam:scan_posts"].invoke(start_date, end_date)
+        end
+
+        expect_not_enqueued_with(job: :ai_spam_scan, args: { post_id: post1.id })
+      end
+    end
+  end
+
+  describe "ai:spam:scan_topics" do
+    it "enqueues first posts of topics within date range" do
+      freeze_time do
+        start_date = 1.day.ago.to_s
+        end_date = Time.now.to_s
+
+        expect_enqueued_with(job: :ai_spam_scan, args: { post_id: topic2.first_post.id }) do
+          Rake::Task["ai:spam:scan_topics"].invoke(start_date, end_date)
+        end
+
+        expect_not_enqueued_with(job: :ai_spam_scan, args: { post_id: topic1.first_post.id })
+      end
+    end
+  end
+end


### PR DESCRIPTION
Two rake tasks have been created to allow sending topics directly to the `AiModeration::SpamScanner`. This is to add older topics/posts to the queue. In the event there are only new topics created by spammers, the first task (topics) should be enough.

```
ai:spam:scan_topics[2024-01-01,2024-02-31]
ai:spam:scan_posts[2024-01-01,2024-02-31]
```

This PR also allows bypassing the `should_scan_post?` check that the spam_scanner uses for regular scanning, with a `perform_scan!`.