### PR TITLE
FIX: Set default for existing summaries' new column.

### DIFF
--- a/app/models/ai_summary.rb
+++ b/app/models/ai_summary.rb
@@ -64,7 +64,7 @@ end
 #  updated_at            :datetime         not null
 #  summary_type          :integer          default("complete"), not null
 #  origin                :integer
-#  highest_target_number :integer          not null
+#  highest_target_number :integer          default(1), not null
 #
 # Indexes
 #

--- a/db/migrate/20250115173456_add_highest_target_number_to_ai_summary.rb
+++ b/db/migrate/20250115173456_add_highest_target_number_to_ai_summary.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class AddHighestTargetNumberToAiSummary < ActiveRecord::Migration[7.2]
   def up
-    add_column :ai_summaries, :highest_target_number, :integer, null: false
+    add_column :ai_summaries, :highest_target_number, :integer, null: false, default: 1
 
     execute <<~SQL
       UPDATE ai_summaries SET highest_target_number = GREATEST(UPPER(content_range) - 1, 1)


### PR DESCRIPTION
We'll later copy the correct value from content_range. 1 should be the min highest post number a topic has.