### PR TITLE
FEATURE: implement thinking token support

### DIFF
--- a/assets/javascripts/discourse/connectors/composer-fields/persona-llm-selector.gjs
+++ b/assets/javascripts/discourse/connectors/composer-fields/persona-llm-selector.gjs
@@ -168,12 +168,14 @@ export default class BotSelector extends Component {
       .filter((bot) => !bot.is_persona)
       .filter(Boolean);
 
-    return availableBots.map((bot) => {
-      return {
-        id: bot.id,
-        name: bot.display_name,
-      };
-    });
+    return availableBots
+      .map((bot) => {
+        return {
+          id: bot.id,
+          name: bot.display_name,
+        };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
   }
 
   <template>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -403,7 +403,7 @@ en:
           open_ai-o1: "Open AI's most capable reasoning model"
           open_ai-o3-mini: "Advanced Cost-efficient reasoning model"
           samba_nova-Meta-Llama-3-1-8B-Instruct: "Efficient lightweight multilingual model"
-          samba_nova-Meta-Llama-3-1-70B-Instruct": "Powerful multipurpose model"
+          samba_nova-Meta-Llama-3-3-70B-Instruct": "Powerful multipurpose model"
           mistral-mistral-large-latest: "Mistral's most powerful model"
           mistral-pixtral-large-latest: "Mistral's most powerful vision capable model"
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -85,10 +85,10 @@ en:
               description: "Prioritize content from this group in the report"
             temperature:
               label: "Temperature"
-              description: "Temperature to use for the LLM. Increase to increase randomness (0 to use model default)"
+              description: "Temperature to use for the LLM. Increase to increase randomness (leave empty to use model default)"
             top_p:
               label: "Top P"
-              description: "Top P to use for the LLM, increase to increase randomness (0 to use model default)"
+              description: "Top P to use for the LLM, increase to increase randomness (leave empty to use model default)"
 
         llm_triage:
           fields:
@@ -131,6 +131,9 @@ en:
             model:
               label: "Model"
               description: "Language model used for triage"
+            temperature:
+              label: "Temperature"
+              description: "Temperature to use for the LLM. Increase to increase randomness (leave empty to use model default)"
 
     discourse_ai:
       title: "AI"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -261,6 +261,7 @@ en:
     ai_bot:
       reply_error: "Sorry, it looks like our system encountered an unexpected issue while trying to reply.\n\n[details='Error details']\n%{details}\n[/details]"
       default_pm_prefix: "[Untitled AI bot PM]"
+      thinking: "Thinking..."
       personas:
         default_llm_required: "Default LLM model is required prior to enabling Chat"
         cannot_delete_system_persona: "System personas cannot be deleted, please disable it instead"

--- a/discourse_automation/llm_report.rb
+++ b/discourse_automation/llm_report.rb
@@ -37,8 +37,8 @@ if defined?(DiscourseAutomation)
 
     field :allow_secure_categories, component: :boolean
 
-    field :top_p, component: :text, required: true, default_value: 0.1
-    field :temperature, component: :text, required: true, default_value: 0.2
+    field :top_p, component: :text
+    field :temperature, component: :text
 
     field :suppress_notifications, component: :boolean
     field :debug_mode, component: :boolean
@@ -64,12 +64,19 @@ if defined?(DiscourseAutomation)
         exclude_category_ids = fields.dig("exclude_categories", "value")
         exclude_tags = fields.dig("exclude_tags", "value")
 
-        # set defaults in code to support easy migration for old rules
-        top_p = 0.1
-        top_p = fields.dig("top_p", "value").to_f if fields.dig("top_p", "value")
+        top_p = fields.dig("top_p", "value")
+        if top_p == "" || top_p.nil?
+          top_p = nil
+        else
+          top_p = top_p.to_f
+        end
 
-        temperature = 0.2
-        temperature = fields.dig("temperature", "value").to_f if fields.dig("temperature", "value")
+        temperature = fields.dig("temperature", "value")
+        if temperature == "" || temperature.nil?
+          temperature = nil
+        else
+          temperature = temperature.to_f
+        end
 
         suppress_notifications = !!fields.dig("suppress_notifications", "value")
         DiscourseAi::Automation::ReportRunner.run!(

--- a/discourse_automation/llm_triage.rb
+++ b/discourse_automation/llm_triage.rb
@@ -24,6 +24,7 @@ if defined?(DiscourseAutomation)
     field :hide_topic, component: :boolean
     field :flag_post, component: :boolean
     field :include_personal_messages, component: :boolean
+    field :temperature, component: :text
     field :flag_type,
           component: :choices,
           required: false,
@@ -53,6 +54,12 @@ if defined?(DiscourseAutomation)
       flag_post = fields.dig("flag_post", "value")
       flag_type = fields.dig("flag_type", "value")
       max_post_tokens = fields.dig("max_post_tokens", "value").to_i
+      temperature = fields.dig("temperature", "value")
+      if temperature == "" || temperature.nil?
+        temperature = nil
+      else
+        temperature = temperature.to_f
+      end
 
       max_post_tokens = nil if max_post_tokens <= 0
 
@@ -93,6 +100,7 @@ if defined?(DiscourseAutomation)
           max_post_tokens: max_post_tokens,
           stop_sequences: stop_sequences,
           automation: self.automation,
+          temperature: temperature,
         )
       rescue => e
         Discourse.warn_exception(e, message: "llm_triage: skipped triage on post #{post.id}")

--- a/lib/ai_bot/artifact_update_strategies/diff.rb
+++ b/lib/ai_bot/artifact_update_strategies/diff.rb
@@ -95,9 +95,9 @@ module DiscourseAi
           blocks = []
           remaining = content
 
-          pattern = /<<+\s*SEARCH\s*\n(.*?)\n=+\s*\n(.*?)\n>>+\s*REPLACE/m
+          pattern = /<<+\s*SEARCH\s*\n(.*?)\n==+\s*(\n(.*?))?\n>>+\s*REPLACE/m
           while remaining =~ pattern
-            blocks << { search: $1.strip, replace: $2.strip }
+            blocks << { search: $1.strip, replace: $3.to_s.strip }
             remaining = $'
           end
 

--- a/lib/ai_bot/artifact_update_strategies/diff.rb
+++ b/lib/ai_bot/artifact_update_strategies/diff.rb
@@ -90,15 +90,45 @@ module DiscourseAi
 
         def extract_search_replace_blocks(content)
           return nil if content.blank? || content.to_s.strip.downcase.match?(/^\(?no changes?\)?$/m)
-          return [{ replace: content }] if !content.match?(/<<+\s*SEARCH/)
+          return [{ replace: content }] if !content.include?("<<< SEARCH")
 
           blocks = []
-          remaining = content
+          current_block = {}
+          state = :initial
+          search_lines = []
+          replace_lines = []
 
-          pattern = /<<+\s*SEARCH\s*\n(.*?)\n==+\s*(\n(.*?))?\n>>+\s*REPLACE/m
-          while remaining =~ pattern
-            blocks << { search: $1.strip, replace: $3.to_s.strip }
-            remaining = $'
+          content.each_line do |line|
+            line = line.chomp
+
+            case state
+            when :initial
+              state = :collecting_search if line.match?(/^<<<* SEARCH/)
+            when :collecting_search
+              if line.start_with?("===")
+                current_block[:search] = search_lines.join("\n").strip
+                search_lines = []
+                state = :collecting_replace
+              else
+                search_lines << line
+              end
+            when :collecting_replace
+              if line.match?(/>>>* REPLACE/)
+                current_block[:replace] = replace_lines.join("\n").strip
+                replace_lines = []
+                blocks << current_block
+                current_block = {}
+                state = :initial
+              else
+                replace_lines << line
+              end
+            end
+          end
+
+          # Handle any remaining block
+          if state == :collecting_replace && !replace_lines.empty?
+            current_block[:replace] = replace_lines.join("\n").strip
+            blocks << current_block
           end
 
           blocks.empty? ? nil : blocks
@@ -108,26 +138,50 @@ module DiscourseAi
           <<~PROMPT
             You are a web development expert generating precise search/replace changes for updating HTML, CSS, and JavaScript code.
 
-            Important rules:
+            CRITICAL RULES:
 
             1. Use EXACTLY this format for changes:
                <<<<<<< SEARCH
-               (first line of code to replace)
-               (other lines of code to avoid ambiguity)
-               (last line of code to replace)
+               (code to replace)
                =======
                (replacement code)
                >>>>>>> REPLACE
-            2. DO NOT modify the markers or add spaces around them
-            3. DO NOT add explanations or comments within sections
-            4. ONLY include [HTML], [CSS], and [JavaScript] sections if they have changes
-            5. HTML should not include <html>, <head>, or <body> tags, it is injected into a template
-            6. When specifying a SEARCH block, ALWAYS keep it 8 lines or less, you will be interrupted and a retry will be required if you exceed this limit
-            7. NEVER EVER ask followup questions, ALL changes must be performed in a single response, you are consumed via an API, there is no opportunity for humans in the loop
-            8. When performing a non-contiguous search, ALWAYS use ... to denote the skipped lines
-            9. Be mindful that ... non-contiguous search is not greedy, the following line will only match the first occurrence of the search block
-            10. Never mix a full section replacement with a search/replace block in the same section
-            11. ALWAYS skip sections you to not want to change, do not include them in the response
+
+            2. SEARCH blocks MUST be 8 lines or less. Break larger changes into multiple smaller search/replace blocks.
+
+            3. DO NOT modify the markers or add spaces around them.
+
+            4. DO NOT add explanations or comments within sections.
+
+            5. ONLY include [HTML], [CSS], and [JavaScript] sections if they have changes.
+
+            6. HTML should not include <html>, <head>, or <body> tags, it is injected into a template.
+
+            7. NEVER EVER ask followup questions, ALL changes must be performed in a single response.
+
+            8. When performing a non-contiguous search, ALWAYS use ... to denote the skipped lines.
+
+            9. Be mindful that ... non-contiguous search is not greedy, it will only match the first occurrence.
+
+            10. Never mix a full section replacement with a search/replace block in the same section.
+
+            11. ALWAYS skip sections you do not want to change, do not include them in the response.
+
+            HANDLING LARGE CHANGES:
+
+            - Break large HTML structures into multiple smaller search/replace blocks.
+            - Use strategic anchor points like unique IDs or class names to target specific elements.
+            - Consider replacing entire components rather than modifying complex internals.
+            - When elements contain dynamic content, use precise context markers or replace entire containers.
+
+            VALIDATION CHECKLIST:
+            - Each SEARCH block is 8 lines or less
+            - Every SEARCH has exactly one matching REPLACE
+            - All blocks are properly closed
+            - No SEARCH/REPLACE blocks are nested
+            - Each change is a complete, separate block with its own SEARCH/REPLACE markers
+
+            WARNING: Never nest search/replace blocks. Each change must be a complete sequence.
 
             JavaScript libraries must be sourced from the following CDNs, otherwise CSP will reject it:
             #{AiArtifact::ALLOWED_CDN_SOURCES.join("\n")}
@@ -143,7 +197,7 @@ module DiscourseAi
             (changes or empty if no changes or entire JavaScript)
             [/JavaScript]
 
-            Example - Multiple changes in one file:
+            EXAMPLE 1 - Multiple small changes in one file:
 
             [JavaScript]
             <<<<<<< SEARCH
@@ -158,39 +212,35 @@ module DiscourseAi
             >>>>>>> REPLACE
             [/JavaScript]
 
-            Example - CSS with multiple blocks:
+            EXAMPLE 2 - Breaking up large HTML changes:
 
-            [CSS]
+            [HTML]
             <<<<<<< SEARCH
-            .button { color: blue; }
+            <div class="header">
+              <div class="logo">
+                <img src="old-logo.png">
+              </div>
             =======
-            .button { color: red; }
+            <div class="header">
+              <div class="logo">
+                <img src="new-logo.png">
+              </div>
             >>>>>>> REPLACE
+
             <<<<<<< SEARCH
-            .text { font-size: 12px; }
+              <div class="navigation">
+                <ul>
+                  <li>Home</li>
+                  <li>Products</li>
             =======
-            .text { font-size: 16px; }
+              <div class="navigation">
+                <ul>
+                  <li>Home</li>
+                  <li>Services</li>
             >>>>>>> REPLACE
-            [/CSS]
+            [/HTML]
 
-            Example - Non contiguous search in CSS (replace most CSS with new CSS)
-
-            Original CSS:
-
-            [CSS]
-            body {
-              color: red;
-            }
-            .button {
-              color: blue;
-            }
-            .alert {
-              background-color: green;
-            }
-            .alert2 {
-              background-color: green;
-            }
-            [/CSS]
+            EXAMPLE 3 - Non-contiguous search in CSS:
 
             [CSS]
             <<<<<<< SEARCH
@@ -203,23 +253,13 @@ module DiscourseAi
               color: red;
             }
             >>>>>>> REPLACE
-
-            RESULT:
-
-            [CSS]
-            body {
-              color: red;
-            }
-            .alert2 {
-              background-color: green;
-            }
             [/CSS]
 
-            Example - full HTML replacement:
+            EXAMPLE 4 - Full HTML replacement:
 
             [HTML]
             <div>something old</div>
-            <div>another somethin old</div>
+            <div>another something old</div>
             [/HTML]
 
             output:
@@ -227,13 +267,6 @@ module DiscourseAi
             [HTML]
             <div>something new</div>
             [/HTML]
-
-            result:
-            [HTML]
-            <div>something new</div>
-            [/HTML]
-
-
           PROMPT
         end
 

--- a/lib/ai_bot/bot.rb
+++ b/lib/ai_bot/bot.rb
@@ -191,7 +191,7 @@ module DiscourseAi
             ongoing_chain = false
             text = result
 
-            # we must strip out thinking
+            # we must strip out thinking and other types of blocks
             if result.is_a?(Array)
               text = +""
               result.each { |item| text << item if item.is_a?(String) }

--- a/lib/ai_bot/bot.rb
+++ b/lib/ai_bot/bot.rb
@@ -6,7 +6,8 @@ module DiscourseAi
       attr_reader :model
 
       BOT_NOT_FOUND = Class.new(StandardError)
-      MAX_COMPLETIONS = 5
+      # the future is agentic, allow for more turns
+      MAX_COMPLETIONS = 8
       # limit is arbitrary, but 5 which was used in the past was too low
       MAX_TOOLS = 20
 

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -220,6 +220,9 @@ module DiscourseAi
                 custom_context[:id] = message[1] if custom_context[:type] != :model
                 custom_context[:name] = message[3] if message[3]
 
+                thinking = message[4]
+                custom_context[:thinking] = thinking if thinking
+
                 builder.push(**custom_context)
               end
             end
@@ -473,8 +476,20 @@ module DiscourseAi
 
         post_streamer = PostStreamer.new(delay: Rails.env.test? ? 0 : 0.5) if stream_reply
 
+        started_thinking = false
+
         new_custom_prompts =
           bot.reply(context) do |partial, cancel, placeholder, type|
+            if type == :thinking && !started_thinking
+              reply << "<details><summary>#{I18n.t("discourse_ai.ai_bot.thinking")}</summary>"
+              started_thinking = true
+            end
+
+            if type != :thinking && started_thinking
+              reply << "</details>\n\n"
+              started_thinking = false
+            end
+
             reply << partial
             raw = reply.dup
             raw << "\n\n" << placeholder if placeholder.present?
@@ -527,8 +542,10 @@ module DiscourseAi
             )
         end
 
