### PR TITLE
FIX: legacy reasoning models not working, missing provider params

### DIFF
--- a/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
+++ b/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
@@ -61,7 +61,7 @@ export default class AiLlmEditorForm extends Component {
       provider: model.provider,
       enabled_chat_bot: model.enabled_chat_bot,
       vision_enabled: model.vision_enabled,
-      provider_params: model.provider_params,
+      provider_params: this.computeProviderParams(model.provider),
       llm_quotas: model.llm_quotas,
     };
   }

--- a/lib/completions/dialects/chat_gpt.rb
+++ b/lib/completions/dialects/chat_gpt.rb
@@ -55,10 +55,15 @@ module DiscourseAi
           end
         end
 
-        # developer messages are preferred on reasoning models
+        # developer messages are preferred on recent reasoning models
         def supports_developer_messages?
-          llm_model.provider == "open_ai" &&
+          !legacy_reasoning_model? && llm_model.provider == "open_ai" &&
             (llm_model.name.start_with?("o1") || llm_model.name.start_with?("o3"))
+        end
+
+        def legacy_reasoning_model?
+          llm_model.provider == "open_ai" &&
+            (llm_model.name.start_with?("o1-preview") || llm_model.name.start_with?("o1-mini"))
         end
 
         def system_msg(msg)
@@ -69,6 +74,8 @@ module DiscourseAi
 
           if supports_developer_messages?
             { role: "developer", content: content }
+          elsif legacy_reasoning_model?
+            { role: "user", content: content }
           else
             { role: "system", content: content }
           end

--- a/spec/system/llms/ai_llm_spec.rb
+++ b/spec/system/llms/ai_llm_spec.rb
@@ -72,6 +72,15 @@ RSpec.describe "Managing LLM configurations", type: :system, js: true do
   end
 
   context "when changing the provider" do
+    it "has the correct provider params when visiting the edit page" do
+      llm = Fabricate(:llm_model, provider: "open_ai", provider_params: {})
+      visit "/admin/plugins/discourse-ai/ai-llms/#{llm.id}/edit"
+
+      expect(form).to have_field_with_name("provider_params.organization")
+      expect(form).to have_field_with_name("provider_params.disable_native_tools")
+      expect(form).to have_field_with_name("provider_params.disable_streaming")
+      expect(form).to have_field_with_name("provider_params.reasoning_effort")
+    end
     it "correctly changes the provider params" do
       visit "/admin/plugins/discourse-ai/ai-llms"
       find("[data-llm-id='none'] button").click()


### PR DESCRIPTION
1. Legacy reasoning models (o1-preview / o1-mini) do not support developer or system messages, do not use them.
2. LLM editor form not showing all provider params due to missing remap

