### PR TITLE
FIX: Restore gists previous group access behavior.

### DIFF
--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -92,7 +92,16 @@ export default class PersonaEditor extends Component {
 
   @action
   async updateAllGroups() {
-    this.allGroups = await Group.findAll();
+    const groups = await Group.findAll({ include_everyone: true });
+
+    // Backwards-compatibility code. TODO(roman): Remove 01-09-2025
+    const hasEveryoneGroup = groups.find((g) => g.id === 0);
+    if (!hasEveryoneGroup) {
+      const everyoneGroupName = "everyone";
+      groups.push({ id: 0, name: everyoneGroupName });
+    }
+
+    this.allGroups = groups;
   }
 
   @action

--- a/db/fixtures/personas/603_ai_personas.rb
+++ b/db/fixtures/personas/603_ai_personas.rb
@@ -25,7 +25,7 @@ DiscourseAi::Personas::Persona.system_personas.each do |persona_class, id|
       setting_name = "ai_custom_summarization_allowed_groups"
       if persona_class == DiscourseAi::Personas::ShortSummarizer
         setting_name = "ai_summary_gists_allowed_groups"
-        default_groups = [] # Blank == everyone
+        default_groups = [Group::AUTO_GROUPS[:everyone]]
       end
 
       persona.allowed_group_ids = from_setting(setting_name).first&.split("|") || default_groups

--- a/db/migrate/20250407125756_set_correct_default_for_short_summarizer_persona.rb
+++ b/db/migrate/20250407125756_set_correct_default_for_short_summarizer_persona.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class SetCorrectDefaultForShortSummarizerPersona < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      UPDATE ai_personas
+      SET allowed_group_ids = ARRAY[0]
+      WHERE id = -12 AND allowed_group_ids = '{}'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -29,10 +29,10 @@ module DiscourseAi
         return false
       end
       persona_groups = ai_persona.allowed_group_ids.to_a
-      return true if persona_groups.empty?
+      return true if persona_groups.include?(Group::AUTO_GROUPS[:everyone])
       return false if anonymous?
 
-      ai_persona.allowed_group_ids.to_a.any? { |group_id| user.group_ids.include?(group_id) }
+      persona_groups.any? { |group_id| user.group_ids.include?(group_id) }
     end
 
     def can_request_summary?

--- a/spec/lib/guardian_extensions_spec.rb
+++ b/spec/lib/guardian_extensions_spec.rb
@@ -86,7 +86,7 @@ describe DiscourseAi::GuardianExtensions do
     end
 
     context "when access is set to everyone" do
-      before { assign_persona_to(:ai_summary_gists_persona, []) }
+      before { assign_persona_to(:ai_summary_gists_persona, [Group::AUTO_GROUPS[:everyone]]) }
 
       it "returns true" do
         expect(guardian.can_see_gists?).to eq(true)


### PR DESCRIPTION
Previously, allowing "everyone" to access gists meant anons would see them too. With the move to Personas, we used "[]" to reflect that.

With discourse/discourse#32199 adding the "everyone" option to the personas-allowed groups, we are switching back to the original behavior. Leaving allowed groups empty should always mean nobody can use the feature.