### PR TITLE
FEATURE: allow specifying tool use none in completion prompt

### DIFF
--- a/lib/ai_bot/bot.rb
+++ b/lib/ai_bot/bot.rb
@@ -208,8 +208,6 @@ module DiscourseAi
 
           # do not allow tools when we are at the end of a chain (total_completions == MAX_COMPLETIONS - 1)
           prompt.tool_choice = :none if total_completions == MAX_COMPLETIONS - 1
-          puts total_completions
-          puts prompt.tool_choice
         end
 
         embed_thinking(raw_context)

--- a/lib/ai_bot/bot.rb
+++ b/lib/ai_bot/bot.rb
@@ -8,7 +8,7 @@ module DiscourseAi
       BOT_NOT_FOUND = Class.new(StandardError)
 
       # the future is agentic, allow for more turns
-      MAX_COMPLETIONS = 2
+      MAX_COMPLETIONS = 8
 
       # limit is arbitrary, but 5 which was used in the past was too low
       MAX_TOOLS = 20

--- a/lib/ai_bot/bot.rb
+++ b/lib/ai_bot/bot.rb
@@ -6,8 +6,10 @@ module DiscourseAi
       attr_reader :model
 
       BOT_NOT_FOUND = Class.new(StandardError)
+
       # the future is agentic, allow for more turns
-      MAX_COMPLETIONS = 8
+      MAX_COMPLETIONS = 2
+
       # limit is arbitrary, but 5 which was used in the past was too low
       MAX_TOOLS = 20
 
@@ -71,6 +73,8 @@ module DiscourseAi
       end
 
       def force_tool_if_needed(prompt, context)
+        return if prompt.tool_choice == :none
+
         context[:chosen_tools] ||= []
         forced_tools = persona.force_tool_use.map { |tool| tool.name }
         force_tool = forced_tools.find { |name| !context[:chosen_tools].include?(name) }
@@ -105,7 +109,7 @@ module DiscourseAi
         needs_newlines = false
         tools_ran = 0
 
-        while total_completions <= MAX_COMPLETIONS && ongoing_chain
+        while total_completions < MAX_COMPLETIONS && ongoing_chain
           tool_found = false
           force_tool_if_needed(prompt, context)
 
@@ -202,8 +206,10 @@ module DiscourseAi
 
           total_completions += 1
 
-          # do not allow tools when we are at the end of a chain (total_completions == MAX_COMPLETIONS)
-          prompt.tools = [] if total_completions == MAX_COMPLETIONS
+          # do not allow tools when we are at the end of a chain (total_completions == MAX_COMPLETIONS - 1)
+          prompt.tool_choice = :none if total_completions == MAX_COMPLETIONS - 1
+          puts total_completions
+          puts prompt.tool_choice
         end
 
         embed_thinking(raw_context)

--- a/lib/completions/dialects/dialect.rb
+++ b/lib/completions/dialects/dialect.rb
@@ -94,7 +94,7 @@ module DiscourseAi
                 translated << model_msg(
                   role: "assistant",
                   content:
-                    "User required I call the tool: #{prompt.tool_choice} I will makes sure I use it now:",
+                    "User required I call the tool: #{prompt.tool_choice} I will make sure I use it now:",
                 )
               end
             end

--- a/lib/completions/dialects/dialect.rb
+++ b/lib/completions/dialects/dialect.rb
@@ -66,6 +66,11 @@ module DiscourseAi
           prompt.tool_choice
         end
 
+        def no_more_tool_calls_text
+          # note, Anthropic must never prefill with an ending whitespace
+          "Since you explicitly asked me not to use tools any more I will not call tools any more.\nHere is the best, complete, answer I can come up with given the information I know:"
+        end
+
         def translate
           messages = prompt.messages
 

--- a/lib/completions/dialects/xml_tools.rb
+++ b/lib/completions/dialects/xml_tools.rb
@@ -54,6 +54,9 @@ module DiscourseAi
             end
         end
 
+        DONE_MESSAGE =
+          "Regardless of what you think, REPLY IMMEDIATELY, WITHOUT MAKING ANY FURTHER TOOL CALLS, YOU ARE OUT OF TOOL CALL QUOTA!"
+
         def from_raw_tool(raw_message)
           result = (<<~TEXT).strip
             <function_results>
@@ -67,8 +70,7 @@ module DiscourseAi
           TEXT
 
           if @injecting_done
