### PR TITLE
FIX: Add workaround to pgvector HNSW search limitations

### DIFF
--- a/lib/embeddings/schema.rb
+++ b/lib/embeddings/schema.rb
@@ -176,7 +176,7 @@ module DiscourseAi
         end
 
         ActiveRecord::Base.transaction do
-          DB.exec(before_query) unless before_query.blank?
+          DB.exec(before_query) if before_query.present?
           builder.query(
             query_embedding: embedding,
             candidates_limit: candidates_limit,
@@ -238,7 +238,7 @@ module DiscourseAi
         yield(builder) if block_given?
 
         ActiveRecord::Base.transaction do
-          DB.exec(before_query) unless before_query.blank?
+          DB.exec(before_query) if before_query.present?
           builder.query(vid: vector_def.id, vsid: vector_def.strategy_id, target_id: record.id)
         end
       rescue PG::Error => e

--- a/lib/embeddings/schema.rb
+++ b/lib/embeddings/schema.rb
@@ -171,7 +171,7 @@ module DiscourseAi
 
         builder.query(
           query_embedding: embedding,
-          candidates_limit: candidates_limit,
+          candidates_limit: limit * 2,
           limit: limit,
           offset: offset,
         )

--- a/lib/embeddings/schema.rb
+++ b/lib/embeddings/schema.rb
@@ -263,6 +263,8 @@ module DiscourseAi
 
       def hnsw_search_workaround(limit)
         return "", "" if limit > DEFAULT_HNSW_EF_SEARCH
+        return "SET LOCAL hnsw.ef_search = #{limit * 2};", "" if Rails.env.test?
+
         before_query = <<~SQL
           BEGIN;
           SET LOCAL hnsw.ef_search = #{limit * 2};

--- a/spec/system/ai_helper/ai_composer_helper_spec.rb
+++ b/spec/system/ai_helper/ai_composer_helper_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe "AI Composer helper", type: :system, js: true do
   fab!(:user) { Fabricate(:admin, refresh_auto_groups: true) }
   fab!(:non_member_group) { Fabricate(:group) }
+  fab!(:embedding_definition)
 
   before do
     Group.find_by(id: Group::AUTO_GROUPS[:admins]).add(user)
@@ -243,7 +244,10 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
   end
 
   context "when suggesting the category with AI category suggester" do
-    before { SiteSetting.ai_embeddings_enabled = true }
+    before do
+      SiteSetting.ai_embeddings_selected_model = embedding_definition.id
+      SiteSetting.ai_embeddings_enabled = true
+    end
 
     it "updates the category with the suggested category" do
       response =
@@ -274,7 +278,10 @@ RSpec.describe "AI Composer helper", type: :system, js: true do
   end
 
   context "when suggesting the tags with AI tag suggester" do
-    before { SiteSetting.ai_embeddings_enabled = true }
+    before do
+      SiteSetting.ai_embeddings_selected_model = embedding_definition.id
+      SiteSetting.ai_embeddings_enabled = true
+    end
 
     it "updates the tag with the suggested tag" do
       response =

--- a/spec/system/ai_helper/ai_split_topic_suggestion_spec.rb
+++ b/spec/system/ai_helper/ai_split_topic_suggestion_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "AI Post helper", type: :system, js: true do
   fab!(:cloud) { Fabricate(:tag) }
   fab!(:feedback) { Fabricate(:tag) }
   fab!(:review) { Fabricate(:tag) }
+  fab!(:embedding_definition)
 
   before do
     Group.find_by(id: Group::AUTO_GROUPS[:admins]).add(user)

--- a/spec/system/ai_helper/ai_split_topic_suggestion_spec.rb
+++ b/spec/system/ai_helper/ai_split_topic_suggestion_spec.rb
@@ -80,7 +80,10 @@ RSpec.describe "AI Post helper", type: :system, js: true do
     end
 
     context "when suggesting categories with AI category suggester" do
-      before { SiteSetting.ai_embeddings_enabled = true }
+      before do
+        SiteSetting.ai_embeddings_selected_model = embedding_definition.id
+        SiteSetting.ai_embeddings_enabled = true
+      end
 
       skip "TODO: Category suggester only loading one category in test" do
         it "updates the category with the suggested category" do
@@ -108,7 +111,10 @@ RSpec.describe "AI Post helper", type: :system, js: true do
     end
 
     context "when suggesting tags with AI tag suggester" do
-      before { SiteSetting.ai_embeddings_enabled = true }
+      before do
+        SiteSetting.ai_embeddings_selected_model = embedding_definition.id
+        SiteSetting.ai_embeddings_enabled = true
+      end
 
       it "update the tag with the suggested tag" do
         response =


### PR DESCRIPTION
From [pgvector/pgvector](https://github.com/pgvector/pgvector) README

> With approximate indexes, filtering is applied after the index is scanned. If a condition matches 10% of rows, with HNSW and the default hnsw.ef_search of 40, only 4 rows will match on average. For more rows, increase hnsw.ef_search.
> 
> Starting with 0.8.0, you can enable [iterative index scans](https://github.com/pgvector/pgvector#iterative-index-scans), which will automatically scan more of the index when needed.


Since we are stuck on 0.7.0 we are going the first option for now.