### PR TITLE
UX: add links to sentiment to admin sidebar

### DIFF
--- a/assets/javascripts/discourse/templates/admin-dashboard-sentiment.hbs
+++ b/assets/javascripts/discourse/templates/admin-dashboard-sentiment.hbs
@@ -1,7 +1,7 @@
 <div class="sentiment section">
   <div class="period-section">
     <div class="section-title">
-      <h2>
+      <h2 id="sentiment-heading">
         {{i18n "discourse_ai.sentiments.dashboard.title"}}
       </h2>
 

--- a/assets/javascripts/initializers/ai-sentiment-admin-nav.js
+++ b/assets/javascripts/initializers/ai-sentiment-admin-nav.js
@@ -1,0 +1,21 @@
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer("1.15.0", (api) => {
+  const settings = api.container.lookup("service:site-settings");
+
+  if (settings.ai_sentiment_enabled) {
+    api.addAdminSidebarSectionLink("reports", {
+      name: "sentiment_overview",
+      href: "/admin/dashboard/sentiment#sentiment-heading",
+      label: "discourse_ai.sentiments.sidebar.overview",
+      icon: "chart-column",
+    });
+    api.addAdminSidebarSectionLink("reports", {
+      name: "sentiment_analysis",
+      route: "adminReports.show",
+      routeModels: ["sentiment_analysis"],
+      label: "discourse_ai.sentiments.sidebar.analysis",
+      icon: "chart-pie",
+    });
+  }
+});

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -652,6 +652,9 @@ en:
       sentiments:
         dashboard:
           title: "Sentiment"
+        sidebar:
+          overview: "Sentiment overview"
+          analysis: "Sentiment analysis"
         sentiment_analysis:
           filter_types:
             all: "All"

--- a/plugin.rb
+++ b/plugin.rb
@@ -123,6 +123,7 @@ after_initialize do
   end
 
   plugin_icons = %w[
+    chart-column
     spell-check
     language
     images


### PR DESCRIPTION
Adds these links to make the sentiment pages easier to access

![image](https://github.com/user-attachments/assets/ee5e5bef-0889-44cc-a3b1-94f497a20c8d)

I've added an anchor to the sentiment dashboard because otherwise the hosted site plugin can push it below the visible area, which makes the link appear to be broken 