-        # we do not need to add a custom prompt for a single reply
-        if new_custom_prompts.length > 1
+        # a bit messy internally, but this is how we tell
+        is_thinking = new_custom_prompts.any? { |prompt| prompt[4].present? }
+
+        if is_thinking || new_custom_prompts.length > 1
           reply_post.post_custom_prompt ||= reply_post.build_post_custom_prompt(custom_prompt: [])
           prompt = reply_post.post_custom_prompt.custom_prompt || []
           prompt.concat(new_custom_prompts)

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -119,8 +119,10 @@ module DiscourseAi
           bot_user ||= User.find_by(id: mentioned[:user_id]) if mentioned
         end
 
-        # in the past we would have an edge case where we would not reply on a mention if it was
-        # also a reply this just causes confusion
+        if !mentioned && bot_user && post.reply_to_post_number && !post.reply_to_post.user&.bot?
+          # replying to a non-bot user
+          return
+        end
 
         if bot_user
           topic_persona_id = post.topic.custom_fields["ai_persona_id"]

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -119,10 +119,8 @@ module DiscourseAi
           bot_user ||= User.find_by(id: mentioned[:user_id]) if mentioned
         end
 
-        if bot_user && post.reply_to_post_number && !post.reply_to_post.user&.bot?
-          # replying to a non-bot user
-          return
-        end
+        # in the past we would have an edge case where we would not reply on a mention if it was
+        # also a reply this just causes confusion
 
         if bot_user
           topic_persona_id = post.topic.custom_fields["ai_persona_id"]

