### PR TITLE
DEV: Use full URL for problem check message

### DIFF
--- a/app/services/problem_check/ai_llm_status.rb
+++ b/app/services/problem_check/ai_llm_status.rb
@@ -8,10 +8,6 @@ class ProblemCheck::AiLlmStatus < ProblemCheck
     llm_errors
   end
 
-  def base_path
-    Discourse.base_path
-  end
-
   private
 
   def llm_errors
@@ -26,20 +22,21 @@ class ProblemCheck::AiLlmStatus < ProblemCheck
       blk.call
       nil
     rescue => e
-      error_message = parse_error_message(e.message)
-      message =
-        "#{I18n.t("dashboard.problem.ai_llm_status", { base_path: base_path, model_name: model.display_name, model_id: model.id })}"
+      details = {
+        model_id: model.id,
+        model_name: model.display_name,
+        error: parse_error_message(e.message),
+        url: "#{Discourse.base_path}/admin/plugins/discourse-ai/ai-llms/#{model.id}/edit",
+      }
+
+      message = I18n.t("dashboard.problem.ai_llm_status", details)
 
       Problem.new(
         message,
         priority: "high",
         identifier: "ai_llm_status",
         target: model.id,
-        details: {
-          model_id: model.id,
-          model_name: model.display_name,
-          error: error_message,
-        },
+        details:,
       )
     end
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -484,4 +484,4 @@ en:
       prompt_message_length: The message %{idx} is over the 1000 character limit.
   dashboard:
     problem:
-      ai_llm_status: "The LLM model: %{model_name} is encountering issues. Please check the <a href='%{base_path}/admin/plugins/discourse-ai/ai-llms/%{model_id}/edit'>model's configuration page</a>."
+      ai_llm_status: "The LLM model: %{model_name} is encountering issues. Please check the <a href='%{url}'>model's configuration page</a>."

--- a/spec/services/problem_check/ai_llm_status_spec.rb
+++ b/spec/services/problem_check/ai_llm_status_spec.rb
@@ -42,7 +42,13 @@ RSpec.describe ProblemCheck::AiLlmStatus do
       it "returns a problem with an LLM model" do
         stub_request(:post, post_url).to_return(status: 403, body: error_response, headers: {})
         message =
-          "#{I18n.t("dashboard.problem.ai_llm_status", { base_path: Discourse.base_path, model_name: llm_model.display_name, model_id: llm_model.id })}"
+          I18n.t(
+            "dashboard.problem.ai_llm_status",
+            {
+              model_name: llm_model.display_name,
+              url: "/admin/plugins/discourse-ai/ai-llms/#{llm_model.id}/edit",
+            },
+          )
 
         expect(described_class.new.call).to contain_exactly(
           have_attributes(
@@ -53,6 +59,7 @@ RSpec.describe ProblemCheck::AiLlmStatus do
             details: {
               model_id: llm_model.id,
               model_name: llm_model.display_name,
+              url: "/admin/plugins/discourse-ai/ai-llms/#{llm_model.id}/edit",
               error: JSON.parse(error_response)["message"],
             },
           ),


### PR DESCRIPTION
### What is this change?

Better to construct the URL in Ruby and pass it to `I18n`, so we don't have to mess with the translations if the URL changes.

**Screenshot:**

<img width="802" alt="Screenshot 2025-03-05 at 10 52 33 AM" src="https://github.com/user-attachments/assets/a75cce6b-9ba7-4459-89a4-9054b55e4a6a" />
