### PR TITLE
FIX: Flaky AI tool spec

### DIFF
--- a/spec/models/ai_tool_spec.rb
+++ b/spec/models/ai_tool_spec.rb
@@ -160,15 +160,15 @@ RSpec.describe AiTool do
       }
     JS
 
-    tool = create_tool(script: script)
-    runner = tool.runner({ "query" => "test" }, llm: nil, bot_user: nil, context: {})
-
     stub_request(:get, "https://example.com/test").to_return do
       sleep 0.01
       { status: 200, body: "Hello World", headers: {} }
     end
 
-    runner.timeout = 5
+    tool = create_tool(script: script)
+    runner = tool.runner({ "query" => "test" }, llm: nil, bot_user: nil, context: {})
+
+    runner.timeout = 10
 
     result = runner.invoke
 


### PR DESCRIPTION
The AI Tool spec that checks that the tool runner will not timeout on slow HTTP request is flaky. In this PR we attempt to resolve the flakiness by:

1. Ensuring stub_request runs before the request
2. Increasing the timeout for CI env