### PR TITLE
DEV: Migration to backfill bot PM custom field

### DIFF
--- a/app/controllers/discourse_ai/ai_bot/conversations_controller.rb
+++ b/app/controllers/discourse_ai/ai_bot/conversations_controller.rb
@@ -15,8 +15,8 @@ module DiscourseAi
           Topic
             .private_messages_for_user(current_user)
             .where(user: current_user) # Only show PMs where the current user is the author
-            .joins(:topic_users)
-            .where(topic_users: { user_id: bot_user_ids })
+            .joins("INNER JOIN topic_custom_fields tcf ON tcf.topic_id = topics.id")
+            .where("tcf.name = ? AND tcf.value = 't'", DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD)
             .distinct
 
         total = base_query.count

--- a/app/controllers/discourse_ai/ai_bot/conversations_controller.rb
+++ b/app/controllers/discourse_ai/ai_bot/conversations_controller.rb
@@ -15,8 +15,11 @@ module DiscourseAi
           Topic
             .private_messages_for_user(current_user)
             .where(user: current_user) # Only show PMs where the current user is the author
-            .joins("INNER JOIN topic_custom_fields tcf ON tcf.topic_id = topics.id")
-            .where("tcf.name = ? AND tcf.value = 't'", DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD)
+            .joins(
+              "INNER JOIN topic_custom_fields tcf ON tcf.topic_id = topics.id
+                   AND tcf.name = '#{DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD}'
+                   AND tcf.value = 't'",
+            )
             .distinct
 
         total = base_query.count

--- a/assets/javascripts/initializers/ai-conversations-sidebar.js
+++ b/assets/javascripts/initializers/ai-conversations-sidebar.js
@@ -5,7 +5,6 @@ import { bind } from "discourse/lib/decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { i18n } from "discourse-i18n";
 import AiBotSidebarNewConversation from "../discourse/components/ai-bot-sidebar-new-conversation";
-import { isPostFromAiBot } from "../discourse/lib/ai-bot-helper";
 import { AI_CONVERSATIONS_PANEL } from "../discourse/services/ai-conversations-sidebar-manager";
 
 export default {
@@ -249,10 +248,7 @@ export default {
         if (
           topic?.archetype === "private_message" &&
           topic.user_id === currentUser.id &&
-          (topic.is_bot_pm ||
-            topic.postStream.posts.some((post) =>
-              isPostFromAiBot(post, currentUser)
-            ))
+          topic.is_bot_pm
         ) {
           return aiConversationsSidebarManager.forceCustomSidebar();
         }

--- a/db/migrate/20250424163718_set_ai_bot_pm_custom_fields.rb
+++ b/db/migrate/20250424163718_set_ai_bot_pm_custom_fields.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class SetAiBotPmCustomFields < ActiveRecord::Migration[7.2]
+  def up
+    # Set the topic custom field for past bot PMs:
+    # - Created by a "real" user (user_id > 0)
+    # - Include exactly 2 participants (creator and 1 bot)
+    # - One participant is a bot (ID <= -1200)
+
+    execute <<~SQL
+      INSERT INTO topic_custom_fields (topic_id, name, value, created_at, updated_at)
+      SELECT t.id, 'is_ai_bot_pm', 't', NOW(), NOW()
+      FROM topics t
+      WHERE t.archetype = 'private_message'
+      AND t.user_id > 0 -- Created by a real user
+      AND (
+        SELECT COUNT(*)
+        FROM topic_allowed_users tau
+        WHERE tau.topic_id = t.id
+      ) = 2 -- Only 2 participants total
+      AND (
+        SELECT COUNT(*)
+        FROM topic_allowed_users tau
+        WHERE tau.topic_id = t.id
+        AND tau.user_id <= -1200 -- Bot users have IDs <= -1200
+      ) = 1 -- One of those participants is a bot
+      AND NOT EXISTS (
+        SELECT 1
+        FROM topic_custom_fields tcf
+        WHERE tcf.topic_id = t.id
+        AND tcf.name = 'is_ai_bot_pm'
+      ) -- Don't duplicate existing custom fields
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/system/ai_bot/homepage_spec.rb
+++ b/spec/system/ai_bot/homepage_spec.rb
@@ -93,6 +93,9 @@ RSpec.describe "AI Bot - Homepage", type: :system do
   end
 
   before do
+    pm.custom_fields[DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD] = "t"
+    pm.save!
+
     SiteSetting.ai_enable_experimental_bot_ux = true
     SiteSetting.ai_bot_enabled = true
     Jobs.run_immediately!


### PR DESCRIPTION
In the last commit, I introduced a topic_custom_field to determine if a PM is indeed a bot PM.

This commit adds a migration to backfill any PM that is between 1 real user, and 1 bot. The correct topic_custom_field is added for these, so they will appear on the bot conversation sidebar properly.

We can also drop the joining to topic_users in the controller for sidebar conversations, and the `isPostFromAiBot` logic from the sidebar.