### PR TITLE
FIX: Remove incorrect full-page-search app event

### DIFF
--- a/assets/javascripts/discourse/components/ai-full-page-search.gjs
+++ b/assets/javascripts/discourse/components/ai-full-page-search.gjs
@@ -172,9 +172,6 @@ export default class AiFullPageSearch extends Component {
     this.AiResults = [];
     this.showingAiResults = false;
     this.args.addSearchResults([], "topic_id");
-    this.appEvents.trigger(AI_RESULTS_TOGGLED, {
-      enabled: false,
-    });
   }
 
   performHyDESearch() {


### PR DESCRIPTION
This appEvent is not firing on click, but instead on `resetAiResults`. This action is fired many times during page load. 