### PR TITLE
FIX: omit thinking tokens from chat

### DIFF
--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -335,9 +335,9 @@ module DiscourseAi
         in_reply_to_id = channel.direct_message_channel? ? message.id : nil
 
         new_prompts =
-          bot.reply(context) do |partial, cancel, placeholder|
+          bot.reply(context) do |partial, cancel, placeholder, type|
             # no support for tools or thinking by design
-            next if !partial.is_a?(String)
+            next if type == :thinking || type == :tool_details
             if !reply
               # just eat all leading spaces we can not create the message
               next if partial.blank?

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -337,7 +337,7 @@ module DiscourseAi
         new_prompts =
           bot.reply(context) do |partial, cancel, placeholder, type|
             # no support for tools or thinking by design
-            next if type == :thinking || type == :tool_details
+            next if type == :thinking || type == :tool_details || type == :partial_tool
             if !reply
               # just eat all leading spaces we can not create the message
               next if partial.blank?

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -397,6 +397,13 @@ RSpec.describe DiscourseAi::AiBot::Playground do
           guardian: guardian,
         )
 
+        thinking_partial =
+          DiscourseAi::Completions::Thinking.new(
+            message: "I should say hello",
+            signature: "thinking-signature-123",
+            partial: true,
+          )
+
         thinking =
           DiscourseAi::Completions::Thinking.new(
             message: "I should say hello",
@@ -404,7 +411,7 @@ RSpec.describe DiscourseAi::AiBot::Playground do
             partial: false,
           )
         DiscourseAi::Completions::Llm.with_prepared_responses(
-          [[thinking, thinking, "wo", "rld", thinking]],
+          [[thinking_partial, thinking, "wo", "rld"]],
         ) do |_, _, _prompts|
           ChatSDK::Message.create(
             channel_id: channel.id,


### PR DESCRIPTION
Thinking tokens lead chat to be basically unusable, cause they flood chat with useless info.

This fix explicitly omits them 
