### PR TITLE
DEV: Sentiment analysis report follow-up updates

### DIFF
--- a/app/controllers/discourse_ai/sentiment/sentiment_controller.rb
+++ b/app/controllers/discourse_ai/sentiment/sentiment_controller.rb
@@ -6,10 +6,8 @@ module DiscourseAi
       include Constants
       requires_plugin ::DiscourseAi::PLUGIN_NAME
 
-      # DEFAULT_POSTS_LIMIT = 50
-      # MAX_POSTS_LIMIT = 100
-      DEFAULT_POSTS_LIMIT = 3
-      MAX_POSTS_LIMIT = 3
+      DEFAULT_POSTS_LIMIT = 50
+      MAX_POSTS_LIMIT = 100
 
       def posts
         group_by = params.required(:group_by)&.to_sym

--- a/app/controllers/discourse_ai/sentiment/sentiment_controller.rb
+++ b/app/controllers/discourse_ai/sentiment/sentiment_controller.rb
@@ -24,7 +24,7 @@ module DiscourseAi
         case group_by
         when :category
           grouping_clause = "c.name"
-          grouping_join = "INNER JOIN categories c ON c.id = t.category_id"
+          grouping_join = "" # categories already joined
         when :tag
           grouping_clause = "tags.name"
           grouping_join =
@@ -44,6 +44,11 @@ module DiscourseAi
             u.username,
             u.name,
             u.uploaded_avatar_id,
