### PR TITLE
DEV: Fix SCSS linting issue

### DIFF
--- a/assets/stylesheets/modules/ai-bot/common/ai-artifact.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-artifact.scss
@@ -1,3 +1,15 @@
+@keyframes slideUp {
+  to {
+    transform: translateY(-100%);
+  }
+}
+
+@keyframes vanishing {
+  to {
+    display: none;
+  }
+}
+
 .ai-artifact__wrapper {
   iframe {
     width: 100%;
@@ -70,17 +82,6 @@ html.ai-artifact-expanded {
           color: var(--secondary-high);
         }
       }
-    }
-  }
-  @keyframes slideUp {
-    to {
-      transform: translateY(-100%);
-    }
-  }
-
-  @keyframes vanishing {
-    to {
-      display: none;
     }
   }
 


### PR DESCRIPTION
Gets rid of this noise

```
Deprecation Warning [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

     ╷
2550 │ ┌   @keyframes slideUp {
2551 │ │     to {
2552 │ │       transform: translateY(-100%);
2553 │ │     }
2554 │ │   }
     │ └─── nested rule
...  │
2575 │     left: 0;
     │     ^^^^^^^ declaration
     ╵
```