### PR TITLE
FEATURE: full support for Sonnet 3.7

### DIFF
--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -26,9 +26,13 @@ class LlmModel < ActiveRecord::Base
         access_key_id: :text,
         region: :text,
         disable_native_tools: :checkbox,
+        enable_reasoning: :checkbox,
+        reasoning_tokens: :number,
       },
       anthropic: {
         disable_native_tools: :checkbox,
+        enable_reasoning: :checkbox,
+        reasoning_tokens: :number,
       },
       open_ai: {
         organization: :text,

--- a/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
+++ b/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
@@ -61,7 +61,10 @@ export default class AiLlmEditorForm extends Component {
       provider: model.provider,
       enabled_chat_bot: model.enabled_chat_bot,
       vision_enabled: model.vision_enabled,
-      provider_params: this.computeProviderParams(model.provider),
+      provider_params: this.computeProviderParams(
+        model.provider,
+        model.provider_params
+      ),
       llm_quotas: model.llm_quotas,
     };
   }
@@ -128,12 +131,12 @@ export default class AiLlmEditorForm extends Component {
     return !this.args.model.isNew;
   }
 
-  computeProviderParams(provider) {
+  computeProviderParams(provider, currentParams = {}) {
     const params = this.args.llms.resultSetMeta.provider_params[provider] ?? {};
     return Object.fromEntries(
       Object.entries(params).map(([k, v]) => [
         k,
-        v?.type === "enum" ? v.default : null,
+        currentParams[k] ?? (v?.type === "enum" ? v.default : null),
       ])
     );
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -390,7 +390,7 @@ en:
 
         model_description:
           none: "General settings that work for most language models"
-          anthropic-claude-3-5-sonnet: "Anthropic's most intelligent model"
+          anthropic-claude-3-7-sonnet: "Anthropic's most intelligent model"
           anthropic-claude-3-5-haiku: "Fast and cost-effective"
           anthropic-claude-3-opus: "Excels at writing and complex tasks"
           google-gemini-1-5-pro: "Mid-sized multimodal model capable of a wide range of tasks"
@@ -459,6 +459,8 @@ en:
           provider_quantizations: "Order of provider quantizations (comma delimited list eg: fp16,fp8)"
           disable_streaming: "Disable streaming completions (convert streaming to non streaming requests)"
           reasoning_effort: "Reasoning effort (only applicable to reasoning models)"
+          enable_reasoning: "Enable reasoning (only applicable to Sonnet 3.7)"
+          reasoning_tokens: "Number of tokens used for reasoning"
 
       related_topics:
         title: "Related topics"

--- a/lib/completions/endpoints/anthropic.rb
+++ b/lib/completions/endpoints/anthropic.rb
@@ -38,6 +38,19 @@ module DiscourseAi
 
           options = { model: mapped_model, max_tokens: max_tokens }
 
+          if llm_model.lookup_custom_param("enable_reasoning")
+            reasoning_tokens = llm_model.lookup_custom_param("reasoning_tokens").to_i
+            if reasoning_tokens < 100
+              reasoning_tokens = 100
+            elsif reasoning_tokens > 65_536
+              reasoning_tokens = 65_536
+            end
+
+            # this allows for lots of tokens beyond reasoning
+            options[:max_tokens] = reasoning_tokens + 30_000
+            options[:thinking] = { type: "enabled", budget_tokens: reasoning_tokens }
+          end
+
           options[:stop_sequences] = ["</function_calls>"] if !dialect.native_tool_support? &&
             dialect.prompt.has_tools?
 

--- a/lib/completions/endpoints/anthropic.rb
+++ b/lib/completions/endpoints/anthropic.rb
@@ -39,12 +39,8 @@ module DiscourseAi
           options = { model: mapped_model, max_tokens: max_tokens }
 
           if llm_model.lookup_custom_param("enable_reasoning")
-            reasoning_tokens = llm_model.lookup_custom_param("reasoning_tokens").to_i
-            if reasoning_tokens < 100
-              reasoning_tokens = 100
-            elsif reasoning_tokens > 65_536
-              reasoning_tokens = 65_536
-            end
+            reasoning_tokens =
+              llm_model.lookup_custom_param("reasoning_tokens").to_i.clamp(100, 65_536)
 
             # this allows for lots of tokens beyond reasoning
             options[:max_tokens] = reasoning_tokens + 30_000

--- a/lib/completions/endpoints/aws_bedrock.rb
+++ b/lib/completions/endpoints/aws_bedrock.rb
@@ -28,12 +28,8 @@ module DiscourseAi
 
               result = { anthropic_version: "bedrock-2023-05-31" }
               if llm_model.lookup_custom_param("enable_reasoning")
-                reasoning_tokens = llm_model.lookup_custom_param("reasoning_tokens").to_i
-                if reasoning_tokens < 100
-                  reasoning_tokens = 100
-                elsif reasoning_tokens > 65_536
-                  reasoning_tokens = 65_536
-                end
+                reasoning_tokens =
+                  llm_model.lookup_custom_param("reasoning_tokens").to_i.clamp(100, 65_536)
 
                 # this allows for ample tokens beyond reasoning
                 max_tokens = reasoning_tokens + 30_000

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -11,9 +11,13 @@ module DiscourseAi
         def normalize_model_params(model_params)
           model_params = model_params.dup
 
-          # max_tokens is deprecated and is not functional on reasoning models
-          max_tokens = model_params.delete(:max_tokens)
-          model_params[:max_completion_tokens] = max_tokens if max_tokens
+          # max_tokens is deprecated however we still need to support it
+          # on older OpenAI models and older Azure models, so we will only normalize
+          # if our model name starts with o (to denote all the reasoning models)
+          if llm_model.name.starts_with?("o")
+            max_tokens = model_params.delete(:max_tokens)
+            model_params[:max_completion_tokens] = max_tokens if max_tokens
+          end
 
           # temperature is already supported
           if model_params[:stop_sequences]

--- a/lib/completions/llm.rb
+++ b/lib/completions/llm.rb
@@ -27,9 +27,9 @@ module DiscourseAi
                   id: "anthropic",
                   models: [
                     {
-                      name: "claude-3-5-sonnet",
+                      name: "claude-3-7-sonnet",
                       tokens: 200_000,
-                      display_name: "Claude 3.5 Sonnet",
+                      display_name: "Claude 3.7 Sonnet",
                     },
                     { name: "claude-3-5-haiku", tokens: 200_000, display_name: "Claude 3.5 Haiku" },
                     { name: "claude-3-opus", tokens: 200_000, display_name: "Claude 3 Opus" },

--- a/spec/system/llms/ai_llm_spec.rb
+++ b/spec/system/llms/ai_llm_spec.rb
@@ -73,13 +73,15 @@ RSpec.describe "Managing LLM configurations", type: :system, js: true do
 
   context "when changing the provider" do
     it "has the correct provider params when visiting the edit page" do
-      llm = Fabricate(:llm_model, provider: "open_ai", provider_params: {})
+      llm =
+        Fabricate(:llm_model, provider: "anthropic", provider_params: { enable_reasoning: true })
       visit "/admin/plugins/discourse-ai/ai-llms/#{llm.id}/edit"
 
-      expect(form).to have_field_with_name("provider_params.organization")
       expect(form).to have_field_with_name("provider_params.disable_native_tools")
-      expect(form).to have_field_with_name("provider_params.disable_streaming")
-      expect(form).to have_field_with_name("provider_params.reasoning_effort")
+      expect(form).to have_field_with_name("provider_params.reasoning_tokens")
+
+      reasoning = form.field("provider_params.enable_reasoning")
+      expect(reasoning).to be_checked
     end
     it "correctly changes the provider params" do
       visit "/admin/plugins/discourse-ai/ai-llms"


### PR DESCRIPTION
- Adds support for Sonnet 3.7 with reasoning on bedrock and anthropic
- Fixes regression where provider params were not populated

Note. reasoning tokens are hardcoded to minimum of 100 maximum of 65536

