### PR TITLE
FIX: Composer helper not appearing on tablets

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -693,7 +693,7 @@
 }
 
 .fk-d-menu[data-identifier="ai-composer-helper-menu"] {
-  z-index: z("composer", "dropdown") + 1;
+  z-index: z("modal", "dialog");
 
   .fullscreen-composer & {
     z-index: z("header") + 1;


### PR DESCRIPTION
This update fixes an issue when the composer helper menu was not being shown on tablets in desktop mode. Updating the `z-index` to use the modal-dialog case is more appropriate here.