### PR TITLE
UX: Adjust bot conversation header and sidebar on hamburger mode

### DIFF
--- a/assets/javascripts/discourse/components/ai-bot-header-icon.gjs
+++ b/assets/javascripts/discourse/components/ai-bot-header-icon.gjs
@@ -10,6 +10,7 @@ import { AI_CONVERSATIONS_PANEL } from "../services/ai-conversations-sidebar-man
 export default class AiBotHeaderIcon extends Component {
   @service composer;
   @service currentUser;
+  @service navigationMenu;
   @service router;
   @service sidebarState;
   @service siteSettings;
@@ -35,6 +36,7 @@ export default class AiBotHeaderIcon extends Component {
 
   get clickShouldRouteOutOfConversations() {
     return (
+      !this.navigationMenu.isHeaderDropdownMode &&
       this.siteSettings.ai_enable_experimental_bot_ux &&
       this.sidebarState.currentPanel?.key === AI_CONVERSATIONS_PANEL
     );

--- a/assets/javascripts/initializers/ai-conversations-sidebar.js
+++ b/assets/javascripts/initializers/ai-conversations-sidebar.js
@@ -29,13 +29,14 @@ export default {
       );
       const appEvents = api.container.lookup("service:app-events");
       const messageBus = api.container.lookup("service:message-bus");
+      const navigationMenu = api.container.lookup("service:navigationMenu");
 
       api.addSidebarPanel(
         (BaseCustomSidebarPanel) =>
           class AiConversationsSidebarPanel extends BaseCustomSidebarPanel {
             key = AI_CONVERSATIONS_PANEL;
             hidden = true;
-            displayHeader = true;
+            displayHeader = !navigationMenu.isHeaderDropdownMode;
             expandActiveSection = true;
           }
       );

--- a/spec/system/ai_bot/homepage_spec.rb
+++ b/spec/system/ai_bot/homepage_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "AI Bot - Homepage", type: :system do
 
     SiteSetting.ai_enable_experimental_bot_ux = true
     SiteSetting.ai_bot_enabled = true
-    SiteSetting.navigation_mode = "sidebar"
+    SiteSetting.navigation_menu = "sidebar"
     Jobs.run_immediately!
     SiteSetting.ai_bot_allowed_groups = "#{Group::AUTO_GROUPS[:trust_level_0]}"
     sign_in(user)

--- a/spec/system/ai_bot/homepage_spec.rb
+++ b/spec/system/ai_bot/homepage_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe "AI Bot - Homepage", type: :system do
 
     SiteSetting.ai_enable_experimental_bot_ux = true
     SiteSetting.ai_bot_enabled = true
+    SiteSetting.navigation_mode = "sidebar"
     Jobs.run_immediately!
     SiteSetting.ai_bot_allowed_groups = "#{Group::AUTO_GROUPS[:trust_level_0]}"
     sign_in(user)
@@ -121,15 +122,6 @@ RSpec.describe "AI Bot - Homepage", type: :system do
       expect(ai_pm_homepage).to have_too_short_dialog
       dialog.click_yes
       expect(composer).to be_closed
-    end
-
-    it "renders sidebar even when navigation menu is set to header" do
-      SiteSetting.navigation_menu = "header dropdown"
-      visit "/"
-      header.click_bot_button
-      expect(ai_pm_homepage).to have_homepage
-      expect(sidebar).to be_visible
-      expect(header_dropdown).to be_visible
     end
 
     it "hides default content in the sidebar" do
@@ -265,6 +257,31 @@ RSpec.describe "AI Bot - Homepage", type: :system do
       ai_pm_homepage.llm_selector.expand
       ai_pm_homepage.llm_selector.select_row_by_name(claude_2_dup.display_name)
       ai_pm_homepage.llm_selector.collapse
+    end
+
+    it "renders back to forum link" do
+      ai_pm_homepage.visit
+      expect(ai_pm_homepage).to have_sidebar_back_link
+    end
+
+    context "with hamburger menu" do
+      before { SiteSetting.navigation_menu = "header dropdown" }
+      it "keeps robot icon in the header and doesn't display sidebar back link" do
+        visit "/"
+        expect(header).to have_icon_in_bot_button(icon: "robot")
+        header.click_bot_button
+        expect(ai_pm_homepage).to have_homepage
+        expect(header).to have_icon_in_bot_button(icon: "robot")
+        expect(ai_pm_homepage).to have_no_sidebar_back_link
+      end
+
+      it "still renders the sidebar" do
+        visit "/"
+        header.click_bot_button
+        expect(ai_pm_homepage).to have_homepage
+        expect(sidebar).to be_visible
+        expect(header_dropdown).to be_visible
+      end
     end
   end
 

--- a/spec/system/page_objects/components/ai_pm_homepage.rb
+++ b/spec/system/page_objects/components/ai_pm_homepage.rb
@@ -53,6 +53,14 @@ module PageObjects
       def llm_selector
         PageObjects::Components::SelectKit.new(".persona-llm-selector__llm-dropdown")
       end
+
+      def has_sidebar_back_link?
+        page.has_css?(".sidebar-sections__back-to-forum")
+      end
+
+      def has_no_sidebar_back_link?
+        page.has_no_css?(".sidebar-sections__back-to-forum")
+      end
     end
   end
 end


### PR DESCRIPTION
Context in dev conversation -- in hamburger mode we don't need the robot icon to swap to shuffle, AND we don't need back to forum like.

Relies on -> https://github.com/discourse/discourse/pull/32515