### PR TITLE
Revert "UX: keep composer actions above AI input icons (#1291)"

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -277,11 +277,10 @@
 }
 
 #reply-control {
-  .reply-details,
   .composer-popup {
     // need to raise the z-index here
     // because we need another layer to put the AI icon above dropdowns
-    // while also keeping them below the composer tips and reply details dropdowns
+    // while also keeping them below the composer tips
     z-index: z("composer", "dropdown") + 2;
   }
 


### PR DESCRIPTION
This reverts commit 51a0516aa8c4caa13b01e47a6e8655659a9648ba.