### PR TITLE
FIX: Invalid access error should be populated to user

### DIFF
--- a/app/controllers/discourse_ai/embeddings/embeddings_controller.rb
+++ b/app/controllers/discourse_ai/embeddings/embeddings_controller.rb
@@ -46,11 +46,19 @@ module DiscourseAi
         end
 
         hijack do
-          semantic_search
-            .search_for_topics(query, _page = 1, hyde: !skip_hyde)
-            .each { |topic_post| grouped_results.add(topic_post) }
+          begin
+            semantic_search
+              .search_for_topics(query, _page = 1, hyde: !skip_hyde)
+              .each { |topic_post| grouped_results.add(topic_post) }
 
-          render_serialized(grouped_results, GroupedSearchResultSerializer, result: grouped_results)
+            render_serialized(
+              grouped_results,
+              GroupedSearchResultSerializer,
+              result: grouped_results,
+            )
+          rescue Discourse::InvalidAccess
+            render_json_error(I18n.t("invalid_access"), status: 403)
+          end
         end
       end
 

--- a/assets/javascripts/discourse/components/ai-full-page-search.gjs
+++ b/assets/javascripts/discourse/components/ai-full-page-search.gjs
@@ -9,6 +9,7 @@ import { SEARCH_TYPE_DEFAULT } from "discourse/controllers/full-page-search";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
 import { isValidSearchTerm, translateResults } from "discourse/lib/search";
 import { i18n } from "discourse-i18n";
 import DTooltip from "float-kit/components/d-tooltip";
@@ -193,6 +194,7 @@ export default class AiFullPageSearch extends Component {
 
         this.AiResults = model.posts;
       })
+      .catch(popupAjaxError)
       .finally(() => {
         this.searching = false;
       });


### PR DESCRIPTION
## :mag: Overview
Invalid access error should be populated to user when trying to search for something they do not have permissions for (i.e. anons searching `in:messages`

This PR has no tests, as there is an upcoming overarching todo to add specs for search and will be covered there instead.

## 📸 Screenshots

### ← Before
<img width="944" alt="Screenshot 2025-04-30 at 11 58 01" src="https://github.com/user-attachments/assets/75fc04b7-90fe-46df-852a-b379df9e8e39" />

```
Failed to process hijacked response correctly : Discourse::InvalidAccess : Discourse::InvalidAccess
```

### → After
<img width="879" alt="Screenshot 2025-04-30 at 11 55 06" src="https://github.com/user-attachments/assets/8a692e14-59fb-4bcf-8670-8a7137679b89" />
