### PR TITLE
DEV: Allow prompt-type evals to take in several prompts and messages

### DIFF
--- a/evals/lib/prompt_evaluator.rb
+++ b/evals/lib/prompt_evaluator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DiscourseAi::Evals::PromptEvaluator
   def initialize(llm)
     @llm = llm.llm_model.to_llm

--- a/evals/lib/prompt_evaluator.rb
+++ b/evals/lib/prompt_evaluator.rb
@@ -1,0 +1,50 @@
+class DiscourseAi::Evals::PromptEvaluator
+  def initialize(llm)
+    @llm = llm.llm_model.to_llm
+  end
+
+  def prompt_call(prompts:, messages: nil, temperature: nil, tools: nil, stream: false)
+    tools = symbolize_tools(tools)
+    total = prompts.size * messages.size
+    count = 0
+    puts ""
+
+    prompts.flat_map do |prompt|
+      messages.map do |content|
+        count += 1
+        print "\rProcessing #{count}/#{total}"
+
+        c_prompt =
+          DiscourseAi::Completions::Prompt.new(prompt, messages: [{ type: :user, content: }])
+        c_prompt.tools = tools if tools
+        result = { prompt:, message: content }
+        result[:result] = generate_result(c_prompt, temperature, stream)
+        result
+      end
+    end
+  ensure
+    print "\r\033[K"
+  end
+
+  private
+
+  def generate_result(c_prompt, temperature, stream)
+    if stream
+      stream_result = []
+      @llm.generate(c_prompt, user: Discourse.system_user, temperature: temperature) do |partial|
+        stream_result << partial
+      end
+      stream_result
+    else
+      @llm.generate(c_prompt, user: Discourse.system_user, temperature: temperature)
+    end
+  end
+
+  def symbolize_tools(tools)
+    return nil if tools.nil?
+
+    tools.map do |tool|
+      { name: tool["name"], parameters: tool["parameters"]&.transform_keys(&:to_sym) }.compact
+    end
+  end
+end

--- a/evals/run
+++ b/evals/run
@@ -6,6 +6,7 @@ require_relative "lib/llm"
 require_relative "lib/cli"
 require_relative "lib/runner"
 require_relative "lib/eval"
+require_relative "lib/prompt_evaluator"
 
 options = DiscourseAi::Evals::Cli.parse_options!
 


### PR DESCRIPTION
This PR moves dealing with prompts into its own evaluator class, and allows prompt evals to take in multiple prompts and messages.

It also tries its best to keep everything else non-prompt working, as we move to handle more results at a time from the change above.