### PR TITLE
UX: keep composer actions above AI input icons

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -281,7 +281,7 @@
   .composer-popup {
     // need to raise the z-index here
     // because we need another layer to put the AI icon above dropdowns
-    // while also keeping them below the composer tips
+    // while also keeping them below the composer tips and reply details dropdowns
     z-index: z("composer", "dropdown") + 2;
   }
 

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -277,6 +277,7 @@
 }
 
 #reply-control {
+  .reply-details,
   .composer-popup {
     // need to raise the z-index here
     // because we need another layer to put the AI icon above dropdowns


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/61acd742-a1ad-4762-81b1-5590917a621a)


After: 
![image](https://github.com/user-attachments/assets/ad4cc9e1-e685-483e-bd08-7fa379eb73da)
