### PR TITLE
FIX: system persona state leaking between sites

### DIFF
--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -459,7 +459,7 @@ module DiscourseAi
               post_type: post_type,
               skip_guardian: true,
               custom_fields: {
-                DiscourseAi::AiBot::POST_AI_LLM_NAME_FIELD => bot.llm.llm_model.name,
+                DiscourseAi::AiBot::POST_AI_LLM_NAME_FIELD => bot.llm.llm_model.display_name,
               },
             )
 

--- a/lib/personas/persona.rb
+++ b/lib/personas/persona.rb
@@ -128,7 +128,8 @@ module DiscourseAi
       end
 
       def id
-        @ai_persona&.id || self.class.system_personas[self.class]
+        @ai_persona&.id || self.class.system_personas[self.class.superclass] ||
+          self.class.system_personas[self.class]
       end
 
       def tools

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -785,7 +785,7 @@ RSpec.describe DiscourseAi::AiBot::Playground do
       expect(last_post.user_id).to eq(persona.user_id)
 
       expect(last_post.custom_fields[DiscourseAi::AiBot::POST_AI_LLM_NAME_FIELD]).to eq(
-        gpt_35_turbo.name,
+        gpt_35_turbo.display_name,
       )
     end
 

--- a/spec/lib/personas/persona_spec.rb
+++ b/spec/lib/personas/persona_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe DiscourseAi::Personas::Persona do
       SiteSetting.ai_google_custom_search_cx = "abc123"
 
       # should be ordered by priority and then alpha
-      expect(DiscourseAi::Personas::Persona.all(user: user)).to eq(
+      expect(DiscourseAi::Personas::Persona.all(user: user).map(&:superclass)).to eq(
         [
           DiscourseAi::Personas::General,
           DiscourseAi::Personas::Artist,
@@ -226,7 +226,7 @@ RSpec.describe DiscourseAi::Personas::Persona do
       )
 
       # it should allow staff access to WebArtifactCreator
-      expect(DiscourseAi::Personas::Persona.all(user: admin)).to eq(
+      expect(DiscourseAi::Personas::Persona.all(user: admin).map(&:superclass)).to eq(
         [
           DiscourseAi::Personas::General,
           DiscourseAi::Personas::Artist,
@@ -245,7 +245,7 @@ RSpec.describe DiscourseAi::Personas::Persona do
       SiteSetting.ai_google_custom_search_api_key = ""
       SiteSetting.ai_artifact_security = "disabled"
 
-      expect(DiscourseAi::Personas::Persona.all(user: admin)).to contain_exactly(
+      expect(DiscourseAi::Personas::Persona.all(user: admin).map(&:superclass)).to contain_exactly(
         DiscourseAi::Personas::General,
         DiscourseAi::Personas::SqlHelper,
         DiscourseAi::Personas::SettingsExplorer,
@@ -258,7 +258,7 @@ RSpec.describe DiscourseAi::Personas::Persona do
         DiscourseAi::Personas::Persona.system_personas[DiscourseAi::Personas::General],
       ).update!(enabled: false)
 
-      expect(DiscourseAi::Personas::Persona.all(user: user)).to contain_exactly(
+      expect(DiscourseAi::Personas::Persona.all(user: user).map(&:superclass)).to contain_exactly(
         DiscourseAi::Personas::SqlHelper,
         DiscourseAi::Personas::SettingsExplorer,
         DiscourseAi::Personas::Creative,

--- a/spec/models/ai_persona_multisite_spec.rb
+++ b/spec/models/ai_persona_multisite_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe AiPersona, type: :multisite do
+  it "is able to amend settings on system personas on multisite" do
+    persona = AiPersona.find_by(name: "Designer")
+    expect(persona.allow_personal_messages).to eq(true)
+    persona.update!(allow_personal_messages: false)
+
+    instance = persona.class_instance
+    expect(instance.allow_personal_messages).to eq(false)
+
+    test_multisite_connection("second") do
+      persona = AiPersona.find_by(name: "Designer")
+      expect(persona.allow_personal_messages).to eq(true)
+      instance = persona.class_instance
+      expect(instance.name).to eq("Designer")
+      expect(instance.allow_personal_messages).to eq(true)
+    end
+
+    persona = AiPersona.find_by(name: "Designer")
+    instance = persona.class_instance
+    expect(instance.allow_personal_messages).to eq(false)
+  end
+end


### PR DESCRIPTION
System personas leaned on reused classes, this was a problem
in a multisite environement cause state, such as "enabled"
ended up being reused between sites.

New implementation ensures state is pristine between sites in
a multisite

