### PR TITLE
FIX: Misconfigured llm should go to edit page

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -476,4 +476,4 @@ en:
       prompt_message_length: The message %{idx} is over the 1000 character limit.
   dashboard:
     problem:
-      ai_llm_status: "The LLM model: %{model_name} is encountering issues. Please check the <a href='%{base_path}/admin/plugins/discourse-ai/ai-llms/%{model_id}'>model's configuration page</a>."
+      ai_llm_status: "The LLM model: %{model_name} is encountering issues. Please check the <a href='%{base_path}/admin/plugins/discourse-ai/ai-llms/%{model_id}/edit'>model's configuration page</a>."


### PR DESCRIPTION
### :mag: Overview
The link for a misconfigured LLM was linking to `/ai-llms/%{model_id}` leading to be directed to 404 error. The correct link should be `/ai-llms/%{model_id}/edit`

### 📸 Screenshots
![Screenshot 2025-02-18 at 10 22 03](https://github.com/user-attachments/assets/b3c4b709-bf14-4cbe-a8ef-7788b14d48fe)
