### PR TITLE
FIX: Only permit config of allowed seeded models

### DIFF
--- a/lib/configuration/llm_validator.rb
+++ b/lib/configuration/llm_validator.rb
@@ -2,6 +2,9 @@
 
 module DiscourseAi
   module Configuration
+    class InvalidSeededModelError < StandardError
+    end
+
     class LlmValidator
       def initialize(opts = {})
         @opts = opts
@@ -18,8 +21,12 @@ module DiscourseAi
         allowed_seeded_model?(val)
 
         run_test(val).tap { |result| @unreachable = result }
+      rescue DiscourseAi::Configuration::InvalidSeededModelError => e
+        @unreachable = true
+        false
       rescue StandardError => e
         raise e if Rails.env.test?
+        @unreachable = true
         true
       end
 
@@ -76,7 +83,7 @@ module DiscourseAi
 
         if allowed_list.split("|").exclude?(id)
           @invalid_seeded_model = true
-          raise Discourse::InvalidParameters.new
+          raise DiscourseAi::Configuration::InvalidSeededModelError.new
         end
       end
     end


### PR DESCRIPTION
### :mag: Overview
This update resolves a regression that was introduced in https://github.com/discourse/discourse-ai/pull/1036/files. Previously, only seeded models that were allowed could be configured for model settings. However, in our attempts to prevent unreachable LLM errors from not allowing settings to persist, it also unknowingly allowed seeded models that were not allowed to be configured. This update resolves this issue, while maintaining the ability to still set unreachable LLMs.

## 📸 Screenshots
 
_Can still set unreachable LLMs_
![Screenshot 2025-01-31 at 12 23 27](https://github.com/user-attachments/assets/078e6fab-8019-459a-afca-3c4749f32c9c)

_Cannot set seeded models that are not permitted_
![Screenshot 2025-01-31 at 12 23 04](https://github.com/user-attachments/assets/6797753f-cafe-44e9-a9d5-7f1bf50828fb)
