### PR TITLE
FEATURE: Add persona-based replies and whisper support to LLM triage

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -146,6 +146,12 @@ en:
             include_personal_messages:
               label: "Include personal messages"
               description: "Also scan and triage personal messages"
+            whisper:
+              label: "Reply as Whisper"
+              description: "Whether the AI's response should be a whisper"
+            reply_persona:
+              label: "Reply Persona"
+              description: "AI Persona to use for replies (must have default LLM), will be prioritized over canned reply"
             model:
               label: "Model"
               description: "Language model used for triage"

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -162,6 +162,20 @@ module DiscourseAi
         end
       end
 
+      def self.reply_to_post(post:, user: nil, persona_id: nil, whisper: nil)
+        ai_persona = AiPersona.find_by(id: persona_id)
+        raise Discourse::InvalidParameters.new(:persona_id) if !ai_persona
+        persona_class = ai_persona.class_instance
+        persona = persona_class.new
+
+        bot_user = user || ai_persona.user
+        raise Discourse::InvalidParameters.new(:user) if bot_user.nil?
+        bot = DiscourseAi::AiBot::Bot.as(bot_user, persona: persona)
+        playground = DiscourseAi::AiBot::Playground.new(bot)
+
+        playground.reply_to(post, whisper: whisper, context_style: :topic)
+      end
+
       def initialize(bot)
         @bot = bot
       end

--- a/lib/automation.rb
+++ b/lib/automation.rb
@@ -38,18 +38,17 @@ module DiscourseAi
       values
     end
 
-    def self.available_persona_choices
-      AiPersona
-        .joins(:user)
-        .where.not(user_id: nil)
-        .where.not(default_llm: nil)
-        .map do |persona|
-          {
-            id: persona.id,
-            translated_name: persona.name,
-            description: "#{persona.name} (#{persona.user.username})",
-          }
-        end
+    def self.available_persona_choices(require_user: true, require_default_llm: true)
+      relation = AiPersona.joins(:user)
+      relation = relation.where.not(user_id: nil) if require_user
+      relation = relation.where.not(default_llm: nil) if require_default_llm
+      relation.map do |persona|
+        {
+          id: persona.id,
+          translated_name: persona.name,
+          description: "#{persona.name} (#{persona.user.username})",
+        }
+      end
     end
   end
 end

--- a/lib/automation/llm_persona_triage.rb
+++ b/lib/automation/llm_persona_triage.rb
@@ -3,21 +3,16 @@ module DiscourseAi
   module Automation
     module LlmPersonaTriage
       def self.handle(post:, persona_id:, whisper: false, automation: nil)
-        ai_persona = AiPersona.find_by(id: persona_id)
-        return if ai_persona.nil?
-
-        persona_class = ai_persona.class_instance
-        persona = persona_class.new
-
-        bot_user = ai_persona.user
-        return if bot_user.nil?
-
-        bot = DiscourseAi::AiBot::Bot.as(bot_user, persona: persona)
-        playground = DiscourseAi::AiBot::Playground.new(bot)
-
-        playground.reply_to(post, whisper: whisper, context_style: :topic)
+        DiscourseAi::AiBot::Playground.reply_to_post(
+          post: post,
+          persona_id: persona_id,
+          whisper: whisper,
+        )
       rescue => e
-        Rails.logger.error("Error in LlmPersonaTriage: #{e.message}\n#{e.backtrace.join("\n")}")
+        Discourse.warn_exception(
+          e,
+          message: "Error responding to: #{post&.url} in LlmPersonaTriage.handle",
+        )
         raise e if Rails.env.test?
         nil
       end

--- a/lib/completions/endpoints/aws_bedrock.rb
+++ b/lib/completions/endpoints/aws_bedrock.rb
@@ -219,6 +219,8 @@ module DiscourseAi
             @processor ||=
               DiscourseAi::Completions::AnthropicMessageProcessor.new(
                 streaming_mode: @streaming_mode,
+                partial_tool_calls: partial_tool_calls,
+                output_thinking: output_thinking,
               )
           else
             @processor ||=

