### PR TITLE
DEV: Don't classify post sentiments on creation.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,7 +18,7 @@ discourse_ai:
     default: ""
     json_schema: DiscourseAi::Sentiment::SentimentSiteSettingJsonSchema
   ai_sentiment_backfill_maximum_posts_per_hour:
-    default: 250
+    default: 2500
     min: 0
     max: 10000
     hidden: true

--- a/lib/sentiment/entry_point.rb
+++ b/lib/sentiment/entry_point.rb
@@ -11,7 +11,6 @@ module DiscourseAi
             end
           end
 
-        plugin.on(:post_created, &sentiment_analysis_cb)
         plugin.on(:post_edited, &sentiment_analysis_cb)
 
         plugin.add_to_serializer(:current_user, :can_see_sentiment_reports) do

--- a/spec/lib/modules/sentiment/entry_point_spec.rb
+++ b/spec/lib/modules/sentiment/entry_point_spec.rb
@@ -6,28 +6,6 @@ RSpec.describe DiscourseAi::Sentiment::EntryPoint do
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
   describe "registering event callbacks" do
-    context "when creating a post" do
-      let(:creator) do
-        PostCreator.new(
-          user,
-          raw: "this is the new content for my topic",
-          title: "this is my new topic title",
-        )
-      end
-
-      it "queues a job on create if sentiment analysis is enabled" do
-        SiteSetting.ai_sentiment_enabled = true
-
-        expect { creator.create }.to change(Jobs::PostSentimentAnalysis.jobs, :size).by(1)
-      end
-
-      it "does nothing if sentiment analysis is disabled" do
-        SiteSetting.ai_sentiment_enabled = false
-
-        expect { creator.create }.not_to change(Jobs::PostSentimentAnalysis.jobs, :size)
-      end
-    end
-
     context "when editing a post" do
       fab!(:post) { Fabricate(:post, user: user) }
       let(:revisor) { PostRevisor.new(post) }


### PR DESCRIPTION
We'll rely on the backfill instead, which runs every five minutes. Bump default batch size x10 to avoid lagging.