### PR TITLE
DEV: add missing class to summarize button

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-trigger.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-trigger.gjs
@@ -23,7 +23,7 @@ export default class AiSummaryTrigger extends Component {
         @label="summary.buttons.generate"
         @icon="discourse-sparkles"
         @action={{this.openAiSummaryModal}}
-        class="ai-summarization-button"
+        class="btn-default ai-summarization-button"
       />
     {{/if}}
   </template>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d4da56bb-0de9-4ec5-bca8-08143ef457dc)

The summarize button shown above uses the default button styling, but is missing the `btn-default` class, making it inconsistent in themes 