### PR TITLE
FIX: Post helper menu results should be selectable

### DIFF
--- a/assets/javascripts/discourse/components/ai-post-helper-menu.gjs
+++ b/assets/javascripts/discourse/components/ai-post-helper-menu.gjs
@@ -13,6 +13,7 @@ import FastEditModal from "discourse/components/modal/fast-edit";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { bind } from "discourse/lib/decorators";
+import { withPluginApi } from "discourse/lib/plugin-api";
 import { sanitize } from "discourse/lib/text";
 import { clipboardCopy } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
@@ -68,6 +69,23 @@ export default class AiPostHelperMenu extends Component {
   });
 
   @tracked _activeAiRequest = null;
+
+  constructor() {
+    super(...arguments);
+
+    withPluginApi((api) => {
+      api.registerValueTransformer(
+        "post-text-selection-prevent-close",
+        ({ value }) => {
+          if (this.menuState === this.MENU_STATES.result) {
+            return true;
+          }
+
+          return value;
+        }
+      );
+    });
+  }
 
   get footnoteDisabled() {
     return this.streaming || !this.supportsAddFootnote;


### PR DESCRIPTION
## :mag: Overview
This update fixes an issue where the results of the post helper menu was not selectable. Previously, selecting any text inside the menu was immediately closing the menu.

## 📸 Screenshot
![Screenshot 2025-03-26 at 11 20 27](https://github.com/user-attachments/assets/c7a5d197-4582-490c-bf70-666c35b36928)

## 🔗 Relevant Links
https://meta.discourse.org/t/setting-to-manually-close-ai-helpers-popup-modal/358300?u=keegan
