### PR TITLE
FIX: better LLM feedback for image generation failures 

### DIFF
--- a/lib/inference/open_ai_image_generator.rb
+++ b/lib/inference/open_ai_image_generator.rb
@@ -42,8 +42,7 @@ module ::DiscourseAi
 
         raise api_responses[0] if api_responses.all? { |resp| resp.is_a?(StandardError) }
 
-        api_responses =
-          api_responses.filter { |response| !response.is_a?(StandardError) }
+        api_responses = api_responses.filter { |response| !response.is_a?(StandardError) }
 
         create_uploads_from_responses(api_responses, user_id, for_private_message, title)
       end

--- a/lib/inference/open_ai_image_generator.rb
+++ b/lib/inference/open_ai_image_generator.rb
@@ -213,14 +213,16 @@ module ::DiscourseAi
           )
         rescue => e
           attempts += 1
-          sleep 2
-          retry if attempts < 3
-          if Rails.env.development? || Rails.env.test?
+          if !Rails.env.test?
+            sleep 2
+            retry if attempts < 3
+          end
+          if Rails.env.development?
             puts "Error editing image(s) with prompt: #{prompt} #{e}"
             p e
           end
           Discourse.warn_exception(e, message: "Failed to edit image(s) with prompt #{prompt}")
-          nil
+          raise e
         end
       end
 

--- a/lib/inference/open_ai_image_generator.rb
+++ b/lib/inference/open_ai_image_generator.rb
@@ -43,7 +43,7 @@ module ::DiscourseAi
         raise api_responses[0] if api_responses.all? { |resp| resp.is_a?(StandardError) }
 
         api_responses =
-          api_responses.filter_map { |response| response.is_a?(StandardError) ? nil : response }
+          api_responses.filter { |response| !response.is_a?(StandardError) }
 
         create_uploads_from_responses(api_responses, user_id, for_private_message, title)
       end

--- a/lib/personas/tools/create_image.rb
+++ b/lib/personas/tools/create_image.rb
@@ -30,7 +30,7 @@ module DiscourseAi
         end
 
         def chain_next_response?
-          false
+          !!@error
         end
 
         def invoke
@@ -42,14 +42,20 @@ module DiscourseAi
 
           results = nil
 
-          results =
-            DiscourseAi::Inference::OpenAiImageGenerator.create_uploads!(
-              max_prompts,
-              model: "gpt-image-1",
-              user_id: bot_user.id,
-            )
+          begin
+            results =
+              DiscourseAi::Inference::OpenAiImageGenerator.create_uploads!(
+                max_prompts,
+                model: "gpt-image-1",
+                user_id: bot_user.id,
+              )
+          rescue => e
+            @error = e
+            return { prompts: max_prompts, error: e.message }
+          end
 
           if results.blank?
+            @error = true
             return { prompts: max_prompts, error: "Something went wrong, could not generate image" }
           end
 


### PR DESCRIPTION
When image edit or creation fails for any sort of reason we should properly inform the LLM of what happened. 

This allows it to self correct. 
