### PR TITLE
DEV: add summary button wrapper removed from core

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-trigger.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-expanded-after/ai-summary-trigger.gjs
@@ -19,12 +19,14 @@ export default class AiSummaryTrigger extends Component {
 
   <template>
     {{#if @outletArgs.topic.summarizable}}
-      <DButton
-        @label="summary.buttons.generate"
-        @icon="discourse-sparkles"
-        @action={{this.openAiSummaryModal}}
-        class="btn-default ai-summarization-button"
-      />
+      <section class="topic-map__additional-contents toggle-summary">
+        <DButton
+          @label="summary.buttons.generate"
+          @icon="discourse-sparkles"
+          @action={{this.openAiSummaryModal}}
+          class="btn-default ai-summarization-button"
+        />
+      </section>
     {{/if}}
   </template>
 }


### PR DESCRIPTION
This wrapper was in core, but it was removed in 

It makes more sense to keep this in the plugin. 