### PR TITLE
DEV: update more deprecated icon names

### DIFF
--- a/app/models/reviewable_ai_chat_message.rb
+++ b/app/models/reviewable_ai_chat_message.rb
@@ -35,7 +35,7 @@ class ReviewableAiChatMessage < Reviewable
   def build_actions(actions, guardian, args)
     return unless pending?
 
-    return build_action(actions, :ignore, icon: "external-link-alt") if chat_message.blank?
+    return build_action(actions, :ignore, icon: "up-right-from-square") if chat_message.blank?
 
     agree =
       actions.add_bundle("#{id}-agree", icon: "thumbs-up", label: "reviewables.actions.agree.title")
@@ -67,7 +67,7 @@ class ReviewableAiChatMessage < Reviewable
       )
     end
 
-    build_action(actions, :ignore, icon: "external-link-alt")
+    build_action(actions, :ignore, icon: "up-right-from-square")
 
     build_action(actions, :delete_and_agree, icon: "far-trash-can") unless chat_message.deleted_at?
   end

--- a/app/models/reviewable_ai_post.rb
+++ b/app/models/reviewable_ai_post.rb
@@ -61,12 +61,12 @@ class ReviewableAiPost < Reviewable
           icon: "far-trash-can",
           label: "reviewables.actions.delete.title",
         )
-      build_action(actions, :delete_and_ignore, icon: "external-link-alt", bundle: delete)
+      build_action(actions, :delete_and_ignore, icon: "up-right-from-square", bundle: delete)
       if post.reply_count > 0
         build_action(
           actions,
           :delete_and_ignore_replies,
-          icon: "external-link-alt",
+          icon: "up-right-from-square",
           confirm: true,
           bundle: delete,
         )
@@ -76,7 +76,7 @@ class ReviewableAiPost < Reviewable
         build_action(
           actions,
           :delete_and_agree_replies,
-          icon: "external-link-alt",
+          icon: "up-right-from-square",
           bundle: delete,
           confirm: true,
         )
@@ -85,7 +85,7 @@ class ReviewableAiPost < Reviewable
 
     delete_user_actions(actions) if guardian.can_delete_user?(target_created_by)
 
-    build_action(actions, :ignore, icon: "external-link-alt")
+    build_action(actions, :ignore, icon: "up-right-from-square")
   end
 
   def perform_agree_and_hide(performed_by, args)

--- a/assets/javascripts/discourse/components/ai-llm-quota-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-llm-quota-editor.gjs
@@ -149,7 +149,7 @@ export default class AiLlmQuotaEditor extends Component {
               </td>
               <td class="ai-llm-quotas__cell ai-llm-quotas__cell--actions">
                 <DButton
-                  @icon="trash-alt"
+                  @icon="trash-can"
                   class="btn-danger ai-llm-quotas__delete-btn"
                   @action={{fn this.deleteQuota quota}}
                 />

--- a/assets/javascripts/initializers/ai-bot-replies.js
+++ b/assets/javascripts/initializers/ai-bot-replies.js
@@ -227,7 +227,7 @@ function initializeShareTopicButton(api) {
 
   api.registerTopicFooterButton({
     id: "share-ai-conversation",
-    icon: "share-alt",
+    icon: "share-nodes",
     label: "discourse_ai.ai_bot.share_ai_conversation.name",
     title: "discourse_ai.ai_bot.share_ai_conversation.title",
     action() {


### PR DESCRIPTION
Noticed "share-alt" come into the site logs, and checked this repo for deprecated icon names with that suffix. Also looked at args to `icon`, this should complete the FA6 icon upgrade for this plugin 😅 .

For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.