### PR TITLE
FIX: persona setting should compare integer value

### DIFF
--- a/assets/javascripts/discourse/components/ai-search-discoveries.gjs
+++ b/assets/javascripts/discourse/components/ai-search-discoveries.gjs
@@ -156,7 +156,8 @@ export default class AiSearchDiscoveries extends Component {
   get canContinueConversation() {
     const personas = this.currentUser?.ai_enabled_personas;
     const discoverPersona = personas.find(
-      (persona) => persona.id === this.siteSettings?.ai_bot_discover_persona
+      (persona) =>
+        persona.id === parseInt(this.siteSettings?.ai_bot_discover_persona, 10)
     );
     const discoverPersonaHasBot = discoverPersona?.username;
 


### PR DESCRIPTION
Oversight from recent feature update: https://github.com/discourse/discourse-ai/pull/1234

We should be comparing integer value of setting, otherwise we will never see continue conversation button.