### PR TITLE
FIX: various issues with llm and triage management

### DIFF
--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -162,7 +162,14 @@ module DiscourseAi
         end
       end
 
-      def self.reply_to_post(post:, user: nil, persona_id: nil, whisper: nil, add_user_to_pm: false)
+      def self.reply_to_post(
+        post:,
+        user: nil,
+        persona_id: nil,
+        whisper: nil,
+        add_user_to_pm: false,
+        stream_reply: false
+      )
         ai_persona = AiPersona.find_by(id: persona_id)
         raise Discourse::InvalidParameters.new(:persona_id) if !ai_persona
         persona_class = ai_persona.class_instance
@@ -178,6 +185,7 @@ module DiscourseAi
           whisper: whisper,
           context_style: :topic,
           add_user_to_pm: add_user_to_pm,
+          stream_reply: stream_reply,
         )
       end
 
@@ -444,6 +452,7 @@ module DiscourseAi
         whisper: nil,
         context_style: nil,
         add_user_to_pm: true,
+        stream_reply: nil,
         &blk
       )
         # this is a multithreading issue
@@ -479,7 +488,7 @@ module DiscourseAi
           reply_user = User.find_by(id: bot.persona.class.user_id) || reply_user
         end
 
-        stream_reply = post.topic.private_message?
+        stream_reply = post.topic.private_message? if stream_reply.nil?
 
         # we need to ensure persona user is allowed to reply to the pm
         if post.topic.private_message? && add_user_to_pm

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -65,7 +65,7 @@ module DiscourseAi
         user_id.to_i <= 0
       end
 
-      def self.get_bot_user(post:, all_llm_users:)
+      def self.get_bot_user(post:, all_llm_users:, mentionables:)
         bot_user = nil
         if post.topic.private_message?
           # this ensures that we reply using the correct llm
@@ -111,7 +111,8 @@ module DiscourseAi
             .joins(:user)
             .pluck("users.id", "users.username_lower")
 
-        bot_user = get_bot_user(post: post, all_llm_users: all_llm_users)
+        bot_user =
+          get_bot_user(post: post, all_llm_users: all_llm_users, mentionables: mentionables)
 
         mentions = nil
         if mentionables.present? || (bot_user && post.topic.private_message?)

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -181,7 +181,8 @@ module DiscourseAi
         persona_id: nil,
         whisper: nil,
         add_user_to_pm: false,
-        stream_reply: false
+        stream_reply: false,
+        auto_set_title: false
       )
         ai_persona = AiPersona.find_by(id: persona_id)
         raise Discourse::InvalidParameters.new(:persona_id) if !ai_persona
@@ -199,6 +200,7 @@ module DiscourseAi
           context_style: :topic,
           add_user_to_pm: add_user_to_pm,
           stream_reply: stream_reply,
+          auto_set_title: auto_set_title,
         )
       end
 
@@ -466,6 +468,7 @@ module DiscourseAi
         context_style: nil,
         add_user_to_pm: true,
         stream_reply: nil,
+        auto_set_title: true,
         &blk
       )
         # this is a multithreading issue
@@ -641,7 +644,7 @@ module DiscourseAi
         end
         post_streamer&.finish(skip_callback: true)
         publish_final_update(reply_post) if stream_reply
-        if reply_post && post.post_number == 1 && post.topic.private_message?
+        if reply_post && post.post_number == 1 && post.topic.private_message? && auto_set_title
           title_playground(reply_post, post.user)
         end
       end

--- a/lib/utils/search.rb
+++ b/lib/utils/search.rb
@@ -125,6 +125,7 @@ module DiscourseAi
 
       def self.format_results(rows, args: nil, result_style:)
         rows = rows&.map { |row| yield row } if block_given?
+        column_names = nil
 
         if result_style == :compact
           index = -1
@@ -142,7 +143,8 @@ module DiscourseAi
           column_names = column_indexes.keys
         end
 
-        result = { column_names: column_names, rows: rows }
+        result = { rows: rows }
+        result[:column_names] = column_names if column_names
         result[:args] = args if args
         result
       end

--- a/spec/lib/utils/search_spec.rb
+++ b/spec/lib/utils/search_spec.rb
@@ -72,8 +72,26 @@ RSpec.describe DiscourseAi::Utils::Search do
       GroupUser.create!(group: group, user: user)
 
       # Now should find the private post
-      results = described_class.perform_search(search_query: private_post.raw, current_user: user)
+      results =
+        described_class.perform_search(
+          search_query: private_post.raw,
+          current_user: user,
+          result_style: :detailed,
+        )
       expect(results[:rows].length).to eq(1)
+      # so API is less confusing
+      expect(results.key?(:column_names)).to eq(false)
+
+      results =
+        described_class.perform_search(
+          search_query: private_post.raw,
+          current_user: user,
+          result_style: :compact,
+        )
+
+      expect(results[:rows].length).to eq(1)
+      # so API is less confusing
+      expect(results[:column_names]).to be_present
     end
 
     it "properly handles subfolder URLs" do


### PR DESCRIPTION
- Fix search API to only include column_names when present to make the API less confusing
- Ensure correct LLM is used in PMs by tracking and preferring the last bot user
- Fix persona_id conversion from string to integer in custom fields
- Add missing test for PM triage with no replies - ensure we don't try to auto title topic 
- Ensure bot users are properly added to PMs
- Make title setting optional when replying to posts
- Add ability to control stream_reply behavior

These changes improve reliability and fix edge cases in bot interactions,
particularly in private messages with multiple LLMs and while triaging posts using personas
