### PR TITLE
DEV: include excerpt-expanded class when gists are enabled

### DIFF
--- a/assets/javascripts/initializers/ai-gist-topic-list-class.js
+++ b/assets/javascripts/initializers/ai-gist-topic-list-class.js
@@ -1,0 +1,19 @@
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer("1.15.0", (api) => {
+  const gistService = api.container.lookup("service:gists");
+
+  api.registerValueTransformer(
+    "topic-list-item-class",
+    ({ value, context }) => {
+      const shouldShow =
+        gistService.preference === "table-ai" && gistService.shouldShow;
+
+      if (context.topic.get("ai_topic_gist") && shouldShow) {
+        value.push("excerpt-expanded");
+      }
+
+      return value;
+    }
+  );
+});


### PR DESCRIPTION
Core adds this class for themes when excerpts are shown in the topic list, so this does the same for gists. This allows us to have more control over the gist layout in themes. 

No visual changes.