### PR TITLE
FIX: convert provider_params hash to json before db insert

### DIFF
--- a/db/migrate/20250110114305_embedding_config_data_migration.rb
+++ b/db/migrate/20250110114305_embedding_config_data_migration.rb
@@ -171,8 +171,6 @@ class EmbeddingConfigDataMigration < ActiveRecord::Migration[7.0]
   end
 
   def persist_config(attrs)
-    provider_params_json = attrs[:provider_params].to_json if attrs[:provider_params].present?
-
     DB.exec(
       <<~SQL,
       INSERT INTO embedding_definitions (id, display_name, dimensions, max_sequence_length, version, pg_function, provider, tokenizer_class, url, api_key, provider_params, seeded, created_at, updated_at)
@@ -187,7 +185,7 @@ class EmbeddingConfigDataMigration < ActiveRecord::Migration[7.0]
       tokenizer_class: attrs[:tokenizer_class],
       url: attrs[:url],
       api_key: attrs[:api_key],
-      provider_params: provider_params_json,
+      provider_params: attrs[:provider_params]&.to_json,
       seeded: !!attrs[:seeded],
       now: Time.zone.now,
     )

--- a/db/migrate/20250110114305_embedding_config_data_migration.rb
+++ b/db/migrate/20250110114305_embedding_config_data_migration.rb
@@ -171,6 +171,12 @@ class EmbeddingConfigDataMigration < ActiveRecord::Migration[7.0]
   end
 
   def persist_config(attrs)
+    provider_params_json = if attrs[:provider_params].present?
+      attrs[:provider_params].to_json
+    else
+      nil
+    end
+
     DB.exec(
       <<~SQL,
       INSERT INTO embedding_definitions (id, display_name, dimensions, max_sequence_length, version, pg_function, provider, tokenizer_class, url, api_key, provider_params, seeded, created_at, updated_at)
@@ -185,7 +191,7 @@ class EmbeddingConfigDataMigration < ActiveRecord::Migration[7.0]
       tokenizer_class: attrs[:tokenizer_class],
       url: attrs[:url],
       api_key: attrs[:api_key],
-      provider_params: attrs[:provider_params],
+      provider_params: provider_params_json,
       seeded: !!attrs[:seeded],
       now: Time.zone.now,
     )

--- a/db/migrate/20250110114305_embedding_config_data_migration.rb
+++ b/db/migrate/20250110114305_embedding_config_data_migration.rb
@@ -171,11 +171,7 @@ class EmbeddingConfigDataMigration < ActiveRecord::Migration[7.0]
   end
 
   def persist_config(attrs)
-    provider_params_json = if attrs[:provider_params].present?
-      attrs[:provider_params].to_json
-    else
-      nil
-    end
+    provider_params_json = attrs[:provider_params].to_json if attrs[:provider_params].present?
 
     DB.exec(
       <<~SQL,


### PR DESCRIPTION
Fix embedding config migration

Fix "can't quote Array" error by converting provider_params to json string before saving to database. 

This fixes the setup of OpenAI text embeddings.