--- a/lib/automation/llm_triage.rb
+++ b/lib/automation/llm_triage.rb
@@ -17,7 +17,8 @@ module DiscourseAi
         flag_type: nil,
         automation: nil,
         max_post_tokens: nil,
-        stop_sequences: nil
+        stop_sequences: nil,
+        temperature: nil
       )
         if category_id.blank? && tags.blank? && canned_reply.blank? && hide_topic.blank? &&
              flag_post.blank?
@@ -40,7 +41,7 @@ module DiscourseAi
         result =
           llm.generate(
             prompt,
-            temperature: 0,
+            temperature: temperature,
             max_tokens: 700, # ~500 words
             user: Discourse.system_user,
             stop_sequences: stop_sequences,

--- a/lib/automation/report_runner.rb
+++ b/lib/automation/report_runner.rb
@@ -84,8 +84,8 @@ module DiscourseAi
         @top_p = top_p
         @temperature = temperature
 
-        @top_p = nil if top_p <= 0
-        @temperature = nil if temperature <= 0
+        @top_p = nil if top_p.to_f < 0
+        @temperature = nil if temperature.to_f < 0
         @suppress_notifications = suppress_notifications
 
         if !@topic_id && !@receivers.present? && !@email_receivers.present?

--- a/lib/completions/anthropic_message_processor.rb
+++ b/lib/completions/anthropic_message_processor.rb
@@ -44,13 +44,15 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
     end
   end
 
-  attr_reader :tool_calls, :input_tokens, :output_tokens
+  attr_reader :tool_calls, :input_tokens, :output_tokens, :output_thinking
 
-  def initialize(streaming_mode:, partial_tool_calls: false)
+  def initialize(streaming_mode:, partial_tool_calls: false, output_thinking: false)
     @streaming_mode = streaming_mode
     @tool_calls = []
     @current_tool_call = nil
     @partial_tool_calls = partial_tool_calls
+    @output_thinking = output_thinking
+    @thinking = nil
   end
 
   def to_tool_calls
@@ -69,13 +71,48 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
           tool_id,
           partial_tool_calls: @partial_tool_calls,
         ) if tool_name
