### PR TITLE
FIX: need to create model when testing new embedding

### DIFF
--- a/assets/javascripts/discourse/components/ai-embedding-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-embedding-editor.gjs
@@ -240,7 +240,20 @@ export default class AiEmbeddingEditor extends Component {
     this.testRunning = true;
 
     try {
-      const configTestResult = await this.args.model.testConfig(data);
+      let testModel;
+
+      // new embeddings
+      if (this.args.model.isNew || this.selectedPreset) {
+        testModel = this.store.createRecord("ai-embedding", {
+          ...this.selectedPreset,
+          ...data,
+        });
+      } else {
+        // existing embeddings
+        testModel = this.args.model;
+      }
+
+      const configTestResult = await testModel.testConfig(data);
       this.testResult = configTestResult.success;
 
       if (this.testResult) {


### PR DESCRIPTION
follow-up to 51ca942, tests for existing embeddings worked but new embeddings were throwing an error... this gets them working again