### PR TITLE
DEV: Remove no longer needed click outside logic

### DIFF
--- a/assets/javascripts/discourse/components/admin-report-sentiment-analysis.gjs
+++ b/assets/javascripts/discourse/components/admin-report-sentiment-analysis.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";


### PR DESCRIPTION
The older design approach for sentiment analysis report needed the click outside logic. However, when the design was changed this logic was accidentally left behind. It is potentially causing some negative performance impacts. This PR removes the old unnecessary logic. 