### PR TITLE
DEV: Don't use delays for streaming summaries.

### DIFF
--- a/spec/jobs/scheduled/summaries_backfill_spec.rb
+++ b/spec/jobs/scheduled/summaries_backfill_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe Jobs::SummariesBackfill do
   let(:limit) { 24 } # guarantee two summaries per batch
   let(:intervals) { 12 } # budget is split into intervals. Job runs every five minutes.
 
+  before { DiscourseAi::Completions::Endpoints::Fake.delays = [] }
+  after { DiscourseAi::Completions::Endpoints::Fake.reset! }
+
   before do
     assign_fake_provider_to(:ai_summarization_model)
     SiteSetting.ai_summarization_enabled = true

--- a/spec/lib/modules/summarization/fold_content_spec.rb
+++ b/spec/lib/modules/summarization/fold_content_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe DiscourseAi::Summarization::FoldContent do
 
   before { SiteSetting.ai_summarization_enabled = true }
 
+  before { DiscourseAi::Completions::Endpoints::Fake.delays = [] }
+  after { DiscourseAi::Completions::Endpoints::Fake.reset! }
+
   describe "#summarize" do
     before do
       # Make sure each content fits in a single chunk.


### PR DESCRIPTION
We started used a callback as a buffer in FoldContent, so the Fake endpoint is attempting to emulate delays in the streaming. However, we don't care about that in these specs.