### PR TITLE
UX: Fix composer helper z-index

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -704,10 +704,6 @@
   z-index: z("mobile-composer");
 }
 
-html.footer-nav-ipad .fk-d-menu[data-identifier="ai-composer-helper-menu"] {
-  z-index: z("ipad-header-nav") + 1;
-}
-
 .fk-d-toasts:has(.ai-proofread-error-toast) {
   top: unset;
   bottom: calc(var(--composer-height) - 5%);


### PR DESCRIPTION
Followup to https://github.com/discourse/discourse-ai/pull/1064

That commits adds a higher z-index due to core changes, we no longer need an iPad-specific z-index.