### PR TITLE
FIX: Discovery shouldn't re-trigger when no search

### DIFF
--- a/assets/javascripts/discourse/components/ai-search-discoveries.gjs
+++ b/assets/javascripts/discourse/components/ai-search-discoveries.gjs
@@ -186,6 +186,12 @@ export default class AiSearchDiscoveries extends Component {
 
   @action
   async triggerDiscovery() {
+    if (this.query?.length === 0) {
+      this.discobotDiscoveries.resetDiscovery();
+      this.smoothStreamer.resetStreaming();
+      return;
+    }
+
     if (this.discobotDiscoveries.lastQuery === this.query) {
       this.hideDiscoveries = false;
       return;


### PR DESCRIPTION
## :mag: Overview
This update fixes an issue where discobot discoveries was re-triggering when search menu was opened with no query present.

## 📹 Screen Recording

### ← Before
https://github.com/user-attachments/assets/fc90f680-7cce-49d2-af87-1648f3c8c61a

### → After
https://github.com/user-attachments/assets/1b6864cd-2410-4c10-9eca-e193856feaf5

