### PR TITLE
FIX: Do not re-render conversations sidebar on navigation

### DIFF
--- a/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
+++ b/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
@@ -10,7 +10,12 @@ export default class AiConversationsSidebarManager extends Service {
   @tracked newTopicForceSidebar = false;
 
   forceCustomSidebar() {
-    // Set the panel to your custom panel
+    // Return early if we already have the correct panel, so we don't
+    // re-render it.
+    if (this.sidebarState.currentPanel?.key === AI_CONVERSATIONS_PANEL) {
+      return;
+    }
+
     this.sidebarState.setPanel(AI_CONVERSATIONS_PANEL);
 
     // Use separated mode to ensure independence from hamburger menu

--- a/spec/system/ai_bot/homepage_spec.rb
+++ b/spec/system/ai_bot/homepage_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "AI Bot - Homepage", type: :system do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:composer) { PageObjects::Components::Composer.new }
   let(:ai_pm_homepage) { PageObjects::Components::AiPmHomepage.new }
+  let(:header) { PageObjects::Pages::DiscourseAi::Header.new }
   let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
   let(:header_dropdown) { PageObjects::Components::NavigationMenu::HeaderDropdown.new }
   let(:dialog) { PageObjects::Components::Dialog.new }
@@ -92,14 +93,14 @@ RSpec.describe "AI Bot - Homepage", type: :system do
   context "when `ai_enable_experimental_bot_ux` is enabled" do
     it "renders landing page on bot click" do
       visit "/"
-      find(".ai-bot-button").click
+      header.click_bot_button
       expect(ai_pm_homepage).to have_homepage
       expect(sidebar).to be_visible
     end
 
     it "displays error when message is too short" do
       visit "/"
-      find(".ai-bot-button").click
+      header.click_bot_button
 
       ai_pm_homepage.input.fill_in(with: "a")
       ai_pm_homepage.submit
@@ -111,7 +112,7 @@ RSpec.describe "AI Bot - Homepage", type: :system do
     it "renders sidebar even when navigation menu is set to header" do
       SiteSetting.navigation_menu = "header dropdown"
       visit "/"
-      find(".ai-bot-button").click
+      header.click_bot_button
       expect(ai_pm_homepage).to have_homepage
       expect(sidebar).to be_visible
       expect(header_dropdown).to be_visible
@@ -119,7 +120,7 @@ RSpec.describe "AI Bot - Homepage", type: :system do
 
     it "hides default content in the sidebar" do
       visit "/"
-      find(".ai-bot-button").click
+      header.click_bot_button
 
       expect(ai_pm_homepage).to have_homepage
       expect(sidebar).to have_no_tags_section
@@ -132,7 +133,7 @@ RSpec.describe "AI Bot - Homepage", type: :system do
 
     it "shows the bot conversation in the sidebar" do
       visit "/"
-      find(".ai-bot-button").click
+      header.click_bot_button
 
       expect(ai_pm_homepage).to have_homepage
       expect(sidebar).to have_section("ai-conversations-history")
@@ -142,13 +143,31 @@ RSpec.describe "AI Bot - Homepage", type: :system do
 
     it "navigates to the bot conversation when clicked" do
       visit "/"
-      find(".ai-bot-button").click
+      header.click_bot_button
 
       expect(ai_pm_homepage).to have_homepage
       sidebar.find(
         ".sidebar-section[data-section-name='ai-conversations-history'] a.sidebar-section-link",
       ).click
       expect(topic_page).to have_topic_title(pm.title)
+    end
+
+    it "displays the shuffle icon when on homepage or bot PM" do
+      visit "/"
+      expect(header).to have_icon_in_bot_button(icon: "robot")
+      header.click_bot_button
+
+      expect(header).to have_icon_in_bot_button(icon: "shuffle")
+
+      # Go to a PM and assert that the icon is still shuffle
+      sidebar.find(
+        ".sidebar-section[data-section-name='ai-conversations-history'] a.sidebar-section-link",
+      ).click
+      expect(header).to have_icon_in_bot_button(icon: "shuffle")
+
+      # Go back home and assert that the icon is now robot again
+      header.click_bot_button
+      expect(header).to have_icon_in_bot_button(icon: "robot")
     end
 
     it "displays sidebar and 'new question' on the topic page" do
@@ -193,7 +212,7 @@ RSpec.describe "AI Bot - Homepage", type: :system do
       sign_in(user_2)
 
       visit "/"
-      find(".ai-bot-button").click
+      header.click_bot_button
       expect(ai_pm_homepage).to have_homepage
       expect(sidebar).to have_no_section_link(pm.title)
     end
@@ -204,7 +223,7 @@ RSpec.describe "AI Bot - Homepage", type: :system do
 
     it "opens composer on bot click" do
       visit "/"
-      find(".ai-bot-button").click
+      header.click_bot_button
 
       expect(ai_pm_homepage).to have_no_homepage
       expect(composer).to be_opened

--- a/spec/system/page_objects/pages/discourse_ai/header.rb
+++ b/spec/system/page_objects/pages/discourse_ai/header.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    module DiscourseAi
+      class Header < ::PageObjects::Pages::Header
+        def click_bot_button
+          find(".ai-bot-button").click
+        end
+
+        def has_icon_in_bot_button?(icon:)
+          page.has_css?(".ai-bot-button .d-icon-#{icon}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR prevents the conversations sidebar from re-rendering (thus losing infinite-loaded content and flashing) when navigating between Bot PMs and the landing page. 

It also swaps out the header icon to be a toggle when you are on the conversations landing page.
![Screenshot 2025-04-22 at 3 27 26 PM](https://github.com/user-attachments/assets/8be25f0f-a94f-489f-a6d4-4703b5731335)