+    elsif parsed[:type] == "content_block_start" && parsed.dig(:content_block, :type) == "thinking"
+      if @output_thinking
+        @thinking =
+          DiscourseAi::Completions::Thinking.new(
+            message: +parsed.dig(:content_block, :thinking).to_s,
+            signature: +"",
+            partial: true,
+          )
+        result = @thinking.dup
+      end
+    elsif parsed[:type] == "content_block_delta" && parsed.dig(:delta, :type) == "thinking_delta"
+      if @output_thinking
+        delta = parsed.dig(:delta, :thinking)
+        @thinking.message << delta if @thinking
+        result = DiscourseAi::Completions::Thinking.new(message: delta, partial: true)
+      end
+    elsif parsed[:type] == "content_block_delta" && parsed.dig(:delta, :type) == "signature_delta"
+      if @output_thinking
+        @thinking.signature << parsed.dig(:delta, :signature) if @thinking
+      end
+    elsif parsed[:type] == "content_block_stop" && @thinking
+      @thinking.partial = false
+      result = @thinking
+      @thinking = nil
     elsif parsed[:type] == "content_block_start" || parsed[:type] == "content_block_delta"
       if @current_tool_call
         tool_delta = parsed.dig(:delta, :partial_json).to_s
         @current_tool_call.append(tool_delta)
         result = @current_tool_call.partial_tool_call if @current_tool_call.has_partial?
+      elsif parsed.dig(:content_block, :type) == "redacted_thinking"
+        if @output_thinking
+          result =
+            DiscourseAi::Completions::Thinking.new(
+              message: nil,
+              signature: parsed.dig(:content_block, :data),
+              redacted: true,
+            )
+        end
       else
         result = parsed.dig(:delta, :text).to_s
+        # no need to return empty strings for streaming, no value
+        result = nil if result == ""
       end
     elsif parsed[:type] == "content_block_stop"
       if @current_tool_call
@@ -105,15 +142,32 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
     content = parsed.dig(:content)
     if content.is_a?(Array)
       result =
-        content.map do |data|
-          if data[:type] == "tool_use"
-            call = AnthropicToolCall.new(data[:name], data[:id])
-            call.append(data[:input].to_json)
-            call.to_tool_call
-          else
-            data[:text]
+        content
+          .map do |data|
+            if data[:type] == "tool_use"
+              call = AnthropicToolCall.new(data[:name], data[:id])
+              call.append(data[:input].to_json)
+              call.to_tool_call
+            elsif data[:type] == "thinking"
+              if @output_thinking
+                DiscourseAi::Completions::Thinking.new(
+                  message: data[:thinking],
+                  signature: data[:signature],
+                )
+              end
+            elsif data[:type] == "redacted_thinking"
+              if @output_thinking
+                DiscourseAi::Completions::Thinking.new(
+                  message: nil,
+                  signature: data[:data],
+                  redacted: true,
+                )
+              end
+            else
+              data[:text]
+            end
           end
