### PR TITLE
UX: Improve groups list in feature table when many groups

### DIFF
--- a/assets/stylesheets/common/ai-features.scss
+++ b/assets/stylesheets/common/ai-features.scss
@@ -17,8 +17,9 @@
 
   &__row-item-groups {
     list-style: none;
-    margin: 0.5em 0 0 0;
     display: flex;
+    flex-flow: row wrap;
+    gap: 0.25em;
 
     li {
       font-size: var(--font-down-2);
@@ -26,7 +27,6 @@
       background: var(--primary-very-low);
       border: 1px solid var(--primary-low);
       padding: 1px 3px;
-      margin-right: 0.5em;
     }
   }
 }


### PR DESCRIPTION
## :mag: Overview
This update improves the displaying of groups in the features table when there are many groups for a particular persona.

## 📷 Screenshots

### ← Before
<img width="956" alt="Screenshot 2025-04-10 at 08 56 36" src="https://github.com/user-attachments/assets/8885e45c-8efe-426f-a1ec-ecab5b776390" />

### → After
<img width="946" alt="Screenshot 2025-04-10 at 08 56 26" src="https://github.com/user-attachments/assets/e48c784c-6a9f-4f75-bd26-04a8e135428c" />
