### PR TITLE
UX: set usage as first AI admin tab instead of embeddings

### DIFF
--- a/assets/javascripts/initializers/admin-plugin-configuration-nav.js
+++ b/assets/javascripts/initializers/admin-plugin-configuration-nav.js
@@ -13,8 +13,8 @@ export default {
     withPluginApi("1.1.0", (api) => {
       api.addAdminPluginConfigurationNav("discourse-ai", PLUGIN_NAV_MODE_TOP, [
         {
-          label: "discourse_ai.embeddings.short_title",
-          route: "adminPlugins.show.discourse-ai-embeddings",
+          label: "discourse_ai.usage.short_title",
+          route: "adminPlugins.show.discourse-ai-usage",
         },
         {
           label: "discourse_ai.llms.short_title",
@@ -25,16 +25,16 @@ export default {
           route: "adminPlugins.show.discourse-ai-personas",
         },
         {
+          label: "discourse_ai.embeddings.short_title",
+          route: "adminPlugins.show.discourse-ai-embeddings",
+        },
+        {
           label: "discourse_ai.tools.short_title",
           route: "adminPlugins.show.discourse-ai-tools",
         },
         {
           label: "discourse_ai.spam.short_title",
           route: "adminPlugins.show.discourse-ai-spam",
-        },
-        {
-          label: "discourse_ai.usage.short_title",
-          route: "adminPlugins.show.discourse-ai-usage",
         },
       ]);
     });


### PR DESCRIPTION
Embeddings as the tab you land on when visiting the AI plugin admin page didn't make much sense... this treats usage as a dashboard for it instead



Before:
![image](https://github.com/user-attachments/assets/9eb8ba30-e6eb-4363-8468-e7f847cdb623)


After:
![image](https://github.com/user-attachments/assets/54a9f1f0-0d99-49ba-91ce-44b8f662b5d6)