-        end
+          .compact
     end
 
     @input_tokens = parsed.dig(:usage, :input_tokens)

--- a/lib/completions/dialects/claude.rb
+++ b/lib/completions/dialects/claude.rb
@@ -87,7 +87,30 @@ module DiscourseAi
         end
 
         def model_msg(msg)
-          { role: "assistant", content: msg[:content] }
+          if msg[:thinking] || msg[:redacted_thinking_signature]
+            content_array = []
+
+            if msg[:thinking]
+              content_array << {
+                type: "thinking",
+                thinking: msg[:thinking],
+                signature: msg[:thinking_signature],
+              }
+            end
+
+            if msg[:redacted_thinking_signature]
+              content_array << {
+                type: "redacted_thinking",
+                data: msg[:redacted_thinking_signature],
+              }
+            end
+
+            content_array << { type: "text", text: msg[:content] }
+
+            { role: "assistant", content: content_array }
+          else
+            { role: "assistant", content: msg[:content] }
+          end
         end
 
         def system_msg(msg)

--- a/lib/completions/dialects/claude_tools.rb
+++ b/lib/completions/dialects/claude_tools.rb
@@ -45,15 +45,35 @@ module DiscourseAi
 
         def from_raw_tool_call(raw_message)
           call_details = JSON.parse(raw_message[:content], symbolize_names: true)
+          result = []
+
+          if raw_message[:thinking] || raw_message[:redacted_thinking_signature]
+            if raw_message[:thinking]
+              result << {
+                type: "thinking",
+                thinking: raw_message[:thinking],
+                signature: raw_message[:thinking_signature],
+              }
+            end
+
+            if raw_message[:redacted_thinking_signature]
+              result << {
+                type: "redacted_thinking",
+                data: raw_message[:redacted_thinking_signature],
+              }
+            end
+          end
+
           tool_call_id = raw_message[:id]
-          [
-            {
-              type: "tool_use",
-              id: tool_call_id,
-              name: raw_message[:name],
-              input: call_details[:arguments],
-            },
-          ]
+
+          result << {
+            type: "tool_use",
+            id: tool_call_id,
+            name: raw_message[:name],
+            input: call_details[:arguments],
+          }
+
+          result
         end
 
         def from_raw_tool(raw_message)

--- a/lib/completions/endpoints/anthropic.rb
+++ b/lib/completions/endpoints/anthropic.rb
@@ -40,7 +40,7 @@ module DiscourseAi
 
           if llm_model.lookup_custom_param("enable_reasoning")
             reasoning_tokens =
-              llm_model.lookup_custom_param("reasoning_tokens").to_i.clamp(100, 65_536)
+              llm_model.lookup_custom_param("reasoning_tokens").to_i.clamp(1024, 65_536)
 
             # this allows for lots of tokens beyond reasoning
             options[:max_tokens] = reasoning_tokens + 30_000

--- a/lib/completions/endpoints/anthropic.rb
+++ b/lib/completions/endpoints/anthropic.rb
@@ -34,13 +34,15 @@ module DiscourseAi
 
           # Note: Anthropic requires this param
           max_tokens = 4096
-          max_tokens = 8192 if mapped_model.match?(/3.5/)
+          # 3.5 and 3.7 models have a higher token limit
+          max_tokens = 8192 if mapped_model.match?(/3.[57]/)
 
           options = { model: mapped_model, max_tokens: max_tokens }
 
+          # reasoning has even higher token limits
           if llm_model.lookup_custom_param("enable_reasoning")
             reasoning_tokens =
-              llm_model.lookup_custom_param("reasoning_tokens").to_i.clamp(1024, 65_536)
+              llm_model.lookup_custom_param("reasoning_tokens").to_i.clamp(1024, 32_768)
 
             # this allows for lots of tokens beyond reasoning
             options[:max_tokens] = reasoning_tokens + 30_000

--- a/lib/completions/endpoints/anthropic.rb
+++ b/lib/completions/endpoints/anthropic.rb
@@ -123,6 +123,7 @@ module DiscourseAi
             DiscourseAi::Completions::AnthropicMessageProcessor.new(
               streaming_mode: @streaming_mode,
               partial_tool_calls: partial_tool_calls,
+              output_thinking: output_thinking,
             )
         end
 

--- a/lib/completions/endpoints/aws_bedrock.rb
+++ b/lib/completions/endpoints/aws_bedrock.rb
@@ -24,12 +24,14 @@ module DiscourseAi
           options =
             if dialect.is_a?(DiscourseAi::Completions::Dialects::Claude)
               max_tokens = 4096
-              max_tokens = 8192 if bedrock_model_id.match?(/3.5/)
+              max_tokens = 8192 if bedrock_model_id.match?(/3.[57]/)
 
               result = { anthropic_version: "bedrock-2023-05-31" }
               if llm_model.lookup_custom_param("enable_reasoning")
+                # we require special headers to go over 64k output tokens, lets
+                # wait for feature requests before enabling this
                 reasoning_tokens =
-                  llm_model.lookup_custom_param("reasoning_tokens").to_i.clamp(1024, 65_536)
+                  llm_model.lookup_custom_param("reasoning_tokens").to_i.clamp(1024, 32_768)
 
                 # this allows for ample tokens beyond reasoning
                 max_tokens = reasoning_tokens + 30_000