--- a/spec/lib/discourse_automation/llm_triage_spec.rb
+++ b/spec/lib/discourse_automation/llm_triage_spec.rb
@@ -123,4 +123,84 @@ describe DiscourseAi::Automation::LlmTriage do
     last_post = post.topic.reload.posts.order(:post_number).last
     expect(last_post.raw).to eq post.raw
   end
+
+  it "can respond using an AI persona when configured" do
+    bot_user = Fabricate(:user, username: "ai_assistant")
+    ai_persona =
+      Fabricate(
+        :ai_persona,
+        name: "Help Bot",
+        description: "AI assistant for forum help",
+        system_prompt: "You are a helpful forum assistant",
+        default_llm: llm_model,
+        user_id: bot_user.id,
+      )
+
+    # Configure the automation to use the persona instead of canned reply
+    add_automation_field("canned_reply", nil, type: "message") # Clear canned reply
+    add_automation_field("reply_persona", ai_persona.id, type: "choices")
+    add_automation_field("whisper", true, type: "boolean")
+
+    post = Fabricate(:post, raw: "I need help with a problem")
+
+    ai_response = "I'll help you with your problem!"
+
+    # Set up the test to provide both the triage and the persona responses
+    DiscourseAi::Completions::Llm.with_prepared_responses(["bad", ai_response]) do
+      automation.running_in_background!
+      automation.trigger!({ "post" => post })
+    end
+
+    # Verify the response was created
+    topic = post.topic.reload
+    last_post = topic.posts.order(:post_number).last
+
+    # Verify the AI persona's user created the post
+    expect(last_post.user_id).to eq(bot_user.id)
+
+    # Verify the content matches the AI response
+    expect(last_post.raw).to eq(ai_response)
+
+    # Verify it's a whisper post (since we set whisper: true)
+    expect(last_post.post_type).to eq(Post.types[:whisper])
+  end
+
+  it "does not create replies when the action is edit" do
+    # Set up bot user and persona
+    bot_user = Fabricate(:user, username: "helper_bot")
+    ai_persona =
+      Fabricate(
+        :ai_persona,
+        name: "Edit Helper",
+        description: "AI assistant for editing",
+        system_prompt: "You help with editing",
+        default_llm: llm_model,
+        user_id: bot_user.id,
+      )
+
+    # Configure the automation with both reply methods
+    add_automation_field("canned_reply", "This is a canned reply", type: "message")
+    add_automation_field("reply_persona", ai_persona.id, type: "choices")
+
+    # Create a post and capture its topic
+    post = Fabricate(:post, raw: "This needs to be evaluated")
+    topic = post.topic
+
+    # Get initial post count
+    initial_post_count = topic.posts.count
+
+    # Run automation with action: :edit and a matching response
+    DiscourseAi::Completions::Llm.with_prepared_responses(["bad"]) do
+      automation.running_in_background!
+      automation.trigger!({ "post" => post, "action" => :edit })
+    end
+
+    # Topic should be updated (if configured) but no new posts
+    topic.reload
+    expect(topic.posts.count).to eq(initial_post_count)
+
+    # Verify no replies were created
+    last_post = topic.posts.order(:post_number).last
+    expect(last_post.id).to eq(post.id)
+  end
 end


### PR DESCRIPTION
This PR enhances the LLM triage automation with several important improvements:

- Add ability to use AI personas for automated replies instead of canned replies
- Add support for whisper responses
- Refactor LLM persona reply functionality into a reusable method
- Add new settings to configure response behavior in automations
- Improve error handling and logging
- Fix handling of personal messages in the triage flow
- Add comprehensive test coverage for new features
- Make personas configurable with more flexible requirements

This allows for more dynamic and context-aware responses in automated workflows, with better control over visibility and attribution.
