### PR TITLE
FIX: Ensure category badging present in sentiment reports

### DIFF
--- a/app/controllers/discourse_ai/sentiment/sentiment_controller.rb
+++ b/app/controllers/discourse_ai/sentiment/sentiment_controller.rb
@@ -46,10 +46,6 @@ module DiscourseAi
             u.name,
             u.uploaded_avatar_id,
             c.id AS category_id,
-            c.name AS category_name,
-            c.color AS category_color,
-            c.slug AS category_slug,
-            c.description AS category_description,
             (CASE 
               WHEN (cr.classification::jsonb->'positive')::float > :threshold THEN 'positive'
               WHEN (cr.classification::jsonb->'negative')::float > :threshold THEN 'negative'

--- a/app/serializers/ai_sentiment_post_serializer.rb
+++ b/app/serializers/ai_sentiment_post_serializer.rb
@@ -11,7 +11,7 @@ class AiSentimentPostSerializer < ApplicationSerializer
              :excerpt,
              :sentiment,
              :truncated,
-             :category,
+             :category_id,
              :created_at
 
   def avatar_template
@@ -24,15 +24,5 @@ class AiSentimentPostSerializer < ApplicationSerializer
 
   def truncated
     object.post_cooked.length > SiteSetting.post_excerpt_maxlength
-  end
-
-  def category
-    {
-      id: object.category_id,
-      name: object.category_name,
-      color: object.category_color,
-      slug: object.category_slug,
-      description: object.category_description,
-    }
   end
 end

--- a/assets/javascripts/discourse/components/admin-report-sentiment-analysis.gjs
+++ b/assets/javascripts/discourse/components/admin-report-sentiment-analysis.gjs
@@ -11,6 +11,7 @@ import DButton from "discourse/components/d-button";
 import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav";
 import PostList from "discourse/components/post-list";
 import bodyClass from "discourse/helpers/body-class";
+import categoryBadge from "discourse/helpers/category-badge";
 import dIcon from "discourse/helpers/d-icon";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import { ajax } from "discourse/lib/ajax";
@@ -18,6 +19,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { getAbsoluteURL } from "discourse/lib/get-url";
 import discourseLater from "discourse/lib/later";
 import { clipboardCopy } from "discourse/lib/utilities";
+import Category from "discourse/models/category";
 import Post from "discourse/models/post";
 import closeOnClickOutside from "discourse/modifiers/close-on-click-outside";
 import { i18n } from "discourse-i18n";
@@ -111,6 +113,7 @@ export default class AdminReportSentimentAnalysis extends Component {
   get transformedData() {
     return this.args.model.data.map((data) => {
       return {
+        category: Category.findById(data.category_id),
         title: data.category_name || data.tag_name,
         scores: [
           data.positive_count,
@@ -139,6 +142,7 @@ export default class AdminReportSentimentAnalysis extends Component {
 
     return this.posts.filter((post) => {
       post.topic_title = replaceEmoji(post.topic_title);
+      post.category = Category.findById(post.category_id);
 
       if (this.activeFilter === "all") {
         return true;
@@ -347,7 +351,13 @@ export default class AdminReportSentimentAnalysis extends Component {
                   )
                 }}
               >
-                <td class="sentiment-analysis-table__title">{{data.title}}</td>
+                <td class="sentiment-analysis-table__title">
+                  {{#if data.category}}
+                    {{categoryBadge data.category}}
+                  {{else}}
+                    {{data.title}}
+                  {{/if}}
+                </td>
                 <td
                   class="sentiment-analysis-table__total-score"
                 >{{data.total_score}}</td>

--- a/lib/sentiment/sentiment_analysis_report.rb
+++ b/lib/sentiment/sentiment_analysis_report.rb
@@ -80,12 +80,23 @@ module DiscourseAi
           case grouping
           when :category
             <<~SQL
+                c.id AS category_id,
                 c.name AS category_name,
               SQL
           when :tag
             <<~SQL
                   tags.name AS tag_name,
               SQL
+          else
+            raise Discourse::InvalidParameters
+          end
+
+        group_by_clause =
+          case grouping
+          when :category
+            "GROUP BY c.id, c.name"
+          when :tag
+            "GROUP BY tags.name"
           else
             raise Discourse::InvalidParameters
           end
@@ -154,7 +165,7 @@ module DiscourseAi
                 cr.model_used = 'cardiffnlp/twitter-roberta-base-sentiment-latest' AND
                 (p.created_at > :report_start AND p.created_at < :report_end)
                 #{where_clause}
-              GROUP BY 1
+              #{group_by_clause}
               #{order_by_clause}
             SQL
             report_start: report.start_date,


### PR DESCRIPTION
## :mag: Overview
This PR ensures that the category badges are present in the sentiment analysis report. Since the core change in https://github.com/discourse/discourse/pull/31795, there was a regression in the post list drill-down where category badges were not being shown. This PR fixes that and also ensures icons/emojis are shown when categories make use of them. This PR also adds the category badge in the table list.

## 📸 Screenshots

### ← Before
![Screenshot 2025-03-26 at 12 30 12](https://github.com/user-attachments/assets/0f7123d1-c121-4f71-9dff-507736bc219d)
![Screenshot 2025-03-26 at 12 30 06](https://github.com/user-attachments/assets/89723d7a-68cb-4ac0-9a80-5d209abef38e)

### → After
![Screenshot 2025-03-26 at 12 26 25](https://github.com/user-attachments/assets/0e5c3956-9157-4b2f-a66a-89f7841dd07c)
![Screenshot 2025-03-26 at 12 26 35](https://github.com/user-attachments/assets/699fc29d-cab4-4a04-9905-ffe0a3111e15)