--- a/lib/completions/endpoints/aws_bedrock.rb
+++ b/lib/completions/endpoints/aws_bedrock.rb
@@ -29,7 +29,7 @@ module DiscourseAi
               result = { anthropic_version: "bedrock-2023-05-31" }
               if llm_model.lookup_custom_param("enable_reasoning")
                 reasoning_tokens =
-                  llm_model.lookup_custom_param("reasoning_tokens").to_i.clamp(100, 65_536)
+                  llm_model.lookup_custom_param("reasoning_tokens").to_i.clamp(1024, 65_536)
 
                 # this allows for ample tokens beyond reasoning
                 max_tokens = reasoning_tokens + 30_000

--- a/lib/completions/endpoints/base.rb
+++ b/lib/completions/endpoints/base.rb
@@ -4,7 +4,7 @@ module DiscourseAi
   module Completions
     module Endpoints
       class Base
-        attr_reader :partial_tool_calls
+        attr_reader :partial_tool_calls, :output_thinking
 
         CompletionFailed = Class.new(StandardError)
         # 6 minutes
@@ -67,12 +67,15 @@ module DiscourseAi
           feature_name: nil,
           feature_context: nil,
           partial_tool_calls: false,
+          output_thinking: false,
           &blk
         )
           LlmQuota.check_quotas!(@llm_model, user)
           start_time = Time.now
 
           @partial_tool_calls = partial_tool_calls
+          @output_thinking = output_thinking
+
           model_params = normalize_model_params(model_params)
           orig_blk = blk
 
@@ -85,6 +88,7 @@ module DiscourseAi
                 feature_name: feature_name,
                 feature_context: feature_context,
                 partial_tool_calls: partial_tool_calls,
+                output_thinking: output_thinking,
               )
 
             wrapped = result

--- a/lib/completions/endpoints/canned_response.rb
+++ b/lib/completions/endpoints/canned_response.rb
@@ -29,7 +29,8 @@ module DiscourseAi
           model_params,
           feature_name: nil,
           feature_context: nil,
-          partial_tool_calls: false
+          partial_tool_calls: false,
+          output_thinking: false
         )
           @dialect = dialect
           @model_params = model_params
@@ -51,6 +52,8 @@ module DiscourseAi
             as_array.each do |response|
               if is_tool?(response)
                 yield(response, cancel_fn)
+              elsif is_thinking?(response)
+                yield(response, cancel_fn)
               else
                 response.each_char do |char|
                   break if cancelled
@@ -69,6 +72,10 @@ module DiscourseAi
         end
 
         private
+
+        def is_thinking?(response)
+          response.is_a?(DiscourseAi::Completions::Thinking)
+        end
 
         def is_tool?(response)
           response.is_a?(DiscourseAi::Completions::ToolCall)

--- a/lib/completions/endpoints/fake.rb
+++ b/lib/completions/endpoints/fake.rb
@@ -122,7 +122,7 @@ module DiscourseAi
           feature_name: nil,
           feature_context: nil,
           partial_tool_calls: false,
-          ouput_thinking: false
+          output_thinking: false
         )
           last_call = { dialect: dialect, user: user, model_params: model_params }
           self.class.last_call = last_call

--- a/lib/completions/endpoints/fake.rb
+++ b/lib/completions/endpoints/fake.rb
@@ -121,7 +121,8 @@ module DiscourseAi
           model_params = {},
           feature_name: nil,
           feature_context: nil,
-          partial_tool_calls: false
+          partial_tool_calls: false,
+          ouput_thinking: false
         )
           last_call = { dialect: dialect, user: user, model_params: model_params }
           self.class.last_call = last_call

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -42,6 +42,7 @@ module DiscourseAi
           feature_name: nil,
           feature_context: nil,
           partial_tool_calls: false,
+          output_thinkings: false,
           &blk
         )
           @disable_native_tools = dialect.disable_native_tools?

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -42,7 +42,7 @@ module DiscourseAi
           feature_name: nil,
           feature_context: nil,
           partial_tool_calls: false,
-          output_thinkings: false,
+          output_thinking: false,
           &blk
         )
           @disable_native_tools = dialect.disable_native_tools?

--- a/lib/completions/llm.rb
+++ b/lib/completions/llm.rb
@@ -172,8 +172,9 @@ module DiscourseAi
           @canned_response = DiscourseAi::Completions::Endpoints::CannedResponse.new(responses)
           @canned_llm = llm
           @prompts = []
+          @prompt_options = []
 
-          yield(@canned_response, llm, @prompts)
+          yield(@canned_response, llm, @prompts, @prompt_options)
         ensure
           # Don't leak prepared response if there's an exception.
           @canned_response = nil
@@ -181,8 +182,13 @@ module DiscourseAi
           @prompts = nil
         end
 
-        def record_prompt(prompt)
+        def record_prompt(prompt, options)
           @prompts << prompt.dup if @prompts
+          @prompt_options << options if @prompt_options
+        end
+
+        def prompt_options
+          @prompt_options
         end
 
         def prompts
@@ -254,7 +260,20 @@ module DiscourseAi
         output_thinking: false,
         &partial_read_blk
       )
-        self.class.record_prompt(prompt)
+        self.class.record_prompt(
+          prompt,
+          {
+            temperature: temperature,
+            top_p: top_p,
+            max_tokens: max_tokens,
+            stop_sequences: stop_sequences,
+            user: user,
+            feature_name: feature_name,
+            feature_context: feature_context,
+            partial_tool_calls: partial_tool_calls,
+            output_thinking: output_thinking,
+          },
+        )
 
         model_params = { max_tokens: max_tokens, stop_sequences: stop_sequences }
 

