### PR TITLE
UX: put full page search discoveries in sidebar

### DIFF
--- a/assets/javascripts/discourse/components/ai-full-page-search.gjs
+++ b/assets/javascripts/discourse/components/ai-full-page-search.gjs
@@ -213,8 +213,11 @@ export default class AiFullPageSearch extends Component {
   }
 
   <template>
-    <span {{didUpdate this.sortChanged @sortOrder}}></span>
-    <div class="semantic-search__container search-results" role="region">
+    <div
+      {{didUpdate this.sortChanged @sortOrder}}
+      class="semantic-search__container search-results"
+      role="region"
+    >
       <div class="semantic-search__results">
         <div
           class={{concatClass "semantic-search__searching" this.searchClass}}

--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/ai-full-page-discobot-discoveries.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/ai-full-page-discobot-discoveries.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import bodyClass from "discourse/helpers/body-class";
 import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import AiSearchDiscoveries from "../../components/ai-search-discoveries";
@@ -15,23 +16,39 @@ export default class AiFullPageDiscobotDiscoveries extends Component {
   }
 
   @service discobotDiscoveries;
+  @service site;
+
+  get previewLength() {
+    // todo: replace with js breakpoint API
+    // https://github.com/discourse/discourse/pull/32060
+    if (this.site.mobileView || this.site.narrowDesktopView) {
+      return 50;
+    } else {
+      return 10000;
+    }
+  }
 
   <template>
