### PR TITLE
UX: minor alignment adjustments for experiemental bot UI

### DIFF
--- a/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -153,7 +153,7 @@ body.has-ai-conversations-sidebar {
   .ai-bot-conversations {
     display: flex;
     flex-direction: column;
-    height: calc(100dvh - var(--header-offset) - 1.5em);
+    height: calc(100dvh - var(--header-offset) - 5em);
 
     .persona-llm-selector {
       display: flex;

--- a/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -204,7 +204,7 @@ body.has-ai-conversations-sidebar {
       }
 
       // optical centering for layout balance
-      @media screen and (height > 600px) {
+      @media screen and (min-height: 600px) {
         h1 {
           margin-top: -6em;
         }

--- a/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -7,12 +7,12 @@
 
 body.has-ai-conversations-sidebar {
   .ai-new-question-button {
-    margin: 1em 2em 1em 1em;
+    margin: 1.8em 1rem 0;
   }
 
   .sidebar-wrapper {
     .ai-conversations-panel {
-      padding-top: 0;
+      padding-top: 1em;
     }
 
     // ai related sidebar content
@@ -151,7 +151,9 @@ body.has-ai-conversations-sidebar {
   }
 
   .ai-bot-conversations {
-    height: calc(100dvh - var(--header-offset) - 1.25em);
+    display: flex;
+    flex-direction: column;
+    height: calc(100dvh - var(--header-offset) - 1.5em);
 
     .persona-llm-selector {
       display: flex;
@@ -195,14 +197,17 @@ body.has-ai-conversations-sidebar {
       box-sizing: border-box;
       align-items: center;
       justify-content: center;
-      height: calc(90% - 1.25em - var(--header-offset));
-
-      @include viewport.until(sm) {
-        height: calc(75% - 1.25em - var(--header-offset) - 2em);
-      }
+      flex: 1 1 auto;
 
       .loading-container {
         display: contents;
+      }
+
+      // optical centering for layout balance
+      @media screen and (height > 600px) {
+        h1 {
+          margin-top: -6em;
+        }
       }
     }
 


### PR DESCRIPTION
These are very minor changes that get us some more consistent alignment 

![align-ai](https://github.com/user-attachments/assets/084c95ae-0e10-427b-8df1-dad2d28f49b6)
![align-ai-2](https://github.com/user-attachments/assets/32215eaa-b751-4023-a52c-7e2e8a3af3ad)

This also avoids having this page scroll, especially when the "powered by discourse" badge is present 