### PR TITLE
FIX: hardcoded require for evals

### DIFF
--- a/evals/lib/boot.rb
+++ b/evals/lib/boot.rb
@@ -24,12 +24,12 @@ if !Dir.exist?(EVAL_PATH)
   end
 end
 
-discourse_path = File.expand_path(File.join(__dir__, "../../../.."))
+discourse_path = ENV["DISCOURSE_PATH"] || File.expand_path(File.join(__dir__, "../../../.."))
 # rubocop:disable Discourse/NoChdir
 Dir.chdir(discourse_path)
 # rubocop:enable Discourse/NoChdir
 
-require File.expand_path("../../../../discourse/config/environment", __dir__)
+require "#{discourse_path}/config/environment"
 
 ENV["DISCOURSE_AI_NO_DEBUG"] = "1"
 module DiscourseAi::Evals


### PR DESCRIPTION
The require for `discourse/config/environment` should point to the local user's core Discourse environment instead of the hardcoded path for Sam's env.