### PR TITLE
UX: try AI search to side on large screens

### DIFF
--- a/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
@@ -106,3 +106,46 @@
   height: 1.15em;
   width: 1.15em;
 }
+
+@include breakpoint("medium", min-width) {
+  .search-menu .menu-panel:has(.ai-discobot-discoveries) {
+    width: 80vw;
+    max-width: 800px;
+    transition: width 0.5s;
+
+    .search-result-topic {
+      display: grid;
+      grid-template-areas: "results-title ai-title" "results ai";
+      grid-template-columns: 59% 39%;
+      gap: 0 2%;
+
+      .list {
+        grid-area: results;
+      }
+
+      .ai-discobot-discoveries {
+        grid-area: ai;
+      }
+    }
+
+    .ai-search-discoveries {
+      font-size: var(--font-0);
+    }
+
+    .ai-search-discoveries__regular-results-title {
+      display: none;
+    }
+
+    .ai-search-discoveries__toggle {
+      display: none;
+    }
+
+    .ai-search-discoveries__discovery.preview {
+      height: 100%;
+
+      &::after {
+        display: none;
+      }
+    }
+  }
+}

--- a/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
@@ -116,8 +116,8 @@
     .search-result-topic {
       display: grid;
       grid-template-areas: "results-title ai-title" "results ai";
-      grid-template-columns: 59% 39%;
-      gap: 0 2%;
+      grid-template-columns: 58% 38%;
+      gap: 0 4%;
 
       .list {
         grid-area: results;
@@ -130,6 +130,7 @@
 
     .ai-search-discoveries {
       font-size: var(--font-0);
+      color: var(--primary-high);
     }
 
     .ai-search-discoveries__regular-results-title {


### PR DESCRIPTION
Wanted to give this alternate layout a try, it's behind a media query so it will still work the same way it does now on smaller screens. 

This allows the topic results to still appear at the top, and removes the need to expand the AI result. 


![image](https://github.com/user-attachments/assets/b6909099-d975-42e3-abb3-c21107267e93)


Smaller screens don't change: 

![image](https://github.com/user-attachments/assets/c05f6b7a-2820-4a7f-ac0e-75035ede0fb5)

