### PR TITLE
FIX: Android tablet composer menu z-index

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -272,7 +272,7 @@
 .ai-category-suggester-content,
 .ai-tag-suggester-content,
 .ai-title-suggester-content {
-  z-index: z("modal", "dropdown");
+  z-index: z("composer", "dropdown");
 }
 
 .ai-suggestions-menu .btn {
@@ -693,7 +693,7 @@
 }
 
 .fk-d-menu[data-identifier="ai-composer-helper-menu"],
-.fk-d-menu[data-identifier="ai-suggester-menu"] {
+.fk-d-menu[data-identifier="ai-title-suggester"] {
   z-index: z("modal", "dialog");
 
   .fullscreen-composer & {


### PR DESCRIPTION
@keegangeorge I think the more solid fix here would be to add a new class that identifies any `DMenu` components loaded inside the composer and then setting the right z-index for those elements. This likely should be a `DMenu` flag in core, and then the AI plugin can use that where applicable. (I know we use these menus outside the composer, so it's not entirely straightforward.) 

Feel free to take this draft PR and build on it. (Or we can merge this quick fix and follow up at a later time.) 

Bug report: https://meta.discourse.org/t/ai-helper-hiding-on-android-tablets/349719 