+            c.id AS category_id,
+            c.name AS category_name,
+            c.color AS category_color,
+            c.slug AS category_slug,
+            c.description AS category_description,
             (CASE 
               WHEN (cr.classification::jsonb->'positive')::float > :threshold THEN 'positive'
               WHEN (cr.classification::jsonb->'negative')::float > :threshold THEN 'negative'
@@ -53,6 +58,7 @@ module DiscourseAi
           INNER JOIN topics t ON t.id = p.topic_id
           INNER JOIN classification_results cr ON cr.target_id = p.id AND cr.target_type = 'Post'
           LEFT JOIN users u ON u.id = p.user_id
+          LEFT JOIN categories c ON c.id = t.category_id
           #{grouping_join}
           WHERE
             #{grouping_clause} = :group_value AND

--- a/app/serializers/ai_sentiment_post_serializer.rb
+++ b/app/serializers/ai_sentiment_post_serializer.rb
@@ -10,7 +10,8 @@ class AiSentimentPostSerializer < ApplicationSerializer
              :avatar_template,
              :excerpt,
              :sentiment,
-             :truncated
+             :truncated,
+             :category
 
   def avatar_template
     User.avatar_template(object.username, object.uploaded_avatar_id)
@@ -22,5 +23,15 @@ class AiSentimentPostSerializer < ApplicationSerializer
 
   def truncated
     true
+  end
+
+  def category
+    {
+      id: object.category_id,
+      name: object.category_name,
+      color: object.category_color,
+      slug: object.category_slug,
+      description: object.category_description,
+    }
   end
 end

--- a/assets/javascripts/discourse/components/admin-report-sentiment-analysis.gjs
+++ b/assets/javascripts/discourse/components/admin-report-sentiment-analysis.gjs
@@ -182,6 +182,7 @@ export default class AdminReportSentimentAnalysis extends Component {
   backToAllCharts() {
     this.showingSelectedChart = false;
     this.selectedChart = null;
+    this.activeFilter = "all";
   }
 
   get postFilters() {

--- a/assets/stylesheets/modules/sentiment/common/dashboard.scss
+++ b/assets/stylesheets/modules/sentiment/common/dashboard.scss
@@ -105,7 +105,7 @@
   overflow-y: auto;
   height: 100%;
 
-  .horizontal-overflow-nav {
+  &__filters {
     border-bottom: 1px solid var(--primary-low);
     margin-bottom: 1rem;
   }

--- a/assets/stylesheets/modules/sentiment/common/dashboard.scss
+++ b/assets/stylesheets/modules/sentiment/common/dashboard.scss
@@ -83,6 +83,12 @@
       cursor: pointer;
     }
   }
+
+  &__selected-chart {
+    border: 1px solid var(--primary-low);
+    border-radius: var(--d-border-radius);
+    padding: 1rem;
+  }
 }
 
 :root {
@@ -99,8 +105,20 @@
   overflow-y: auto;
   height: 100%;
 
+  .horizontal-overflow-nav {
+    border-bottom: 1px solid var(--primary-low);
+    margin-bottom: 1rem;
+  }
+
   &__title {
     font-size: var(--font-up-2);
+    margin: 0 auto;
+    text-align: center;
+    margin-bottom: 1rem;
+    margin-top: 0.3rem;
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+    border-top: 1px solid var(--primary-low);
   }
 
   &__scores {

--- a/assets/stylesheets/modules/sentiment/common/dashboard.scss
+++ b/assets/stylesheets/modules/sentiment/common/dashboard.scss
@@ -53,6 +53,7 @@
   .main {
     flex: 100%;
     display: flex;
+    flex-flow: row wrap;
     order: 2;
     gap: 1rem;
     align-items: flex-start;
@@ -99,7 +100,9 @@
 
 .admin-report-sentiment-analysis-details {
   @include report-container-box();
-  flex: 1;
+  flex: 1 1 300px;
+  min-width: 300px;
+
   display: flex;
   flex-flow: column nowrap;
   overflow-y: auto;
@@ -108,6 +111,12 @@
   &__filters {
     border-bottom: 1px solid var(--primary-low);
     margin-bottom: 1rem;
+
+    @include breakpoint("mobile-extra-large") {
+      .d-button-label {
+        display: none;
+      }
+    }
   }
 
   &__title {
@@ -170,6 +179,7 @@
   }
 
   &__post-list {
+    margin-top: 1rem;
     .avatar-wrapper,
     .avatar-link {
       width: calc(48px * 0.75);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -651,7 +651,8 @@ en:
         dashboard:
           title: "Sentiment"
         sentiment_analysis:
-          score_types:
+          filter_types:
+            all: "All"
             positive: "Positive"
             neutral: "Neutral"
             negative: "Negative"

--- a/lib/sentiment/sentiment_analysis_report.rb
+++ b/lib/sentiment/sentiment_analysis_report.rb
@@ -68,7 +68,6 @@ module DiscourseAi
         grouping = (report.filters.dig(:group_by) || GROUP_BY_FILTER_DEFAULT).to_sym
         sorting = (report.filters.dig(:sort_by) || SORT_BY_FILTER_DEFAULT).to_sym
         category_filter = report.filters.dig(:category)
-        pp "========================== category_filter ===================================== #{category_filter} include subcategories?: #{opts[:include_subcategories]}"
         tag_filter = report.filters.dig(:tag)
 
         sentiment_count_sql = Proc.new { |sentiment| <<~SQL }

--- a/spec/requests/sentiment/sentiment_controller_spec.rb
+++ b/spec/requests/sentiment/sentiment_controller_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe DiscourseAi::Sentiment::SentimentController do
 
       expect(response).to be_successful
 
-      posts = JSON.parse(response.body)
+      post_response = JSON.parse(response.body)
+      posts = post_response["posts"]
       posts.each do |post|
         expect(post).to have_key("sentiment")
         expect(post["sentiment"]).to match(/positive|negative|neutral/)


### PR DESCRIPTION
> [!NOTE]
> This update includes a series of small follow-up updates to the new Sentiment Analysis report added in https://github.com/discourse/discourse-ai/pull/1109. 

## ✔️ Updates
- [x] Make `include subcategories` checkbox operational (checking the box while filtering a parent category will include visualizations from the subcategories)
- [x] Add category color to posts list
- [x] Truncate category/tag name in doughnut visualization
- [x] Improve UX for when a doughnut visualization is selected
- [x] Add tabbed interface for filtering through posts based on sentiment type
- [X] Limit amount of posts fetched for visualizations and paginate on scroll.

## 📸 Screenshots
![Screenshot 2025-02-21 at 16 37 41](https://github.com/user-attachments/assets/9ac935b2-c4a1-4947-a85f-715daf9a63b1)

