### PR TITLE
UX: increase composer action z-index above ai suggestion

### DIFF
--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -277,6 +277,7 @@
 }
 
 #reply-control {
+  .composer-actions.is-expanded,
   .composer-popup {
     // need to raise the z-index here
     // because we need another layer to put the AI icon above dropdowns


### PR DESCRIPTION
51a0516 was reverted because it put the autocomplete popup below the composer actions — this follow-up makes the same change but only applies it when the composer actions dropdown is open. Using `is-expanded` ensures it's above the AI suggestion icons, but cannot be above the composer suggestions because the action menu closes when the suggestions are opened

Previously:

![image](https://github.com/user-attachments/assets/5f082fba-5aff-4be9-a709-46198eabbfb9)

Now: 

![image](https://github.com/user-attachments/assets/aa8996ed-1a97-4c28-9aaf-297b5bdc7e16)

The original issue, also fixed: 

Before:
![image](https://github.com/user-attachments/assets/61acd742-a1ad-4762-81b1-5590917a621a)


After: 
![image](https://github.com/user-attachments/assets/ad4cc9e1-e685-483e-bd08-7fa379eb73da)