--- a/lib/completions/llm.rb
+++ b/lib/completions/llm.rb
@@ -234,6 +234,7 @@ module DiscourseAi
       # @param feature_name { String - Optional } - The feature name to use for the completion.
       # @param feature_context { Hash - Optional } - The feature context to use for the completion.
       # @param partial_tool_calls { Boolean - Optional } - If true, the completion will return partial tool calls.
+      # @param output_thinking { Boolean - Optional } - If true, the completion will return the thinking output for thinking models.
       #
       # @param &on_partial_blk { Block - Optional } - The passed block will get called with the LLM partial response alongside a cancel function.
       #
@@ -250,6 +251,7 @@ module DiscourseAi
         feature_name: nil,
         feature_context: nil,
         partial_tool_calls: false,
+        output_thinking: false,
         &partial_read_blk
       )
         self.class.record_prompt(prompt)
@@ -285,6 +287,7 @@ module DiscourseAi
           feature_name: feature_name,
           feature_context: feature_context,
           partial_tool_calls: partial_tool_calls,
+          output_thinking: output_thinking,
           &partial_read_blk
         )
       end

--- a/lib/completions/prompt.rb
+++ b/lib/completions/prompt.rb
@@ -41,12 +41,26 @@ module DiscourseAi
         @tool_choice = tool_choice
       end
 
-      def push(type:, content:, id: nil, name: nil, upload_ids: nil)
+      def push(
+        type:,
+        content:,
+        id: nil,
+        name: nil,
+        upload_ids: nil,
+        thinking: nil,
+        thinking_signature: nil,
+        redacted_thinking_signature: nil
+      )
         return if type == :system
         new_message = { type: type, content: content }
         new_message[:name] = name.to_s if name
         new_message[:id] = id.to_s if id
         new_message[:upload_ids] = upload_ids if upload_ids
+        new_message[:thinking] = thinking if thinking
+        new_message[:thinking_signature] = thinking_signature if thinking_signature
+        new_message[
+          :redacted_thinking_signature
+        ] = redacted_thinking_signature if redacted_thinking_signature
 
         validate_message(new_message)
         validate_turn(messages.last, new_message)
@@ -73,7 +87,16 @@ module DiscourseAi
           raise ArgumentError, "message type must be one of #{valid_types}"
         end
 
-        valid_keys = %i[type content id name upload_ids]
+        valid_keys = %i[
+          type
+          content
+          id
+          name
+          upload_ids
+          thinking
+          thinking_signature
+          redacted_thinking_signature
+        ]
         if (invalid_keys = message.keys - valid_keys).any?
           raise ArgumentError, "message contains invalid keys: #{invalid_keys}"
         end

--- a/lib/completions/prompt_messages_builder.rb
+++ b/lib/completions/prompt_messages_builder.rb
@@ -102,7 +102,7 @@ module DiscourseAi
         end
       end
 
-      def push(type:, content:, name: nil, upload_ids: nil, id: nil)
+      def push(type:, content:, name: nil, upload_ids: nil, id: nil, thinking: nil)
         if !%i[user model tool tool_call system].include?(type)
           raise ArgumentError, "type must be either :user, :model, :tool, :tool_call or :system"
         end
@@ -112,6 +112,15 @@ module DiscourseAi
         message[:name] = name.to_s if name
         message[:upload_ids] = upload_ids if upload_ids
         message[:id] = id.to_s if id
+        if thinking
+          message[:thinking] = thinking["thinking"] if thinking["thinking"]
+          message[:thinking_signature] = thinking["thinking_signature"] if thinking[
+            "thinking_signature"
+          ]
+          message[:redacted_thinking_signature] = thinking[
+            "redacted_thinking_signature"
+          ] if thinking["redacted_thinking_signature"]
+        end
 
         @raw_messages << message
       end

--- a/lib/completions/thinking.rb
+++ b/lib/completions/thinking.rb
@@ -12,6 +12,10 @@ module DiscourseAi
         @partial = partial
       end
 
+      def partial?
+        !!@partial
+      end
+
       def ==(other)
         message == other.message && signature == other.signature && redacted == other.redacted &&
           partial == other.partial

--- a/lib/completions/thinking.rb
+++ b/lib/completions/thinking.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Completions
+    class Thinking
+      attr_accessor :message, :signature, :redacted, :partial
+
+      def initialize(message:, signature: nil, redacted: false, partial: false)
+        @message = message
+        @signature = signature
+        @redacted = redacted
+        @partial = partial
+      end
+
+      def ==(other)
+        message == other.message && signature == other.signature && redacted == other.redacted &&
+          partial == other.partial
+      end
+
+      def dup
+        Thinking.new(
+          message: message.dup,
+          signature: signature.dup,
+          redacted: redacted,
+          partial: partial,
+        )
+      end
+
+      def to_s
+        "#{message} - #{signature} - #{redacted} - #{partial}"
+      end
+    end
+  end
+end

