### PR TITLE
DEV: Add Ai summary persona siteSettings WIP

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -358,3 +358,12 @@ discourse_ai:
   ai_rag_images_enabled:
     default: false
     hidden: true
+
+  ai_summary_persona_id:
+    default: ""
+    client: true
+    hidden: true
+  ai_summary_consolidator_persona_id:
+    default: ""
+    client: true
+    hidden: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -361,9 +361,7 @@ discourse_ai:
 
   ai_summary_persona_id:
     default: ""
-    client: true
     hidden: true
   ai_summary_consolidator_persona_id:
     default: ""
-    client: true
     hidden: true

--- a/spec/lib/modules/summarization/strategies/topic_summary_spec.rb
+++ b/spec/lib/modules/summarization/strategies/topic_summary_spec.rb
@@ -64,18 +64,23 @@ RSpec.describe DiscourseAi::Summarization::Strategies::TopicSummary do
     end
   end
 
-  describe "#summary_extension_prompt" do
+  describe "Summary prompt" do
+    let!(:ai_persona) do
+      AiPersona.create!(
+        name: "TestPersona",
+        system_prompt: "test prompt",
+        description: "test",
+        allowed_group_ids: [Group::AUTO_GROUPS[:trust_level_0]],
+      )
+    end
+
+    let!(:persona_class) do
+      DiscourseAi::AiBot::Personas::Persona.find_by(user: admin, name: "TestPersona")
+    end
+
     context "when ai_summary_consolidator_persona_id siteSetting is set" do
-      it "returns a prompt with the correct text" do
-        AiPersona.create!(
-          name: "TestPersona",
-          system_prompt: "test prompt",
-          description: "test",
-          allowed_group_ids: [Group::AUTO_GROUPS[:trust_level_0]],
-        )
-        personaClass =
-          DiscourseAi::AiBot::Personas::Persona.find_by(user: admin, name: "TestPersona")
-        SiteSetting.ai_summary_consolidator_persona_id = personaClass.id
+      it "returns a summary extension prompt with the correct text" do
+        SiteSetting.ai_summary_consolidator_persona_id = persona_class.id
 
         expect(
           topic_summary
@@ -87,20 +92,10 @@ RSpec.describe DiscourseAi::Summarization::Strategies::TopicSummary do
         ).to include("test prompt")
       end
     end
-  end
 
-  describe "#first_summary_prompt" do
     context "when ai_summary_persona_id siteSetting is set" do
-      it "returns a prompt with the correct text" do
-        AiPersona.create!(
-          name: "TestPersona",
-          system_prompt: "test prompt",
-          description: "test",
-          allowed_group_ids: [Group::AUTO_GROUPS[:trust_level_0]],
-        )
-        personaClass =
-          DiscourseAi::AiBot::Personas::Persona.find_by(user: admin, name: "TestPersona")
-        SiteSetting.ai_summary_persona_id = personaClass.id
+      it "returns a first summary prompt with the correct text" do
+        SiteSetting.ai_summary_persona_id = persona_class.id
 
         expect(
           topic_summary


### PR DESCRIPTION
## Background

Meta topic that brings up this change:
https://meta.discourse.org/t/ai-summarization-formatting-and-bugs/351163

## Changes 

This PR adds hidden site settings to the AI plugin:

- ai_summary_persona_id 
- ai_summary_consolidator_persona_id 

Then in the Ai summary methods, we see if those site settings are filled in. If so, we grab the prompt from the persona. If not, we use what is there now.