### PR TITLE
DEV: Ai summary utilizing name instead of username

### DIFF
--- a/lib/summarization/strategies/topic_summary.rb
+++ b/lib/summarization/strategies/topic_summary.rb
@@ -13,11 +13,18 @@ module DiscourseAi
         end
 
         def targets_data
+          name_or_username =
+            if SiteSetting.enable_names && !SiteSetting.prioritize_username_in_ux
+              :name || :username
+            else
+              :username
+            end
+
           posts_data =
             (target.has_summary? ? best_replies : pick_selection).pluck(
               :post_number,
               :raw,
-              :username,
+              name_or_username,
               :last_version_at,
             )
 

--- a/spec/lib/modules/summarization/strategies/topic_summary_spec.rb
+++ b/spec/lib/modules/summarization/strategies/topic_summary_spec.rb
@@ -61,5 +61,21 @@ RSpec.describe DiscourseAi::Summarization::Strategies::TopicSummary do
         expect(op_content).to include(topic_embed.embed_content_cache)
       end
     end
+
+    context "when enable_names enabled and prioritize_username_in_ux disabled" do
+      fab!(:user) { Fabricate(:user, name: "test") }
+
+      it "includes the name" do
+        SiteSetting.enable_names = true
+        SiteSetting.prioritize_username_in_ux = false
+
+        post_1.update!(user: user)
+
+        content = topic_summary.targets_data
+        poster_name = content.first[:poster]
+
+        expect(poster_name).to eq("test")
+      end
+    end
   end
 end

--- a/spec/lib/modules/summarization/strategies/topic_summary_spec.rb
+++ b/spec/lib/modules/summarization/strategies/topic_summary_spec.rb
@@ -77,5 +77,21 @@ RSpec.describe DiscourseAi::Summarization::Strategies::TopicSummary do
         expect(poster_name).to eq("test")
       end
     end
+
+    context "when enable_names enabled and prioritize_username_in_ux enabled" do
+      fab!(:user) { Fabricate(:user, username: "test") }
+
+      it "includes the username" do
+        SiteSetting.enable_names = true
+        SiteSetting.prioritize_username_in_ux = true
+
+        post_1.update!(user: user)
+
+        content = topic_summary.targets_data
+        poster_name = content.first[:poster]
+
+        expect(poster_name).to eq("test")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes

This PR lets Ai summarization to utilize name instead of username when `enable_names` is enabled and `prioritize_username_in_ux` is disabled.

<img width="533" alt="Screenshot 2025-03-10 at 3 45 27 PM" src="https://github.com/user-attachments/assets/600de137-29ed-452d-80ba-cdd45263ee3b" />