-    {{#if this.discobotDiscoveries.showDiscoveryTitle}}
-      <h3
-        class="ai-search-discoveries__discoveries-title full-page-discoveries"
-      >
-        <span>
-          {{icon "discobot"}}
-          {{i18n "discourse_ai.discobot_discoveries.main_title"}}
-        </span>
+    {{bodyClass "has-discoveries"}}
+    <div class="ai-search-discoveries__discoveries-wrapper">
+      {{#if this.discobotDiscoveries.showDiscoveryTitle}}
+        <h3
+          class="ai-search-discoveries__discoveries-title full-page-discoveries"
+        >
+          <span>
+            {{icon "discobot"}}
+            {{i18n "discourse_ai.discobot_discoveries.main_title"}}
+          </span>
+          <AiSearchDiscoveriesTooltip />
+        </h3>
+      {{/if}}
 
-        <AiSearchDiscoveriesTooltip />
-      </h3>
-    {{/if}}
-
-    <div class="full-page-discoveries">
-      <AiSearchDiscoveries @searchTerm={{@outletArgs.search}} />
+      <div class="full-page-discoveries">
+        <AiSearchDiscoveries
+          @discoveryPreviewLength={{this.previewLength}}
+          @searchTerm={{@outletArgs.search}}
+        />
+      </div>
     </div>
   </template>
 }

--- a/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 @keyframes fade-in {
   from {
     opacity: 0;
@@ -99,7 +101,11 @@
 }
 
 .full-page-discoveries {
-  padding: 1em 10%;
+  padding: 0 1rem;
+
+  @include viewport.until(md) {
+    padding: 0.25rem 1rem 0 1rem;
+  }
 }
 
 .d-icon-discobot {
@@ -164,6 +170,116 @@
       &::after {
         display: none;
       }
+    }
+  }
+}
+
+.search-page .ai-search-discoveries__discoveries-wrapper {
+  padding-bottom: 0.5rem;
+}
+
+.ai-search-discoveries__discoveries-title.full-page-discoveries {
+  border: none;
+  padding-top: 1rem;
+}
+
+@mixin discoveries-sidebar {
+  .full-page-discoveries {
+    padding: 1em 10%;
+  }
+
+  &.search-page.has-discoveries {
+    .semantic-search__container {
+      background: transparent;
+      margin: 0;
+    }
+
+    .semantic-search__container .semantic-search__results {
+      .semantic-search__searching {
+        margin-left: 0;
+      }
+
+      .semantic-search__searching-text {
+        margin-left: 1.25em;
+      }
+    }
+
+    .search-container .search-header {
+      padding: 1em 2em;
+    }
+
+    .semantic-search__container .search-results,
+    .search-container .search-advanced .search-results,
+    .search-container .search-advanced .search-info {
+      padding: 1em 2em;
+    }
+
+    .search-results .fps-result {
+      padding: 0;
+      margin-bottom: 2.5em;
+    }
+
+    .search-advanced {
+      display: grid;
+      grid-template-columns: 70% 30%;
+      grid-auto-rows: auto;
+
+      > * {
+        grid-column: 1;
+        align-self: start;
+      }
+    }
+
+    .search-info {
+      grid-row: 1;
+    }
+
+    .ai-search-discoveries__discoveries-title {
+      border: none;
+      margin-bottom: 0;
+      padding-bottom: 0;
+    }
+
+    .ai-search-discoveries__discoveries-wrapper {
+      grid-column: 2 / -1;
+      grid-row: 1 / 5;
+      border-left: 1px solid var(--primary-low);
+      align-self: stretch;
+
+      .cooked {
+        color: var(--primary-high);
+      }
+    }
+  }
+}
+
+body:not(.has-sidebar-page) {
+  @include viewport.from(md) {
+    @include discoveries-sidebar;
+  }
+}
+
+body.has-sidebar-page {
+  @include viewport.from(lg) {
+    @include discoveries-sidebar;
+  }
+
+  @include viewport.between(md, lg) {
+    .ai-search-discoveries__discoveries-wrapper {
+      padding-bottom: 0;
+    }
+
+    .ai-search-discoveries__discoveries-title {
+      padding-top: 1rem;
+    }
+
+    .search-container .search-advanced .search-info,
+    .semantic-search__container.search-results {
+      padding-inline: 10%;
+    }
+
+    .full-page-discoveries {
+      padding-inline: 10%;
     }
   }
 }

--- a/assets/stylesheets/modules/embeddings/common/semantic-search.scss
+++ b/assets/stylesheets/modules/embeddings/common/semantic-search.scss
@@ -1,6 +1,19 @@
+@use "lib/viewport";
+
 .semantic-search__container {
-  background: var(--primary-very-low);
-  margin: 1rem 0 1rem 0;
+  margin: 1rem 0 0 0;
+
+  .has-sidebar-page & {
+    @include viewport.until(lg) {
+      border-top: 1px solid var(--primary-low);
+    }
+  }
+
+  body:not(.has-sidebar-page) & {
+    @include viewport.until(md) {
+      border-top: 1px solid var(--primary-low);
+    }
+  }
 
   .semantic-search__results {
     display: flex;
@@ -15,13 +28,17 @@
       &__searching {
         display: flex;
         align-items: center;
-        margin-left: 5px;
 
         &.in-progress,
         &.unavailable {
           .semantic-search__searching-text {
             color: var(--primary-medium);
           }
+        }
+
+        svg {
+          font-size: var(--font-down-1);
+          color: var(--primary-high);
         }
       }
 
@@ -70,5 +87,18 @@
   .ai-quick-search-spinner ~ a.clear-search,
   .ai-quick-search-spinner ~ a.show-advanced-search {
     display: none;
+  }
+}
+
+@include viewport.until(md) {
+  .search-container .search-advanced .semantic-search__container {
+    + .search-info {
+      padding-inline: 1rem;
+    }
+
+    &.search-results {
+      margin-bottom: 0;
+      padding-inline: 1rem;
+    }
   }
 }


### PR DESCRIPTION
This puts the Discobot Discovery section into a right sidebar and adjusts related styles



Before:
![image](https://github.com/user-attachments/assets/4fd1fc37-d11d-4266-a02b-1174440320ec)


After:
![image](https://github.com/user-attachments/assets/de054432-281b-4834-b9e8-60d73298ccc7)


At narrow widths, we still stack:

![image](https://github.com/user-attachments/assets/0ca3362c-ce6c-4bbd-b84f-cc0491040919)
