### PR TITLE
DEV: fix Zeitwerk issue with SpamScanner class

### DIFF
--- a/lib/ai_moderation/entry_point.rb
+++ b/lib/ai_moderation/entry_point.rb
@@ -4,12 +4,18 @@ module DiscourseAi
   module AiModeration
     class EntryPoint
       def inject_into(plugin)
-        plugin.on(:post_created) { |post| SpamScanner.new_post(post) }
-        plugin.on(:post_edited) { |post| SpamScanner.edited_post(post) }
-        plugin.on(:post_process_cooked) { |_doc, post| SpamScanner.after_cooked_post(post) }
+        plugin.on(:post_created) { |post| ::DiscourseAi::AiModeration::SpamScanner.new_post(post) }
+        plugin.on(:post_edited) do |post|
+          ::DiscourseAi::AiModeration::SpamScanner.edited_post(post)
+        end
+        plugin.on(:post_process_cooked) do |_doc, post|
+          ::DiscourseAi::AiModeration::SpamScanner.after_cooked_post(post)
+        end
 
         plugin.on(:site_setting_changed) do |name, _old_value, new_value|
-          SpamScanner.ensure_flagging_user! if name == :ai_spam_detection_enabled && new_value
+          if name == :ai_spam_detection_enabled && new_value
+            ::DiscourseAi::AiModeration::SpamScanner.ensure_flagging_user!
+          end
         end
 
         custom_filter = [


### PR DESCRIPTION
When spam scanner is enabled and code is reloaded, developer experience this error:

```
NameError at /posts
===================

uninitialized constant DiscourseAi::AiModeration::EntryPoint::SpamScanner

> To access an interactive console with this error, point your browser to: /__better_errors

plugins/discourse-ai/lib/ai_moderation/entry_point.rb, line 7
```

It is because when we call `SpamScanner` it is searched within parent `DiscourseAi::AiModeration::EntryPoint` namespace.

We can help a bit Zeitwerk by calling SpamScanner more explicitly.