### PR TITLE
FIX: Missing table check in post_migration

### DIFF
--- a/db/post_migrate/20250114184356_drop_old_embedding_tables2.rb
+++ b/db/post_migrate/20250114184356_drop_old_embedding_tables2.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 class DropOldEmbeddingTables2 < ActiveRecord::Migration[7.2]
   def up
-    # Copy rag embeddings created during deploy.
-    execute <<~SQL
-        INSERT INTO ai_document_fragments_embeddings (rag_document_fragment_id, model_id, model_version, strategy_id, strategy_version, digest, embeddings, created_at, updated_at)
-        (
-          SELECT  old_table.*
-          FROM ai_document_fragment_embeddings old_table
-          LEFT OUTER JOIN ai_document_fragments_embeddings target ON (
-            target.model_id = old_table.model_id AND
-            target.strategy_id = old_table.strategy_id AND
-            target.rag_document_fragment_id = old_table.rag_document_fragment_id
+    if table_exists?(:ai_document_fragment_embeddings)
+      # Copy rag embeddings created during deploy.
+      execute <<~SQL
+          INSERT INTO ai_document_fragments_embeddings (rag_document_fragment_id, model_id, model_version, strategy_id, strategy_version, digest, embeddings, created_at, updated_at)
+          (
+            SELECT  old_table.*
+            FROM ai_document_fragment_embeddings old_table
+            LEFT OUTER JOIN ai_document_fragments_embeddings target ON (
+              target.model_id = old_table.model_id AND
+              target.strategy_id = old_table.strategy_id AND
+              target.rag_document_fragment_id = old_table.rag_document_fragment_id
+            )
+            WHERE target.rag_document_fragment_id IS NULL
           )
-          WHERE target.rag_document_fragment_id IS NULL
-        )
-      SQL
+        SQL
+    end
 
     execute <<~SQL
         DROP INDEX IF EXISTS ai_topic_embeddings_1_1_search_bit;


### PR DESCRIPTION
Tables were already dropped on some sites. We need to check there's something left to migrate.