### PR TITLE
FIX: prevents to call Object.keys on null

### DIFF
--- a/assets/javascripts/discourse/components/ai-embedding-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-embedding-editor.gjs
@@ -290,7 +290,7 @@ export default class AiEmbeddingEditor extends Component {
 
   @action
   providerKeys(providerParams) {
-    return Object.keys(providerParams);
+    return providerParams ? Object.keys(providerParams) : [];
   }
 
   <template>

--- a/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
+++ b/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
@@ -252,7 +252,7 @@ export default class AiLlmEditorForm extends Component {
 
   @action
   providerParamsKeys(providerParams) {
-    return Object.keys(providerParams);
+    return providerParams ? Object.keys(providerParams) : [];
   }
 
   <template>

--- a/assets/javascripts/discourse/components/ai-persona-tool-options.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-tool-options.gjs
@@ -30,7 +30,7 @@ export default class AiPersonaToolOptions extends Component {
 
   @action
   formObjectKeys(toolOptions) {
-    return Object.keys(toolOptions);
+    return toolOptions ? Object.keys(toolOptions) : [];
   }
 
   <template>


### PR DESCRIPTION
This was causing errors in the forms under specific cases.