-            result +
-              "\n\nRegardless of what you think, REPLY IMMEDIATELY, WITHOUT MAKING ANY FURTHER TOOL CALLS, YOU ARE OUT OF TOOL CALL QUOTA!"
+            "#{result}\n\n#{DONE_MESSAGE}"
           else
             result
           end

--- a/lib/completions/dialects/xml_tools.rb
+++ b/lib/completions/dialects/xml_tools.rb
@@ -55,7 +55,7 @@ module DiscourseAi
         end
 
         def from_raw_tool(raw_message)
-          (<<~TEXT).strip
+          result = (<<~TEXT).strip
             <function_results>
             <result>
             <tool_name>#{raw_message[:name] || raw_message[:id]}</tool_name>
@@ -65,6 +65,13 @@ module DiscourseAi
             </result>
             </function_results>
           TEXT
+
+          if @injecting_done
+            result +
+              "\n\nRegardless of what you think, REPLY IMMEDIATELY, WITHOUT MAKING ANY FURTHER TOOL CALLS, YOU ARE OUT OF TOOL CALL QUOTA!"
+          else
+            result
+          end
         end
 
         def from_raw_tool_call(raw_message)
@@ -84,6 +91,13 @@ module DiscourseAi
             #{parameters}</invoke>
             </function_calls>
           TEXT
+        end
+
+        def inject_done(&blk)
+          @injecting_done = true
+          blk.call
+        ensure
+          @injecting_done = false
         end
 
         private

--- a/lib/completions/endpoints/anthropic.rb
+++ b/lib/completions/endpoints/anthropic.rb
@@ -110,7 +110,6 @@ module DiscourseAi
             end
           end
 
-          puts "tool_choice: #{payload[:tool_choice]} - #{dialect.tool_choice}"
           payload
         end
 

--- a/lib/completions/endpoints/anthropic.rb
+++ b/lib/completions/endpoints/anthropic.rb
@@ -95,10 +95,22 @@ module DiscourseAi
           if prompt.has_tools?
             payload[:tools] = prompt.tools
             if dialect.tool_choice.present?
-              payload[:tool_choice] = { type: "tool", name: dialect.tool_choice }
+              if dialect.tool_choice == :none
+                payload[:tool_choice] = { type: "none" }
+
+                # prefill prompt to nudge LLM to generate a response that is useful.
+                # without this LLM (even 3.7) can get confused and start text preambles for a tool calls.
+                payload[:messages] << {
+                  role: "assistant",
+                  content: dialect.no_more_tool_calls_text,
+                }
+              else
+                payload[:tool_choice] = { type: "tool", name: prompt.tool_choice }
+              end
             end
           end
 
+          puts "tool_choice: #{payload[:tool_choice]} - #{dialect.tool_choice}"
           payload
         end
 

--- a/lib/completions/endpoints/gemini.rb
+++ b/lib/completions/endpoints/gemini.rb
@@ -72,10 +72,14 @@ module DiscourseAi
 
             function_calling_config = { mode: "AUTO" }
             if dialect.tool_choice.present?
-              function_calling_config = {
-                mode: "ANY",
-                allowed_function_names: [dialect.tool_choice],
-              }
+              if dialect.tool_choice == :none
+                function_calling_config = { mode: "NONE" }
+              else
+                function_calling_config = {
+                  mode: "ANY",
+                  allowed_function_names: [dialect.tool_choice],
+                }
+              end
             end
 
             payload[:tool_config] = { function_calling_config: function_calling_config }

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -92,12 +92,16 @@ module DiscourseAi
             if dialect.tools.present?
               payload[:tools] = dialect.tools
               if dialect.tool_choice.present?
-                payload[:tool_choice] = {
-                  type: "function",
-                  function: {
-                    name: dialect.tool_choice,
-                  },
-                }
+                if dialect.tool_choice == :none
+                  payload[:tool_choice] = "none"
+                else
+                  payload[:tool_choice] = {
+                    type: "function",
+                    function: {
+                      name: dialect.tool_choice,
+                    },
+                  }
+                end
               end
             end
           end


### PR DESCRIPTION
This PR adds support for disabling further tool calls by setting tool_choice to :none across all supported LLM providers:

- OpenAI: Uses "none" tool_choice parameter
- Anthropic: Uses {type: "none"} and adds a prefill message to prevent confusion
- Gemini: Sets function_calling_config mode to "NONE"
- AWS Bedrock: Doesn't natively support tool disabling, so adds a prefill message

We previously used to disable tool calls by simply removing tool definitions, but this would cause errors with some providers. This implementation uses the supported method appropriate for each provider while providing a fallback for Bedrock.
