### PR TITLE
FIX: update draft key for new PM with AI bot

### DIFF
--- a/assets/javascripts/discourse/lib/ai-bot-helper.js
+++ b/assets/javascripts/discourse/lib/ai-bot-helper.js
@@ -25,6 +25,7 @@ export function showShareConversationModal(modal, topicId) {
 
 export function composeAiBotMessage(targetBot, composer) {
   const currentUser = composer.currentUser;
+  const draftKey = "new_private_message_ai_" + new Date().getTime();
 
   let botUsername = currentUser.ai_enabled_chat_bots.find(
     (bot) => bot.model_name === targetBot
@@ -37,7 +38,7 @@ export function composeAiBotMessage(targetBot, composer) {
       recipients: botUsername,
       topicTitle: i18n("discourse_ai.ai_bot.default_pm_prefix"),
       archetypeId: "private_message",
-      draftKey: "new_private_message_ai",
+      draftKey: draftKey,
       hasGroups: false,
       warningsDisabled: true,
     },

--- a/assets/javascripts/discourse/lib/ai-bot-helper.js
+++ b/assets/javascripts/discourse/lib/ai-bot-helper.js
@@ -37,10 +37,9 @@ export function composeAiBotMessage(targetBot, composer) {
       recipients: botUsername,
       topicTitle: i18n("discourse_ai.ai_bot.default_pm_prefix"),
       archetypeId: "private_message",
-      draftKey: "private_message_ai",
+      draftKey: "new_private_message_ai",
       hasGroups: false,
       warningsDisabled: true,
-      skipDraftCheck: true,
     },
   });
 }

--- a/assets/javascripts/discourse/lib/ai-bot-helper.js
+++ b/assets/javascripts/discourse/lib/ai-bot-helper.js
@@ -38,7 +38,7 @@ export function composeAiBotMessage(targetBot, composer) {
       recipients: botUsername,
       topicTitle: i18n("discourse_ai.ai_bot.default_pm_prefix"),
       archetypeId: "private_message",
-      draftKey: draftKey,
+      draftKey,
       hasGroups: false,
       warningsDisabled: true,
     },


### PR DESCRIPTION
Very small change to draft key to assign proper draft title and icon within core drafts list and dropdown menu. The draft key for each PM with AI Bot will now be unique, allowing multiple drafts.

I've also removed the now redundant `skipDraftCheck` from the multiple drafts work carried out in core.

Internal ref: /t/120592