### PR TITLE
FIX: Embeddings backfill job compat when transitioning models

### DIFF
--- a/app/jobs/scheduled/embeddings_backfill.rb
+++ b/app/jobs/scheduled/embeddings_backfill.rb
@@ -26,7 +26,9 @@ module Jobs
 
       topics =
         Topic
-          .joins("LEFT JOIN #{table_name} ON #{table_name}.topic_id = topics.id")
+          .joins(
+            "LEFT JOIN #{table_name} ON #{table_name}.topic_id = topics.id AND #{table_name}.model_id = #{vector_def.id}",
+          )
           .where(archetype: Archetype.default)
           .where(deleted_at: nil)
           .order("topics.bumped_at DESC")
@@ -43,7 +45,7 @@ module Jobs
           #{table_name}.strategy_version < #{vector_def.strategy_version}
         SQL
 
-      rebaked += populate_topic_embeddings(vector, relation)
+      rebaked += populate_topic_embeddings(vector, relation, force: true)
 
       return if rebaked >= limit
 
@@ -67,7 +69,9 @@ module Jobs
 
       posts =
         Post
-          .joins("LEFT JOIN #{table_name} ON #{table_name}.post_id = posts.id")
+          .joins(
+            "LEFT JOIN #{table_name} ON #{table_name}.post_id = posts.id AND #{table_name}.model_id = #{vector_def.id}",
+          )
           .where(deleted_at: nil)
           .where(post_type: Post.types[:regular])
 


### PR DESCRIPTION
When you already have embeddings for a model stored and change models,
our backfill script was failing to backfill the newly configured model.

Regression introduced most likely in 1686a8a
