### PR TITLE
DEV: update display name field in AiLlmEditorForm to show more relevant tooltip

### DIFF
--- a/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
+++ b/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
@@ -275,7 +275,7 @@ export default class AiLlmEditorForm extends Component {
         @validation="required|length:1,100"
         @disabled={{this.seeded}}
         @format="large"
-        @tooltip={{i18n "discourse_ai.llms.hints.max_prompt_tokens"}}
+        @tooltip={{i18n "discourse_ai.llms.hints.display_name"}}
         as |field|
       >
         <field.Input />

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -432,6 +432,7 @@ en:
 
         hints:
           max_prompt_tokens: "Max numbers of tokens for the prompt. As a rule of thumb, this should be 50% of the model's context window."
+          display_name: "The name used to reference this model across your site's interface."
           name: "We include this in the API call to specify which model we'll use"
           vision_enabled: "If enabled, the AI will attempt to understand images. It depends on the model being used supporting vision. Supported by latest models from Anthropic, Google, and OpenAI."
           enabled_chat_bot: "If enabled, users can select this model when creating PMs with the AI bot"


### PR DESCRIPTION
Noticed the content for this field was wrong:

<img width="503" alt="before-screenshot" src="https://github.com/user-attachments/assets/f302529f-0ce5-4166-a9d9-11c8e2841e31" />

With this change:

<img width="503" alt="after-screenshot" src="https://github.com/user-attachments/assets/785f3f31-a39e-4299-80a9-7e21977ab380" />
