### PR TITLE
FIX: prevents double escaping of filters

### DIFF
--- a/assets/javascripts/discourse/components/admin-report-sentiment-analysis.gjs
+++ b/assets/javascripts/discourse/components/admin-report-sentiment-analysis.gjs
@@ -219,6 +219,7 @@ export default class AdminReportSentimentAnalysis extends Component {
     this.router.transitionTo(this.router.currentRoute.name, {
       queryParams: {
         ...currentQueryParams,
+        filters: JSON.parse(currentQueryParams.filters), // avoids a double escaping
         selectedChart: data.title,
       },
     });


### PR DESCRIPTION
We were passing: `{"category": 4}` which was then escape by Ember, basically causing a double Json stringify and preventing code to work down the road.