--- a/spec/lib/completions/anthropic_message_processor_spec.rb
+++ b/spec/lib/completions/anthropic_message_processor_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+describe DiscourseAi::Completions::AnthropicMessageProcessor do
+  it "correctly handles and combines partial thinking chunks into complete thinking objects" do
+    processor =
+      DiscourseAi::Completions::AnthropicMessageProcessor.new(
+        streaming_mode: true,
+        partial_tool_calls: false,
+        output_thinking: true,
+      )
+
+    # Simulate streaming thinking output in multiple chunks
+    result1 =
+      processor.process_streamed_message(
+        { type: "content_block_start", content_block: { type: "thinking", thinking: "" } },
+      )
+
+    result2 =
+      processor.process_streamed_message(
+        {
+          type: "content_block_delta",
+          delta: {
+            type: "thinking_delta",
+            thinking: "First part of thinking",
+          },
+        },
+      )
+
+    result3 =
+      processor.process_streamed_message(
+        {
+          type: "content_block_delta",
+          delta: {
+            type: "thinking_delta",
+            thinking: " and second part",
+          },
+        },
+      )
+
+    _result4 =
+      processor.process_streamed_message(
+        {
+          type: "content_block_delta",
+          delta: {
+            type: "signature_delta",
+            signature: "thinking-sig-123",
+          },
+        },
+      )
+
+    # Finish the thinking block
+    final_result = processor.process_streamed_message({ type: "content_block_stop" })
+
+    # Verify the partial thinking chunks
+    expect(result1).to be_a(DiscourseAi::Completions::Thinking)
+    expect(result1.message).to eq("")
+    expect(result1.partial?).to eq(true)
+
+    expect(result2).to be_a(DiscourseAi::Completions::Thinking)
+    expect(result2.message).to eq("First part of thinking")
+    expect(result2.partial?).to eq(true)
+
+    expect(result3).to be_a(DiscourseAi::Completions::Thinking)
+    expect(result3.message).to eq(" and second part")
+    expect(result3.partial?).to eq(true)
+
+    # Verify the final complete thinking object
+    expect(final_result).to be_a(DiscourseAi::Completions::Thinking)
+    expect(final_result.message).to eq("First part of thinking and second part")
+    expect(final_result.signature).to eq("thinking-sig-123")
+    expect(final_result.partial?).to eq(false)
+  end
+end

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -828,6 +828,59 @@ RSpec.describe DiscourseAi::AiBot::Playground do
   end
 
   describe "#reply_to" do
+    it "preserves thinking context between replies" do
+      thinking_progress =
+        DiscourseAi::Completions::Thinking.new(message: "I should say hello", partial: true)
+      thinking =
+        DiscourseAi::Completions::Thinking.new(
+          message: "I should say hello",
+          signature: "thinking-signature-123",
+          partial: false,
+        )
+
+      thinking_redacted =
+        DiscourseAi::Completions::Thinking.new(
+          message: nil,
+          signature: "thinking-redacted-signature-123",
+          partial: false,
+          redacted: true,
+        )
+
+      first_responses = [[thinking_progress, thinking, thinking_redacted, "Hello Sam"]]
+
+      DiscourseAi::Completions::Llm.with_prepared_responses(first_responses) do
+        playground.reply_to(third_post)
+      end
+
+      new_post = third_post.topic.reload.posts.order(:post_number).last
+      expect(new_post.raw).to include("Hello Sam")
+      expect(new_post.raw).to include("I should say hello")
+
+      post = Fabricate(:post, topic: third_post.topic, user: user, raw: "Say Cat")
+
+      prompt_detail = nil
+      # Capture the prompt to verify thinking context was included
+      DiscourseAi::Completions::Llm.with_prepared_responses(["Cat"]) do |_, _, prompts|
+        playground.reply_to(post)
+        prompt_detail = prompts.first
+      end
+
+      last_messages = prompt_detail.messages.last(2)
+
+      expect(last_messages).to eq(
+        [
+          {
+            type: :model,
+            content: "Hello Sam",
+            thinking: "I should say hello",
+            thinking_signature: "thinking-signature-123",
+            redacted_thinking_signature: "thinking-redacted-signature-123",
+          },
+          { type: :user, content: "Say Cat", id: "bruce1" },
+        ],
+      )
+    end
+
     it "streams the bot reply through MB and create a new post in the PM with a cooked responses" do
       expected_bot_response =
         "Hello this is a bot and what you just said is an interesting question"

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -828,7 +828,7 @@ RSpec.describe DiscourseAi::AiBot::Playground do
   end
 
   describe "#reply_to" do
-    it "preserves thinking context between replies" do
+    it "preserves thinking context between replies and correctly renders" do
       thinking_progress =
         DiscourseAi::Completions::Thinking.new(message: "I should say hello", partial: true)
       thinking =
@@ -853,7 +853,9 @@ RSpec.describe DiscourseAi::AiBot::Playground do
       end
 
       new_post = third_post.topic.reload.posts.order(:post_number).last
+      # confirm message is there
       expect(new_post.raw).to include("Hello Sam")
+      # confirm thinking is there
       expect(new_post.raw).to include("I should say hello")
 
       post = Fabricate(:post, topic: third_post.topic, user: user, raw: "Say Cat")

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -876,7 +876,7 @@ RSpec.describe DiscourseAi::AiBot::Playground do
             thinking_signature: "thinking-signature-123",
             redacted_thinking_signature: "thinking-redacted-signature-123",
           },
-          { type: :user, content: "Say Cat", id: "bruce1" },
+          { type: :user, content: "Say Cat", id: user.username },
         ],
       )
     end


### PR DESCRIPTION
This PR adds support for "thinking tokens" - a feature that exposes the model's reasoning process before providing the final response. Key improvements include:

- Add a new Thinking class to handle thinking content from LLMs
- Modify endpoints (Claude, AWS Bedrock) to handle thinking output
- Update AI bot to display thinking in collapsible details section
- Fix SEARCH/REPLACE blocks to support empty replacement strings
- Allow configurable temperature in triage and report automations
- Various bug fixes and improvements to diff parsing