### PR TITLE
FIX: Use `route` for admin sentiment sidebar links

### DIFF
--- a/assets/javascripts/initializers/ai-sentiment-admin-nav.js
+++ b/assets/javascripts/initializers/ai-sentiment-admin-nav.js
@@ -6,7 +6,7 @@ export default apiInitializer("1.15.0", (api) => {
   if (settings.ai_sentiment_enabled) {
     api.addAdminSidebarSectionLink("reports", {
       name: "sentiment_overview",
-      href: "/admin/dashboard/sentiment#sentiment-heading",
+      route: "admin.dashboardSentiment",
       label: "discourse_ai.sentiments.sidebar.overview",
       icon: "chart-column",
     });


### PR DESCRIPTION
Minor, but there is a core bug when using `href` at the moment,
this fixes the issue, and I will do more in core separately.
