### PR TITLE
FEATURE: allow tools to amend personas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules
 evals/log
 evals/cases
 config/eval-llms.local.yml
+# this gets rid of search results from ag, ripgrep, etc
+tokenizers/
+public/ai-share/highlight.min.js

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7,6 +7,7 @@ en:
             discourse_ai:
               search: "Allows AI search"
               stream_completion: "Allows streaming AI persona completions"
+              update_personas: "Allows updating AI personas"
 
       site_settings:
         categories:

--- a/lib/personas/tool_runner.rb
+++ b/lib/personas/tool_runner.rb
@@ -180,6 +180,20 @@ module DiscourseAi
         { error: "Script terminated due to timeout" }
       end
 
+      def has_custom_context?
+        mini_racer_context.eval(tool.script)
+        mini_racer_context.eval("typeof customContext === 'function'")
+      rescue StandardError
+        false
+      end
+
+      def custom_context
+        mini_racer_context.eval(tool.script)
+        mini_racer_context.eval("customContext()")
+      rescue StandardError
+        nil
+      end
+
       private
 
       MAX_FRAGMENTS = 200

--- a/lib/personas/tool_runner.rb
+++ b/lib/personas/tool_runner.rb
@@ -93,9 +93,9 @@ module DiscourseAi
           getTopic: _discourse_get_topic,
           getUser: _discourse_get_user,
           getPersona: function(name) {
-            const result = _discourse_get_persona(name);
-            if (result.error) {
-              throw new Error(result.error);
+            const personaDetails = _discourse_get_persona(name);
+            if (personaDetails.error) {
+              throw new Error(personaDetails.error);
             }
 
             // merge result.persona with {}..
@@ -108,13 +108,13 @@ module DiscourseAi
                 return result;
               },
               respondTo: function(params) {
-                result = _discourse_respond_to_persona(name, params);
+                const result = _discourse_respond_to_persona(name, params);
                 if (result.error) {
                   throw new Error(result.error);
                 }
                 return result;
               }
-            }, result.persona);
+            }, personaDetails.persona);
           },
           createChatMessage: function(params) {
             const result = _discourse_create_chat_message(params);

--- a/plugin.rb
+++ b/plugin.rb
@@ -127,6 +127,11 @@ after_initialize do
     end
   end
 
+  add_api_key_scope(
+    :discourse_ai,
+    { update_personas: { actions: %w[discourse_ai/admin/ai_personas#update] } },
+  )
+
   plugin_icons = %w[
     chart-column
     spell-check


### PR DESCRIPTION
Add API methods to AI tools for reading and updating personas, enabling
more flexible AI workflows. This allows custom tools to:

- Fetch persona information through discourse.getPersona()
- Update personas with modified settings via discourse.updatePersona()
- Also update using persona.update()

These APIs enable new use cases like "trainable" moderation bots, where
users with appropriate permissions can set and refine moderation rules
through direct chat interactions, without needing admin panel access.

Also adds a special API scope which allows people to lean on API
for similar actions

