### PR TITLE
FIX: unable to click doughnut when no filters

### DIFF
--- a/assets/javascripts/discourse/components/admin-report-sentiment-analysis.gjs
+++ b/assets/javascripts/discourse/components/admin-report-sentiment-analysis.gjs
@@ -216,10 +216,15 @@ export default class AdminReportSentimentAnalysis extends Component {
     }
 
     const currentQueryParams = this.router.currentRoute.queryParams;
+
+    const currentFilters = currentQueryParams?.filters
+      ? JSON.parse(currentQueryParams.filters)
+      : {};
+
     this.router.transitionTo(this.router.currentRoute.name, {
       queryParams: {
         ...currentQueryParams,
-        filters: JSON.parse(currentQueryParams.filters), // avoids a double escaping
+        filters: currentFilters, // avoids a double escaping
         selectedChart: data.title,
       },
     });
@@ -265,10 +270,13 @@ export default class AdminReportSentimentAnalysis extends Component {
     this.posts = [];
 
     const currentQueryParams = this.router.currentRoute.queryParams;
+    const currentFilters = currentQueryParams?.filters
+      ? JSON.parse(currentQueryParams.filters)
+      : {};
     this.router.transitionTo(this.router.currentRoute.name, {
       queryParams: {
         ...currentQueryParams,
-        filters: JSON.parse(currentQueryParams.filters), // avoids a double escaping
+        filters: currentFilters, // avoids a double escaping
         selectedChart: null,
       },
     });


### PR DESCRIPTION
## :mag: Overview
This PR fixes an issue where you are unable to click to see the sentiment drill-down when there are no current filters applied. This is due to trying to `JSON.parse()` the filters when there are no filters. This fix ensures there are filters first before trying to parse the JSON.