### PR TITLE
FEATURE: forum researcher persona for deep research

### DIFF
--- a/assets/javascripts/discourse/lib/ai-streamer/progress-handlers.js
+++ b/assets/javascripts/discourse/lib/ai-streamer/progress-handlers.js
@@ -2,7 +2,7 @@ import { later } from "@ember/runloop";
 import PostUpdater from "./updaters/post-updater";
 
 const PROGRESS_INTERVAL = 40;
-const GIVE_UP_INTERVAL = 60000;
+const GIVE_UP_INTERVAL = 600000; // 10 minutes which is our max thinking time for now
 export const MIN_LETTERS_PER_INTERVAL = 6;
 const MAX_FLUSH_TIME = 800;
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -306,8 +306,8 @@ en:
           name: Settings Explorer
           description: "AI Bot specialized in helping explore Discourse site settings"
         researcher:
-          name: Researcher
-          description: "AI Bot with Google access that can research information for you"
+          name: Web Researcher
+          description: "AI Bot with Google access that can both search and read web pages"
         creative:
           name: Creative
           description: "AI Bot with no external integrations specialized in creative tasks"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -337,6 +337,9 @@ en:
           include_private:
             name: "Include private"
             description: "Include private topics in the filters"
+          max_tokens_per_post:
+            name: "Maximum tokens per post"
+            description: "Maximum number of tokens to use for each post in the filter"
         create_artifact:
           creator_llm:
             name: "LLM"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -330,6 +330,13 @@ en:
       summarizing: "Summarizing topic"
       searching: "Searching for: '%{query}'"
       tool_options:
+        researcher:
+          max_results:
+            name: "Maximum number of results"
+            description: "Maximum number of results to include in a filter"
+          include_private:
+            name: "Include private"
+            description: "Include private topics in the filters"
         create_artifact:
           creator_llm:
             name: "LLM"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -457,9 +457,12 @@ en:
           other: "Found %{count} <a href='%{url}'>results</a> for '%{query}'"
         setting_context: "Reading context for: %{setting_name}"
         schema: "%{tables}"
+        researcher_dry_run:
+          one: "Proposed research: %{goals}\n\nFound %{count} result for '%{filter}'"
+          other: "Proposed research: %{goals}\n\nFound %{count} result for '%{filter}'"
         researcher:
-          one: "Found %{count} result for '%{filter}'"
-          other: "Found %{count} results for '%{filter}'"
+          one: "Researching: %{goals}\n\nFound %{count} result for '%{filter}'"
+          other: "Researching: %{goals}\n\nFound %{count} result for '%{filter}'"
         search_settings:
           one: "Found %{count} result for '%{query}'"
           other: "Found %{count} results for '%{query}'"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -296,6 +296,9 @@ en:
         designer:
           name: Designer
           description: "AI Bot specialized in generating and editing images"
+        forum_researcher:
+          name: Forum Researcher
+          description: "AI Bot specialized in deep research for the forum"
         sql_helper:
           name: SQL Helper
           description: "AI Bot specialized in helping craft SQL queries on this Discourse instance"
@@ -385,6 +388,7 @@ en:
         javascript_evaluator: "Evaluate JavaScript"
         create_image: "Creating image"
         edit_image: "Editing image"
+        researcher: "Researching"
       tool_help:
         read_artifact: "Read a web artifact using the AI Bot"
         update_artifact: "Update a web artifact using the AI Bot"
@@ -411,6 +415,7 @@ en:
         dall_e: "Generate image using DALL-E 3"
         search_meta_discourse: "Search Meta Discourse"
         javascript_evaluator: "Evaluate JavaScript"
+        researcher: "Research forum information using the AI Bot"
       tool_description:
         read_artifact: "Read a web artifact using the AI Bot"
         update_artifact: "Updated a web artifact using the AI Bot"
@@ -445,6 +450,9 @@ en:
           other: "Found %{count} <a href='%{url}'>results</a> for '%{query}'"
         setting_context: "Reading context for: %{setting_name}"
         schema: "%{tables}"
+        researcher:
+          one: "Found %{count} result for '%{filter}'"
+          other: "Found %{count} results for '%{filter}'"
         search_settings:
           one: "Found %{count} result for '%{query}'"
           other: "Found %{count} results for '%{query}'"

--- a/db/fixtures/personas/603_ai_personas.rb
+++ b/db/fixtures/personas/603_ai_personas.rb
@@ -33,7 +33,7 @@ DiscourseAi::Personas::Persona.system_personas.each do |persona_class, id|
       persona.allowed_group_ids = [Group::AUTO_GROUPS[:trust_level_0]]
     end
 
-    persona.enabled = !summarization_personas.include?(persona_class)
+    persona.enabled = persona_class.default_enabled
     persona.priority = true if persona_class == DiscourseAi::Personas::General
   end
 

--- a/lib/ai_bot/chat_streamer.rb
+++ b/lib/ai_bot/chat_streamer.rb
@@ -6,16 +6,23 @@
 module DiscourseAi
   module AiBot
     class ChatStreamer
-      attr_accessor :cancel
       attr_reader :reply,
                   :guardian,
                   :thread_id,
                   :force_thread,
                   :in_reply_to_id,
                   :channel,
-                  :cancelled
+                  :cancel_manager
 
-      def initialize(message:, channel:, guardian:, thread_id:, in_reply_to_id:, force_thread:)
+      def initialize(
+        message:,
+        channel:,
+        guardian:,
+        thread_id:,
+        in_reply_to_id:,
+        force_thread:,
+        cancel_manager: nil
+      )
         @message = message
         @channel = channel
         @guardian = guardian
@@ -35,6 +42,8 @@ module DiscourseAi
             guardian: guardian,
             thread_id: thread_id,
           )
+
+        @cancel_manager = cancel_manager
       end
 
       def <<(partial)
@@ -111,8 +120,7 @@ module DiscourseAi
 
           streaming = ChatSDK::Message.stream(message_id: reply.id, raw: buffer, guardian: guardian)
           if !streaming
-            cancel.call
-            @cancelled = true
+            @cancel_manager.cancel! if @cancel_manager
           end
         end
       end

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -331,6 +331,7 @@ module DiscourseAi
               ),
             user: message.user,
             skip_tool_details: true,
+            cancel_manager: DiscourseAi::Completions::CancelManager.new,
           )
 
         reply = nil
@@ -347,15 +348,14 @@ module DiscourseAi
             thread_id: message.thread_id,
             in_reply_to_id: in_reply_to_id,
             force_thread: force_thread,
+            cancel_manager: context.cancel_manager,
           )
 
         new_prompts =
-          bot.reply(context) do |partial, cancel, placeholder, type|
+          bot.reply(context) do |partial, placeholder, type|
             # no support for tools or thinking by design
             next if type == :thinking || type == :tool_details || type == :partial_tool
-            streamer.cancel = cancel
             streamer << partial
-            break if streamer.cancelled
           end
 
         reply = streamer.reply
@@ -383,6 +383,7 @@ module DiscourseAi
         auto_set_title: true,
         silent_mode: false,
         feature_name: nil,
+        cancel_manager: nil,
         &blk
       )
         # this is a multithreading issue
@@ -472,22 +473,25 @@ module DiscourseAi
           redis_stream_key = "gpt_cancel:#{reply_post.id}"
           Discourse.redis.setex(redis_stream_key, MAX_STREAM_DELAY_SECONDS, 1)
 
-          context.cancel_manager = DiscourseAi::Completions::CancelManager.new
+          cancel_manager ||= DiscourseAi::Completions::CancelManager.new
+          context.cancel_manager = cancel_manager
           context
             .cancel_manager
             .start_monitor(delay: 0.2) do
               context.cancel_manager.cancel! if !Discourse.redis.get(redis_stream_key)
             end
+
+          context.cancel_manager.add_callback(
+            lambda { reply_post.update!(raw: reply, cooked: PrettyText.cook(reply)) },
+          )
         end
 
         context.skip_tool_details ||= !bot.persona.class.tool_details
-
         post_streamer = PostStreamer.new(delay: Rails.env.test? ? 0 : 0.5) if stream_reply
-
         started_thinking = false
 
         new_custom_prompts =
-          bot.reply(context) do |partial, cancel, placeholder, type|
+          bot.reply(context) do |partial, placeholder, type|
             if type == :thinking && !started_thinking
               reply << "<details><summary>#{I18n.t("discourse_ai.ai_bot.thinking")}</summary>"
               started_thinking = true
@@ -504,15 +508,6 @@ module DiscourseAi
 
             if blk && type != :tool_details && type != :partial_tool && type != :partial_invoke
               blk.call(partial)
-            end
-
-            if stream_reply && !Discourse.redis.get(redis_stream_key)
-              cancel&.call
-              reply_post.update!(raw: reply, cooked: PrettyText.cook(reply))
-              # we do not break out, cause if we do
-              # we will not get results from bot
-              # leading to broken context
-              # we need to trust it to cancel at the endpoint
             end
 
             if post_streamer

--- a/lib/completions/cancel_manager.rb
+++ b/lib/completions/cancel_manager.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# special object that can be used to cancel completions and http requests
+module DiscourseAi
+  module Completions
+    class CancelManager
+      attr_reader :cancelled
+      attr_reader :callbacks
+
+      def initialize
+        @cancelled = false
+        @callbacks = Concurrent::Array.new
+        @mutex = Mutex.new
+        @monitor_thread = nil
+      end
+
+      def monitor_thread
+        @mutex.synchronize { @monitor_thread }
+      end
+
+      def start_monitor(delay: 0.5, &block)
+        @mutex.synchronize do
+          raise "Already monitoring" if @monitor_thread
+          raise "Expected a block" if !block
+
+          db = RailsMultisite::ConnectionManagement.current_db
+          @stop_monitor = false
+
+          @monitor_thread =
+            Thread.new do
+              begin
+                loop do
+                  @mutex.synchronize { break if @stop_monitor }
+                  sleep delay
+                  @mutex.synchronize { break if @stop_monitor }
+                  @mutex.synchronize { break if cancelled? }
+
+                  should_cancel = false
+                  RailsMultisite::ConnectionManagement.with_connection(db) do
+                    should_cancel = block.call
+                  end
+
+                  @mutex.synchronize { cancel! if should_cancel }
+
+                  break if cancelled?
+                end
+              ensure
+                @mutex.synchronize { @monitor_thread = nil }
+              end
+            end
+        end
+      end
+
+      def stop_monitor
+        monitor_thread = nil
+
+        @mutex.synchronize { monitor_thread = @monitor_thread }
+
+        if monitor_thread
+          @mutex.synchronize { @stop_monitor = true }
+          # so we do not deadlock
+          monitor_thread.wakeup
+          monitor_thread.join(2)
+          # should not happen
+          if monitor_thread.alive?
+            Rails.logger.warn("DiscourseAI: CancelManager monitor thread did not stop in time")
+            monitor_thread.kill if monitor_thread.alive?
+          end
+        end
+      end
+
+      def cancelled?
+        @cancelled
+      end
+
+      def add_callback(cb)
+        @callbacks << cb
+      end
+
+      def remove_callback(cb)
+        @callbacks.delete(cb)
+      end
+
+      def cancel!
+        @cancelled = true
+        @callbacks.each do |cb|
+          begin
+            cb.call
+          rescue StandardError
+            # ignore cause this may have already been cancelled
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/completions/cancel_manager.rb
+++ b/lib/completions/cancel_manager.rb
@@ -30,10 +30,13 @@ module DiscourseAi
             Thread.new do
               begin
                 loop do
-                  @mutex.synchronize { break if @stop_monitor }
+                  done = false
+                  @mutex.synchronize { done = true if @stop_monitor }
+                  break if done
                   sleep delay
-                  @mutex.synchronize { break if @stop_monitor }
-                  @mutex.synchronize { break if cancelled? }
+                  @mutex.synchronize { done = true if @stop_monitor }
+                  @mutex.synchronize { done = true if cancelled? }
+                  break if done
 
                   should_cancel = false
                   RailsMultisite::ConnectionManagement.with_connection(db) do

--- a/lib/completions/endpoints/canned_response.rb
+++ b/lib/completions/endpoints/canned_response.rb
@@ -30,7 +30,8 @@ module DiscourseAi
           feature_name: nil,
           feature_context: nil,
           partial_tool_calls: false,
-          output_thinking: false
+          output_thinking: false,
+          cancel_manager: nil
         )
           @dialect = dialect
           @model_params = model_params

--- a/lib/completions/endpoints/fake.rb
+++ b/lib/completions/endpoints/fake.rb
@@ -122,7 +122,8 @@ module DiscourseAi
           feature_name: nil,
           feature_context: nil,
           partial_tool_calls: false,
-          output_thinking: false
+          output_thinking: false,
+          cancel_manager: nil
         )
           last_call = { dialect: dialect, user: user, model_params: model_params }
           self.class.last_call = last_call

--- a/lib/completions/endpoints/open_ai.rb
+++ b/lib/completions/endpoints/open_ai.rb
@@ -46,6 +46,7 @@ module DiscourseAi
           feature_context: nil,
           partial_tool_calls: false,
           output_thinking: false,
+          cancel_manager: nil,
           &blk
         )
           @disable_native_tools = dialect.disable_native_tools?

--- a/lib/completions/llm.rb
+++ b/lib/completions/llm.rb
@@ -307,7 +307,7 @@ module DiscourseAi
       # @param response_format { Hash - Optional } - JSON schema passed to the API as the desired structured output.
       # @param [Experimental] extra_model_params { Hash - Optional } - Other params that are not available accross models. e.g. response_format JSON schema.
       #
-      # @param &on_partial_blk { Block - Optional } - The passed block will get called with the LLM partial response alongside a cancel function.
+      # @param &on_partial_blk { Block - Optional } - The passed block will get called with the LLM partial response.
       #
       # @returns String | ToolCall - Completion result.
       # if multiple tools or a tool and a message come back, the result will be an array of ToolCall / String objects.

--- a/lib/completions/llm.rb
+++ b/lib/completions/llm.rb
@@ -325,6 +325,7 @@ module DiscourseAi
         output_thinking: false,
         response_format: nil,
         extra_model_params: nil,
+        cancel_manager: nil,
         &partial_read_blk
       )
         self.class.record_prompt(
@@ -378,6 +379,7 @@ module DiscourseAi
           feature_context: feature_context,
           partial_tool_calls: partial_tool_calls,
           output_thinking: output_thinking,
+          cancel_manager: cancel_manager,
           &partial_read_blk
         )
       end

--- a/lib/completions/prompt_messages_builder.rb
+++ b/lib/completions/prompt_messages_builder.rb
@@ -247,6 +247,10 @@ module DiscourseAi
         # 3. ensures we always interleave user and model messages
         last_type = nil
         messages.each do |message|
+          if message[:type] == :model && !message[:content]
+            message[:content] = "Reply cancelled by user."
+          end
+
           next if !last_type && message[:type] != :user
 
           if last_type == :tool_call && message[:type] != :tool

--- a/lib/discord/bot/persona_replier.rb
+++ b/lib/discord/bot/persona_replier.rb
@@ -24,7 +24,7 @@ module DiscourseAi
         full_reply =
           @bot.reply(
             { conversation_context: [{ type: :user, content: @query }], skip_tool_details: true },
-          ) do |partial, _cancel, _something|
+          ) do |partial, _something|
             reply << partial
             next if reply.blank?
 

--- a/lib/inference/open_ai_image_generator.rb
+++ b/lib/inference/open_ai_image_generator.rb
@@ -162,10 +162,10 @@ module ::DiscourseAi
             rescue => e
               attempts += 1
               # to keep tests speedy
-              if !Rails.env.test? && !cancel_manager&.canceled?
+              if !Rails.env.test? && !cancel_manager&.cancelled?
                 retry if attempts < 3
               end
-              if !cancel_manager&.canceled?
+              if !cancel_manager&.cancelled?
                 Discourse.warn_exception(
                   e,
                   message: "Failed to generate image for prompt #{prompt}\n",
@@ -221,7 +221,7 @@ module ::DiscourseAi
             cancel_manager: cancel_manager,
           )
         rescue => e
-          raise e if cancel_manager&.canceled?
+          raise e if cancel_manager&.cancelled?
           attempts += 1
           if !Rails.env.test?
             sleep 2

--- a/lib/personas/artifact_update_strategies/base.rb
+++ b/lib/personas/artifact_update_strategies/base.rb
@@ -5,15 +5,24 @@ module DiscourseAi
       class InvalidFormatError < StandardError
       end
       class Base
-        attr_reader :post, :user, :artifact, :artifact_version, :instructions, :llm
+        attr_reader :post, :user, :artifact, :artifact_version, :instructions, :llm, :cancel_manager
 
-        def initialize(llm:, post:, user:, artifact:, artifact_version:, instructions:)
+        def initialize(
+          llm:,
+          post:,
+          user:,
+          artifact:,
+          artifact_version:,
+          instructions:,
+          cancel_manager:
+        )
           @llm = llm
           @post = post
           @user = user
           @artifact = artifact
           @artifact_version = artifact_version
           @instructions = instructions
+          @cancel_manager = cancel_manager
         end
 
         def apply(&progress)
@@ -26,7 +35,7 @@ module DiscourseAi
 
         def generate_changes(&progress)
           response = +""
-          llm.generate(build_prompt, user: user) do |partial|
+          llm.generate(build_prompt, user: user, cancel_manager: cancel_manager) do |partial|
             progress.call(partial) if progress
             response << partial
           end

--- a/lib/personas/artifact_update_strategies/base.rb
+++ b/lib/personas/artifact_update_strategies/base.rb
@@ -14,7 +14,7 @@ module DiscourseAi
           artifact:,
           artifact_version:,
           instructions:,
-          cancel_manager:
+          cancel_manager: nil
         )
           @llm = llm
           @post = post

--- a/lib/personas/bot.rb
+++ b/lib/personas/bot.rb
@@ -55,6 +55,7 @@ module DiscourseAi
         unless context.is_a?(BotContext)
           raise ArgumentError, "context must be an instance of BotContext"
         end
+        context.cancel_manager ||= DiscourseAi::Completions::CancelManager.new
         current_llm = llm
         prompt = persona.craft_prompt(context, llm: current_llm)
 
@@ -91,6 +92,7 @@ module DiscourseAi
               feature_name: context.feature_name,
               partial_tool_calls: allow_partial_tool_calls,
               output_thinking: true,
+              cancel_manager: context.cancel_manager,
               **llm_kwargs,
             ) do |partial, cancel|
               tool =

--- a/lib/personas/bot_context.rb
+++ b/lib/personas/bot_context.rb
@@ -34,7 +34,8 @@ module DiscourseAi
         channel_id: nil,
         context_post_ids: nil,
         feature_name: "bot",
-        resource_url: nil
+        resource_url: nil,
+        cancel_manager: nil
       )
         @participants = participants
         @user = user
@@ -54,6 +55,8 @@ module DiscourseAi
 
         @feature_name = feature_name
         @resource_url = resource_url
+
+        @cancel_manager = cancel_manager
 
         if post
           @post_id = post.id

--- a/lib/personas/bot_context.rb
+++ b/lib/personas/bot_context.rb
@@ -16,7 +16,8 @@ module DiscourseAi
                     :channel_id,
                     :context_post_ids,
                     :feature_name,
-                    :resource_url
+                    :resource_url,
+                    :cancel_manager
 
       def initialize(
         post: nil,

--- a/lib/personas/forum_researcher.rb
+++ b/lib/personas/forum_researcher.rb
@@ -1,0 +1,29 @@
+#frozen_string_literal: true
+
+module DiscourseAi
+  module Personas
+    class ForumResearcher < Persona
+      def tools
+        [Tools::Researcher]
+      end
+
+      def system_prompt
+        <<~PROMPT
+            You are a helpful Discourse assistant specializing in forum research.
+            You _understand_ and **generate** Discourse Markdown.
+
+            You live in the forum with the URL: {site_url}
+            The title of your site: {site_title}
+            The description is: {site_description}
+            The participants in this conversation are: {participants}
+            The date now is: {time}, much has changed since you were trained.
+
+            As a forum researcher, you will help users come up with the correct research criteria to
+            properly analyze the forum data.
+
+            You will always start with a dry_run of the proposed research criteria.
+          PROMPT
+      end
+    end
+  end
+end

--- a/lib/personas/forum_researcher.rb
+++ b/lib/personas/forum_researcher.rb
@@ -3,6 +3,10 @@
 module DiscourseAi
   module Personas
     class ForumResearcher < Persona
+      def self.default_enabled
+        false
+      end
+
       def tools
         [Tools::Researcher]
       end

--- a/lib/personas/forum_researcher.rb
+++ b/lib/personas/forum_researcher.rb
@@ -22,13 +22,29 @@ module DiscourseAi
             The participants in this conversation are: {participants}
             The date now is: {time}, much has changed since you were trained.
 
-            As a forum researcher, you will help users come up with the correct research criteria to
-            properly analyze the forum data.
+            As a forum researcher, guide users through a structured research process:
+            1. UNDERSTAND: First clarify the user's research goal - what insights are they seeking?
+            2. PLAN: Design an appropriate research approach with specific filters
+            3. TEST: Always begin with dry_run:true to gauge the scope of results
+            4. REFINE: If results are too broad/narrow, suggest filter adjustments
+            5. EXECUTE: Run the final analysis only when filters are well-tuned
+            6. SUMMARIZE: Present findings with links to supporting evidence
 
-            BE MINDFUL: when running the research tool, specify all the goals you want to achieve in one go, avoid running research multiple times in one turn.
+            BE MINDFUL: specify all research goals in one request to avoid multiple processing runs.
 
-            When creating reports ALWAYS bias grounding information you provide with links to original posts on the forum.
-            You will always start with a dry_run of the proposed research criteria.
+            REMEMBER: Different filters serve different purposes:
+            - Use post date filters (after/before) for analyzing specific posts
+            - Use topic date filters (topic_after/topic_before) for analyzing entire topics
+            - Combine user/group filters with categories/tags to find specialized contributions
+
+            Always ground your analysis with links to original posts on the forum.
+
+            Research workflow best practices:
+            1. Start with a dry_run to gauge the scope (set dry_run:true)
+            2. If results are too numerous (>1000), add more specific filters
+            3. If results are too few (<5), broaden your filters
+            4. For temporal analysis, specify explicit date ranges
+            5. For user behavior analysis, combine @username with categories or tags
           PROMPT
       end
     end

--- a/lib/personas/forum_researcher.rb
+++ b/lib/personas/forum_researcher.rb
@@ -25,6 +25,9 @@ module DiscourseAi
             As a forum researcher, you will help users come up with the correct research criteria to
             properly analyze the forum data.
 
+            BE MINDFUL: when running the research tool, specify all the goals you want to achieve in one go, avoid running research multiple times in one turn.
+
+            When creating reports ALWAYS bias grounding information you provide with links to original posts on the forum.
             You will always start with a dry_run of the proposed research criteria.
           PROMPT
       end

--- a/lib/personas/persona.rb
+++ b/lib/personas/persona.rb
@@ -47,6 +47,7 @@ module DiscourseAi
             Summarizer => -11,
             ShortSummarizer => -12,
             Designer => -13,
+            ForumResearcher => -14,
           }
         end
 
@@ -99,6 +100,7 @@ module DiscourseAi
             Tools::GithubSearchFiles,
             Tools::WebBrowser,
             Tools::JavascriptEvaluator,
+            Tools::Researcher,
           ]
 
           if SiteSetting.ai_artifact_security.in?(%w[lax strict])

--- a/lib/personas/persona.rb
+++ b/lib/personas/persona.rb
@@ -4,6 +4,10 @@ module DiscourseAi
   module Personas
     class Persona
       class << self
+        def default_enabled
+          true
+        end
+
         def rag_conversation_chunks
           10
         end

--- a/lib/personas/short_summarizer.rb
+++ b/lib/personas/short_summarizer.rb
@@ -3,6 +3,10 @@
 module DiscourseAi
   module Personas
     class ShortSummarizer < Persona
+      def self.default_enabled
+        false
+      end
+
       def system_prompt
         <<~PROMPT.strip
           You are an advanced summarization bot. Analyze a given conversation and produce a concise,
@@ -23,7 +27,7 @@ module DiscourseAi
             <output>
               {"summary": "xx"}
             </output>
-          
+
           Where "xx" is replaced by the summary.
         PROMPT
       end

--- a/lib/personas/summarizer.rb
+++ b/lib/personas/summarizer.rb
@@ -3,6 +3,10 @@
 module DiscourseAi
   module Personas
     class Summarizer < Persona
+      def self.default_enabled
+        false
+      end
+
       def system_prompt
         <<~PROMPT.strip
           You are an advanced summarization bot that generates concise, coherent summaries of provided text.
@@ -18,13 +22,13 @@ module DiscourseAi
           - Example: link to the 6th post by jane: [agreed with]({resource_url}/6)
           - Example: link to the 13th post by joe: [joe]({resource_url}/13)
           - When formatting usernames either use @USERNAME OR [USERNAME]({resource_url}/POST_NUMBER)
-          
+
           Format your response as a JSON object with a single key named "summary", which has the summary as the value.
           Your output should be in the following format:
             <output>
               {"summary": "xx"}
             </output>
-          
+
           Where "xx" is replaced by the summary.
         PROMPT
       end

--- a/lib/personas/tools/create_artifact.rb
+++ b/lib/personas/tools/create_artifact.rb
@@ -151,7 +151,12 @@ module DiscourseAi
                 LlmModel.find_by(id: options[:creator_llm].to_i)&.to_llm
             ) || self.llm
 
-          llm.generate(prompt, user: user, feature_name: "create_artifact") do |partial_response|
+          llm.generate(
+            prompt,
+            user: user,
+            feature_name: "create_artifact",
+            cancel_manager: context.cancel_manager,
+          ) do |partial_response|
             response << partial_response
             yield partial_response
           end

--- a/lib/personas/tools/create_image.rb
+++ b/lib/personas/tools/create_image.rb
@@ -48,6 +48,7 @@ module DiscourseAi
                 max_prompts,
                 model: "gpt-image-1",
                 user_id: bot_user.id,
+                cancel_manager: context.cancel_manager,
               )
           rescue => e
             @error = e

--- a/lib/personas/tools/edit_image.rb
+++ b/lib/personas/tools/edit_image.rb
@@ -60,6 +60,7 @@ module DiscourseAi
                 uploads,
                 prompt,
                 user_id: bot_user.id,
+                cancel_manager: context.cancel_manager,
               )
           rescue => e
             @error = e

--- a/lib/personas/tools/researcher.rb
+++ b/lib/personas/tools/researcher.rb
@@ -101,9 +101,12 @@ module DiscourseAi
             )
 
           results = []
-          llm.generate(prompt, user: post.user, feature_name: context.feature_name) do |partial|
-            results << partial
-          end
+          llm.generate(
+            prompt,
+            user: post.user,
+            feature_name: context.feature_name,
+            cancel_manager: context.cancel_manager,
+          ) { |partial| results << partial }
 
           blk.call(".")
           results.join

--- a/lib/personas/tools/researcher.rb
+++ b/lib/personas/tools/researcher.rb
@@ -56,6 +56,9 @@ module DiscourseAi
           goals = parameters[:goals] || ""
           dry_run = parameters[:dry_run].nil? ? false : parameters[:dry_run]
 
+          return { error: "No goals provided" } if goals.blank?
+          return { error: "No filter provided" } if @last_filter.blank?
+
           filter = DiscourseAi::Utils::Research::Filter.new(@last_filter)
 
           @result_count = filter.search.count

--- a/lib/personas/tools/researcher.rb
+++ b/lib/personas/tools/researcher.rb
@@ -38,6 +38,7 @@ module DiscourseAi
               - tags (tag:tag1,tag2)
               - groups (group:group1,group2).
               - status (status:open, status:closed, status:archived, status:noreplies, status:single_user)
+              - keywords (keywords:keyword1,keyword2) - specific words to search for in posts
 
               If multiple tags or categories are specified, they are treated as OR conditions.
 

--- a/lib/personas/tools/researcher.rb
+++ b/lib/personas/tools/researcher.rb
@@ -34,9 +34,12 @@ module DiscourseAi
               Filter string to target specific content.
               - Supports user (@username)
               - date ranges (after:YYYY-MM-DD, before:YYYY-MM-DD for posts; topic_after:YYYY-MM-DD, topic_before:YYYY-MM-DD for topics)
-              - categories (category:name)
-              - tags (tag:name)
-              - groups (group:name).
+              - categories (category:category1,category2)
+              - tags (tag:tag1,tag2)
+              - groups (group:group1,group2).
+              - status (status:open, status:closed, status:archived, status:noreplies, status:single_user)
+
+              If multiple tags or categories are specified, they are treated as OR conditions.
 
               Multiple filters can be combined with spaces. Example: '@sam after:2023-01-01 tag:feature'
             TEXT

--- a/lib/personas/tools/researcher.rb
+++ b/lib/personas/tools/researcher.rb
@@ -41,8 +41,8 @@ module DiscourseAi
 
           def custom_system_message
             <<~TEXT
-            Use the researcher tool to analyze patterns and extract insights from forum content.
-            For complex research tasks, start with a dry run to gauge the scope before processing.
+              Use the researcher tool to analyze patterns and extract insights from forum content.
+              For complex research tasks, start with a dry run to gauge the scope before processing.
             TEXT
           end
 
@@ -54,26 +54,14 @@ module DiscourseAi
         def invoke
           @last_filter = parameters[:filter] || ""
           goal = parameters[:goal] || ""
-          dry_run = parameters[:dry_run].nil? ? true : parameters[:dry_run]
 
-          yield(I18n.t("discourse_ai.ai_bot.researching", filter: @last_filter, goal: goal))
+          #dry_run = parameters[:dry_run].nil? ? true : parameters[:dry_run]
+          #yield(I18n.t("discourse_ai.ai_bot.researching", filter: @last_filter, goal: goal))
 
-          # Parse the filter string to extract components
-          filter_components = parse_filter(@last_filter)
+          filter = DiscourseAi::Utils::Research::Filter.new(@last_filter)
 
-          # Determine max results
-          max_results = calculate_max_results(llm)
-
-          # In a real implementation, we would query the database here
-          # For now, just simulate the behavior
-          if dry_run
-            @result_count = simulate_count(filter_components)
-            { count: @result_count, filter: @last_filter, goal: goal, dry_run: true }
-          else
-            results = perform_research(filter_components, goal, max_results)
-            @result_count = results[:rows]&.length || 0
-            results
-          end
+          @result_count = filter.search.count
+          { dry_run: true, goal: goal, filter: @last_filter, number_of_results: @result_count }
         end
 
         protected
@@ -83,15 +71,6 @@ module DiscourseAi
         end
 
         private
-
-        def parse_filter(filter_string)
-          # This would parse the filter string into components
-          # For example, extracting username, date ranges, categories, tags, etc.
-          # Simplified implementation for now
-          components = {}
-          components[:raw] = filter_string
-          components
-        end
 
         def simulate_count(filter_components)
           # In a real implementation, this would query the database to get a count

--- a/lib/personas/tools/researcher.rb
+++ b/lib/personas/tools/researcher.rb
@@ -39,6 +39,8 @@ module DiscourseAi
               - groups (group:group1,group2).
               - status (status:open, status:closed, status:archived, status:noreplies, status:single_user)
               - keywords (keywords:keyword1,keyword2) - specific words to search for in posts
+              - max_results (max_results:10) the maximum number of results to return (optional)
+              - order (order:latest, order:oldest, order:latest_topic, order:oldest_topic) - the order of the results (optional)
 
               If multiple tags or categories are specified, they are treated as OR conditions.
 

--- a/lib/personas/tools/researcher.rb
+++ b/lib/personas/tools/researcher.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Personas
+    module Tools
+      class Researcher < Tool
+        attr_reader :last_filter, :result_count
+
+        class << self
+          def signature
+            {
+              name: name,
+              description:
+                "Analyze and extract information from content across the forum based on specified filters",
+              parameters: [
+                {
+                  name: "filter",
+                  description:
+                    "Filter string to target specific content. Supports user (@username), date ranges (after:YYYY-MM-DD, before:YYYY-MM-DD), categories (category:name), tags (tag:name), groups (group:name). Multiple filters can be combined with spaces. Example: '@sam after:2023-01-01 tag:feature'",
+                  type: "string",
+                },
+                {
+                  name: "goal",
+                  description:
+                    "The specific information you want to extract or analyze from the filtered content",
+                  type: "string",
+                },
+                {
+                  name: "dry_run",
+                  description:
+                    "When true, only count matching items without processing data (default: true)",
+                  type: "boolean",
+                },
+              ],
+            }
+          end
+
+          def name
+            "researcher"
+          end
+
+          def custom_system_message
+            <<~TEXT
+            Use the researcher tool to analyze patterns and extract insights from forum content.
+            For complex research tasks, start with a dry run to gauge the scope before processing.
+            TEXT
+          end
+
+          def accepted_options
+            [option(:max_results, type: :integer), option(:include_private, type: :boolean)]
+          end
+        end
+
+        def invoke
+          @last_filter = parameters[:filter] || ""
+          goal = parameters[:goal] || ""
+          dry_run = parameters[:dry_run].nil? ? true : parameters[:dry_run]
+
+          yield(I18n.t("discourse_ai.ai_bot.researching", filter: @last_filter, goal: goal))
+
+          # Parse the filter string to extract components
+          filter_components = parse_filter(@last_filter)
+
+          # Determine max results
+          max_results = calculate_max_results(llm)
+
+          # In a real implementation, we would query the database here
+          # For now, just simulate the behavior
+          if dry_run
+            @result_count = simulate_count(filter_components)
+            { count: @result_count, filter: @last_filter, goal: goal, dry_run: true }
+          else
+            results = perform_research(filter_components, goal, max_results)
+            @result_count = results[:rows]&.length || 0
+            results
+          end
+        end
+
+        protected
+
+        def description_args
+          { count: @result_count || 0, filter: @last_filter || "" }
+        end
+
+        private
+
+        def parse_filter(filter_string)
+          # This would parse the filter string into components
+          # For example, extracting username, date ranges, categories, tags, etc.
+          # Simplified implementation for now
+          components = {}
+          components[:raw] = filter_string
+          components
+        end
+
+        def simulate_count(filter_components)
+          # In a real implementation, this would query the database to get a count
+          # For now, return a simulated count
+          rand(10..100)
+        end
+
+        def perform_research(filter_components, goal, max_results)
+          # This would perform the actual research based on the filter and goal
+          # For now, return a simplified result structure
+          format_results([], %w[content url author date])
+        end
+
+        def calculate_max_results(llm)
+          max_results = options[:max_results].to_i
+          return [max_results, 100].min if max_results > 0
+
+          if llm.max_prompt_tokens > 30_000
+            50
+          elsif llm.max_prompt_tokens > 10_000
+            30
+          else
+            15
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/personas/tools/tool.rb
+++ b/lib/personas/tools/tool.rb
@@ -47,8 +47,9 @@ module DiscourseAi
           end
         end
 
-        attr_accessor :custom_raw, :parameters
-        attr_reader :tool_call_id, :persona_options, :bot_user, :llm, :context
+        # llm being public makes it a bit easier to test
+        attr_accessor :custom_raw, :parameters, :llm
+        attr_reader :tool_call_id, :persona_options, :bot_user, :context
 
         def initialize(
           parameters,

--- a/lib/personas/tools/update_artifact.rb
+++ b/lib/personas/tools/update_artifact.rb
@@ -159,6 +159,7 @@ module DiscourseAi
                   artifact: artifact,
                   artifact_version: artifact_version,
                   instructions: instructions,
+                  cancel_manager: context.cancel_manager,
                 )
                 .apply do |progress|
                   partial_response << progress

--- a/lib/summarization/fold_content.rb
+++ b/lib/summarization/fold_content.rb
@@ -18,7 +18,7 @@ module DiscourseAi
       attr_reader :bot, :strategy
 
       # @param user { User } - User object used for auditing usage.
-      # @param &on_partial_blk { Block - Optional } - The passed block will get called with the LLM partial response alongside a cancel function.
+      # @param &on_partial_blk { Block - Optional } - The passed block will get called with the LLM partial response.
       # Note: The block is only called with results of the final summary, not intermediate summaries.
       #
       # This method doesn't care if we already have an up to date summary. It always regenerate.
@@ -77,7 +77,7 @@ module DiscourseAi
 
       # @param items { Array<Hash> } - Content to summarize. Structure will be: { poster: who wrote the content, id: a way to order content, text: content }
       # @param user { User } - User object used for auditing usage.
-      # @param &on_partial_blk { Block - Optional } - The passed block will get called with the LLM partial response alongside a cancel function.
+      # @param &on_partial_blk { Block - Optional } - The passed block will get called with the LLM partial response.
       # Note: The block is only called with results of the final summary, not intermediate summaries.
       #
       # The summarization algorithm.
@@ -112,7 +112,7 @@ module DiscourseAi
         summary = +""
 
         buffer_blk =
-          Proc.new do |partial, cancel, _, type|
+          Proc.new do |partial, _, type|
             if type == :structured_output
               json_summary_schema_key = bot.persona.response_format&.first.to_h
               partial_summary =
@@ -120,12 +120,12 @@ module DiscourseAi
 
               if partial_summary.present?
                 summary << partial_summary
-                on_partial_blk.call(partial_summary, cancel) if on_partial_blk
+                on_partial_blk.call(partial_summary) if on_partial_blk
               end
             elsif type.blank?
               # Assume response is a regular completion.
               summary << partial
-              on_partial_blk.call(partial, cancel) if on_partial_blk
+              on_partial_blk.call(partial) if on_partial_blk
             end
           end
 

--- a/lib/utils/research/filter.rb
+++ b/lib/utils/research/filter.rb
@@ -57,6 +57,22 @@ module DiscourseAi
           end
         end
 
+        register_filter(/\Atopic_before:(.*)\z/i) do |relation, date_str, _|
+          if date = Filter.word_to_date(date_str)
+            relation.where("topics.created_at < ?", date)
+          else
+            relation
+          end
+        end
+
+        register_filter(/\Atopic_after:(.*)\z/i) do |relation, date_str, _|
+          if date = Filter.word_to_date(date_str)
+            relation.where("topics.created_at > ?", date)
+          else
+            relation
+          end
+        end
+
         # Category filter
         register_filter(/\Acategory:([a-zA-Z0-9_\-]+)\z/i) do |relation, slug, _|
           category = Category.find_by("LOWER(slug) = LOWER(?)", slug)

--- a/lib/utils/research/filter.rb
+++ b/lib/utils/research/filter.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Utils
+    module Research
+      class Filter
+        attr_reader :raw_filter, :parsed_components, :current_offset, :batch_size
+
+        VALID_FILTER_PATTERNS = {
+          user: /\@(\w+)/,
+          before: /before:(\d{4}-\d{2}-\d{2})/,
+          after: /after:(\d{4}-\d{2}-\d{2})/,
+          category: /category:([a-zA-Z0-9_\-]+)/,
+          tag: /tag:([a-zA-Z0-9_\-]+)/,
+          group: /group:([a-zA-Z0-9_\-]+)/,
+          status: /status:(open|closed|archived|noreplies|single_user)/,
+        }
+
+        DEFAULT_BATCH_SIZE = 20
+
+        def initialize(filter_string, batch_size: DEFAULT_BATCH_SIZE)
+          @raw_filter = filter_string.to_s
+          @batch_size = batch_size
+          @current_offset = 0
+          @parsed_components = parse_filter
+        end
+
+        def parse_filter
+          components = {
+            users: [],
+            categories: [],
+            tags: [],
+            groups: [],
+            date_range: {
+            },
+            status: nil,
+            raw: @raw_filter,
+          }
+
+          # Extract user mentions
+          @raw_filter
+            .scan(VALID_FILTER_PATTERNS[:user])
+            .each { |match| components[:users] << match[0] }
+
+          # Extract date ranges
+          if before_match = @raw_filter.match(VALID_FILTER_PATTERNS[:before])
+            components[:date_range][:before] = before_match[1]
+          end
+
+          if after_match = @raw_filter.match(VALID_FILTER_PATTERNS[:after])
+            components[:date_range][:after] = after_match[1]
+          end
+
+          # Extract categories
+          @raw_filter
+            .scan(VALID_FILTER_PATTERNS[:category])
+            .each { |match| components[:categories] << match[0] }
+
+          # Extract tags
+          @raw_filter
+            .scan(VALID_FILTER_PATTERNS[:tag])
+            .each { |match| components[:tags] << match[0] }
+
+          # Extract groups
+          @raw_filter
+            .scan(VALID_FILTER_PATTERNS[:group])
+            .each { |match| components[:groups] << match[0] }
+
+          # Extract status
+          if status_match = @raw_filter.match(VALID_FILTER_PATTERNS[:status])
+            components[:status] = status_match[1]
+          end
+
+          components
+        end
+
+        def next_batch
+          previous_offset = @current_offset
+          @current_offset += @batch_size
+          previous_offset
+        end
+
+        def reset_batch
+          @current_offset = 0
+        end
+
+        def to_query_params
+          params = {}
+          params[:username] = parsed_components[:users].first if parsed_components[:users].any?
+          params[:before] = parsed_components[:date_range][:before] if parsed_components[
+            :date_range
+          ][
+            :before
+          ]
+          params[:after] = parsed_components[:date_range][:after] if parsed_components[:date_range][
+            :after
+          ]
+          params[:category] = parsed_components[:categories].first if parsed_components[
+            :categories
+          ].any?
+          params[:tags] = parsed_components[:tags].join(",") if parsed_components[:tags].any?
+          params[:status] = parsed_components[:status] if parsed_components[:status]
+          params
+        end
+      end
+    end
+  end
+end

--- a/lib/utils/research/filter.rb
+++ b/lib/utils/research/filter.rb
@@ -4,103 +4,175 @@ module DiscourseAi
   module Utils
     module Research
       class Filter
-        attr_reader :raw_filter, :parsed_components, :current_offset, :batch_size
-
-        VALID_FILTER_PATTERNS = {
-          user: /\@(\w+)/,
-          before: /before:(\d{4}-\d{2}-\d{2})/,
-          after: /after:(\d{4}-\d{2}-\d{2})/,
-          category: /category:([a-zA-Z0-9_\-]+)/,
-          tag: /tag:([a-zA-Z0-9_\-]+)/,
-          group: /group:([a-zA-Z0-9_\-]+)/,
-          status: /status:(open|closed|archived|noreplies|single_user)/,
-        }
-
-        DEFAULT_BATCH_SIZE = 20
-
-        def initialize(filter_string, batch_size: DEFAULT_BATCH_SIZE)
-          @raw_filter = filter_string.to_s
-          @batch_size = batch_size
-          @current_offset = 0
-          @parsed_components = parse_filter
+        # Stores custom filter handlers
+        def self.register_filter(matcher, &block)
+          (@registered_filters ||= {})[matcher] = block
         end
 
-        def parse_filter
-          components = {
-            users: [],
-            categories: [],
-            tags: [],
-            groups: [],
-            date_range: {
-            },
-            status: nil,
-            raw: @raw_filter,
-          }
+        def self.registered_filters
+          @registered_filters ||= {}
+        end
 
-          # Extract user mentions
-          @raw_filter
-            .scan(VALID_FILTER_PATTERNS[:user])
-            .each { |match| components[:users] << match[0] }
+        def self.word_to_date(str)
+          ::Search.word_to_date(str)
+        end
 
-          # Extract date ranges
-          if before_match = @raw_filter.match(VALID_FILTER_PATTERNS[:before])
-            components[:date_range][:before] = before_match[1]
+        attr_reader :term, :filters, :order, :guardian, :limit, :offset
+
+        # Define all filters at class level
+        register_filter(/\Astatus:open\z/i) do |relation, _, _|
+          relation.where("topics.closed = false AND topics.archived = false")
+        end
+
+        register_filter(/\Astatus:closed\z/i) do |relation, _, _|
+          relation.where("topics.closed = true")
+        end
+
+        register_filter(/\Astatus:archived\z/i) do |relation, _, _|
+          relation.where("topics.archived = true")
+        end
+
+        register_filter(/\Astatus:noreplies\z/i) do |relation, _, _|
+          relation.where("topics.posts_count = 1")
+        end
+
+        register_filter(/\Astatus:single_user\z/i) do |relation, _, _|
+          relation.where("topics.participant_count = 1")
+        end
+
+        # Date filters
+        register_filter(/\Abefore:(.*)\z/i) do |relation, date_str, _|
+          if date = Filter.word_to_date(date_str)
+            relation.where("posts.created_at < ?", date)
+          else
+            relation
+          end
+        end
+
+        register_filter(/\Aafter:(.*)\z/i) do |relation, date_str, _|
+          if date = Filter.word_to_date(date_str)
+            relation.where("posts.created_at > ?", date)
+          else
+            relation
+          end
+        end
+
+        # Category filter
+        register_filter(/\Acategory:([a-zA-Z0-9_\-]+)\z/i) do |relation, slug, _|
+          category = Category.find_by("LOWER(slug) = LOWER(?)", slug)
+          if category
+            category_ids = [category.id]
+            category_ids +=
+              Category.subcategory_ids(category.id) if category.subcategory_ids.present?
+            relation.where("topics.category_id IN (?)", category_ids)
+          else
+            relation.where("1 = 0") # No results if category doesn't exist
+          end
+        end
+
+        # Tag filter
+        register_filter(/\Atag:([a-zA-Z0-9_\-]+)\z/i) do |relation, name, _|
+          tag = Tag.find_by_name(name)
+          if tag
+            relation.joins("INNER JOIN topic_tags ON topic_tags.topic_id = topics.id").where(
+              "topic_tags.tag_id = ?",
+              tag.id,
+            )
+          else
+            relation.where("1 = 0") # No results if tag doesn't exist
+          end
+        end
+
+        # User filter
+        register_filter(/\A\@(\w+)\z/i) do |relation, username, filter|
+          user = User.find_by(username_lower: username.downcase)
+          if user
+            relation.where("posts.user_id = ?", user.id)
+          else
+            relation.where("1 = 0") # No results if user doesn't exist
+          end
+        end
+
+        # Posted by current user
+        register_filter(/\Ain:posted\z/i) do |relation, _, filter|
+          if filter.guardian.user
+            relation.where("posts.user_id = ?", filter.guardian.user.id)
+          else
+            relation.where("1 = 0") # No results if not logged in
+          end
+        end
+
+        register_filter(/\Agroup:([a-zA-Z0-9_\-]+)\z/i) do |relation, name, filter|
+          group = Group.find_by("name ILIKE ?", name)
+          if group
+            relation.where(
+              "posts.user_id IN (
+              SELECT gu.user_id FROM group_users gu
+              WHERE gu.group_id = ?
+            )",
+              group.id,
+            )
+          else
+            relation.where("1 = 0") # No results if group doesn't exist
+          end
+        end
+
+        def initialize(term, guardian: nil, limit: nil, offset: nil)
+          @term = term.to_s
+          @guardian = guardian || Guardian.new
+          @limit = limit
+          @offset = offset
+          @filters = []
+          @valid = true
+
+          @term = process_filters(@term)
+        end
+
+        def search
+          filtered = Post.secured(@guardian).joins(:topic).merge(Topic.secured(@guardian))
+
+          @filters.each do |filter_block, match_data|
+            filtered = filter_block.call(filtered, match_data, self)
           end
 
-          if after_match = @raw_filter.match(VALID_FILTER_PATTERNS[:after])
-            components[:date_range][:after] = after_match[1]
-          end
+          filtered = filtered.limit(@limit) if @limit.to_i > 0
+          filtered = filtered.offset(@offset) if @offset.to_i > 0
 
-          # Extract categories
-          @raw_filter
-            .scan(VALID_FILTER_PATTERNS[:category])
-            .each { |match| components[:categories] << match[0] }
-
-          # Extract tags
-          @raw_filter
-            .scan(VALID_FILTER_PATTERNS[:tag])
-            .each { |match| components[:tags] << match[0] }
-
-          # Extract groups
-          @raw_filter
-            .scan(VALID_FILTER_PATTERNS[:group])
-            .each { |match| components[:groups] << match[0] }
-
-          # Extract status
-          if status_match = @raw_filter.match(VALID_FILTER_PATTERNS[:status])
-            components[:status] = status_match[1]
-          end
-
-          components
+          filtered
         end
 
-        def next_batch
-          previous_offset = @current_offset
-          @current_offset += @batch_size
-          previous_offset
-        end
+        private
 
-        def reset_batch
-          @current_offset = 0
-        end
+        def process_filters(term)
+          return "" if term.blank?
 
-        def to_query_params
-          params = {}
-          params[:username] = parsed_components[:users].first if parsed_components[:users].any?
-          params[:before] = parsed_components[:date_range][:before] if parsed_components[
-            :date_range
-          ][
-            :before
-          ]
-          params[:after] = parsed_components[:date_range][:after] if parsed_components[:date_range][
-            :after
-          ]
-          params[:category] = parsed_components[:categories].first if parsed_components[
-            :categories
-          ].any?
-          params[:tags] = parsed_components[:tags].join(",") if parsed_components[:tags].any?
-          params[:status] = parsed_components[:status] if parsed_components[:status]
-          params
+          term
+            .to_s
+            .scan(/(([^" \t\n\x0B\f\r]+)?(("[^"]+")?))/)
+            .to_a
+            .map do |(word, _)|
+              next if word.blank?
+
+              # Check for order:xxx syntax
+              if word =~ /\Aorder:(\w+)\z/i
+                @order = $1.downcase.to_sym
+                next nil
+              end
+
+              # Check registered filters
+              found = false
+              self.class.registered_filters.each do |matcher, block|
+                if word =~ matcher
+                  @filters << [block, $1]
+                  found = true
+                  break
+                end
+              end
+
+              found ? nil : word
+            end
+            .compact
+            .join(" ")
         end
       end
     end

--- a/lib/utils/research/llm_formatter.rb
+++ b/lib/utils/research/llm_formatter.rb
@@ -4,145 +4,43 @@ module DiscourseAi
   module Utils
     module Research
       class LlmFormatter
-        attr_reader :processed_count, :total_count, :filter
-
-        def initialize(filter, goal, llm, max_tokens = nil)
+        def initialize(filter, max_tokens_per_batch:, tokenizer:)
           @filter = filter
-          @goal = goal
-          @llm = llm
-          @max_tokens = max_tokens || calculate_default_max_tokens(llm)
-          @processed_count = 0
-          @total_count = 0
+          @max_tokens_per_batch = max_tokens_per_batch
+          @tokenizer = tokenizer
+          @to_process = filter_to_hash
         end
 
-        def format_and_yield(results, &block)
-          @total_count = results[:total] if results[:total]
-
-          if results[:rows].nil? || results[:rows].empty?
-            yield format_empty_result
-            return
-          end
-
-          # For summarization or analysis goals
-          if analysis_goal?
-            yield format_analysis_result(results[:rows])
-            return
-          end
-
-          # For standard listing with potential chunking
-          formatted_results = format_standard_result(results[:rows])
-          @processed_count += results[:rows].length
-
-          if block_given?
-            yield formatted_results
-          else
-            formatted_results
-          end
-        end
-
-        def format_progress
-          {
-            processed: @processed_count,
-            total: @total_count,
-            filter: @filter.raw_filter,
-            goal: @goal,
-            percent_complete: @total_count > 0 ? (@processed_count.to_f / @total_count * 100).round(1) : 0
-          }
+        def next_batch
+          # return text that is easily consumed by the LLM containing:
+          # - topic title, tags, category and creation date
+          # - info about previous posts in the topic that are omitted (mostly count eg: 7 posts omitted)
+          # - raw post content
+          # - author name
+          # - date
+          # - info about future posts in the topic that are omitted
+          #
+          # always attempt to return entire topics (or multiple) if possible
+          # return nil if we are done
+          #
+          # example_return:
+          # { post_count: 12, topic_count: 3, text: "..." }
         end
 
         private
 
-        def analysis_goal?
-          @goal.to_s.downcase.match?(/(summarize|analyze|extract|identify pattern|trend|insight)/)
-        end
+        def filter_to_hash
+          hash = {}
+          filter
+            .search
+            .pluck(:topic_id, :post_id, :post_number)
+            .each do |topic_id, post_id, post_number|
+              hash[topic_id] ||= { posts: [] }
+              hash[topic_id][:posts] << [post_id, post_number]
+            end
 
-        def format_empty_result
-          {
-            message: "No results found for the given filter criteria",
-            filter: @filter.raw_filter,
-            goal: @goal
-          }
-        end
-
-        def format_standard_result(rows)
-          formatted_rows = rows.map do |row|
-            {
-              title: row[:title],
-              excerpt: truncate_text(row[:excerpt] || ""),
-              url: row[:url],
-              author: row[:username],
-              date: row[:created_at],
-              likes: row[:like_count],
-              replies: row[:reply_count]
-            }
-          end
-
-          {
-            goal: @goal,
-            filter: @filter.raw_filter,
-            count: formatted_rows.length,
-            total: @total_count,
-            offset: @filter.current_offset - formatted_rows.length,
-            rows: formatted_rows
-          }
-        end
-
-        def format_analysis_result(rows)
-          # Group by relevant attributes based on goal
-          data_points = extract_data_points(rows)
-
-          {
-            goal: @goal,
-            filter: @filter.raw_filter,
-            count: rows.length,
-            total: @total_count,
-            analysis: {
-              sample_size: rows.length,
-              data_points: data_points,
-              time_range: extract_time_range(rows)
-            }
-          }
-        end
-
-        def extract_data_points(rows)
-          # This would extract relevant data based on the goal
-          # Simplified implementation for now
-          {
-            authors: rows.map { |r| r[:username] }.uniq.count,
-            categories: rows.map { |r| r[:category_name] }.uniq.count,
-            earliest_post: rows.map { |r| r[:created_at] }.min,
-            latest_post: rows.map { |r| r[:created_at] }.max,
-            avg_likes: (rows.sum { |r| r[:like_count].to_i } / [rows.length, 1].max.to_f).round(1)
-          }
-        end
-
-        def extract_time_range(rows)
-          dates = rows.map { |r| r[:created_at] }.compact
-          return nil if dates.empty?
-
-          {
-            earliest: dates.min,
-            latest: dates.max,
-            span_days: ((dates.max - dates.min) / 86400).to_i rescue nil
-          }
-        end
-
-        def truncate_text(text, max_length = 300)
-          return text if text.length <= max_length
-          text[0...max_length] + "..."
-        end
-
-        def calculate_default_max_tokens(llm)
-          # Use a percentage of available tokens for results
-          max_prompt_tokens = llm.max_prompt_tokens
-
-          if max_prompt_tokens > 30_000
-            max_prompt_tokens * 0.7
-          elsif max_prompt_tokens > 10_000
-            max_prompt_tokens * 0.6
-          else
-            max_prompt_tokens * 0.5
-          end.to_i
+          hash.each_value { |topic| topic[:posts].sort_by! { |_, post_number| post_number } }
+          hash
         end
       end
     end

--- a/lib/utils/research/llm_formatter.rb
+++ b/lib/utils/research/llm_formatter.rb
@@ -139,14 +139,27 @@ module DiscourseAi
 
           # Add creation date
           header << "Created: #{format_date(topic.created_at)}\n"
-          header << "Topic url: /t/#{topic.id}\n\n"
+          header << "Topic url: /t/#{topic.id}\n"
+          header << "Status: #{format_topic_status(topic)}\n\n"
 
           header
         end
 
+        def format_topic_status(topic)
+          solved = topic.respond_to?(:solved) && topic.solved.present?
+          solved_text = solved ? " (solved)" : ""
+          if topic.archived?
+            "Archived#{solved_text}"
+          elsif topic.closed?
+            "Closed#{solved_text}"
+          else
+            "Open#{solved_text}"
+          end
+        end
+
         def format_post(post)
           text = +"---\n"
-          text << "## Post by #{post.user.username} - #{format_date(post.created_at)}\n\n"
+          text << "## Post by #{post.user&.username} - #{format_date(post.created_at)}\n\n"
           text << "#{post.raw}\n"
           text << "Likes: #{post.like_count}\n" if post.like_count.to_i > 0
           text << "Post url: /t/-/#{post.topic_id}/#{post.post_number}\n\n"

--- a/lib/utils/research/llm_formatter.rb
+++ b/lib/utils/research/llm_formatter.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Utils
+    module Research
+      class LlmFormatter
+        attr_reader :processed_count, :total_count, :filter
+
+        def initialize(filter, goal, llm, max_tokens = nil)
+          @filter = filter
+          @goal = goal
+          @llm = llm
+          @max_tokens = max_tokens || calculate_default_max_tokens(llm)
+          @processed_count = 0
+          @total_count = 0
+        end
+
+        def format_and_yield(results, &block)
+          @total_count = results[:total] if results[:total]
+
+          if results[:rows].nil? || results[:rows].empty?
+            yield format_empty_result
+            return
+          end
+
+          # For summarization or analysis goals
+          if analysis_goal?
+            yield format_analysis_result(results[:rows])
+            return
+          end
+
+          # For standard listing with potential chunking
+          formatted_results = format_standard_result(results[:rows])
+          @processed_count += results[:rows].length
+
+          if block_given?
+            yield formatted_results
+          else
+            formatted_results
+          end
+        end
+
+        def format_progress
+          {
+            processed: @processed_count,
+            total: @total_count,
+            filter: @filter.raw_filter,
+            goal: @goal,
+            percent_complete: @total_count > 0 ? (@processed_count.to_f / @total_count * 100).round(1) : 0
+          }
+        end
+
+        private
+
+        def analysis_goal?
+          @goal.to_s.downcase.match?(/(summarize|analyze|extract|identify pattern|trend|insight)/)
+        end
+
+        def format_empty_result
+          {
+            message: "No results found for the given filter criteria",
+            filter: @filter.raw_filter,
+            goal: @goal
+          }
+        end
+
+        def format_standard_result(rows)
+          formatted_rows = rows.map do |row|
+            {
+              title: row[:title],
+              excerpt: truncate_text(row[:excerpt] || ""),
+              url: row[:url],
+              author: row[:username],
+              date: row[:created_at],
+              likes: row[:like_count],
+              replies: row[:reply_count]
+            }
+          end
+
+          {
+            goal: @goal,
+            filter: @filter.raw_filter,
+            count: formatted_rows.length,
+            total: @total_count,
+            offset: @filter.current_offset - formatted_rows.length,
+            rows: formatted_rows
+          }
+        end
+
+        def format_analysis_result(rows)
+          # Group by relevant attributes based on goal
+          data_points = extract_data_points(rows)
+
+          {
+            goal: @goal,
+            filter: @filter.raw_filter,
+            count: rows.length,
+            total: @total_count,
+            analysis: {
+              sample_size: rows.length,
+              data_points: data_points,
+              time_range: extract_time_range(rows)
+            }
+          }
+        end
+
+        def extract_data_points(rows)
+          # This would extract relevant data based on the goal
+          # Simplified implementation for now
+          {
+            authors: rows.map { |r| r[:username] }.uniq.count,
+            categories: rows.map { |r| r[:category_name] }.uniq.count,
+            earliest_post: rows.map { |r| r[:created_at] }.min,
+            latest_post: rows.map { |r| r[:created_at] }.max,
+            avg_likes: (rows.sum { |r| r[:like_count].to_i } / [rows.length, 1].max.to_f).round(1)
+          }
+        end
+
+        def extract_time_range(rows)
+          dates = rows.map { |r| r[:created_at] }.compact
+          return nil if dates.empty?
+
+          {
+            earliest: dates.min,
+            latest: dates.max,
+            span_days: ((dates.max - dates.min) / 86400).to_i rescue nil
+          }
+        end
+
+        def truncate_text(text, max_length = 300)
+          return text if text.length <= max_length
+          text[0...max_length] + "..."
+        end
+
+        def calculate_default_max_tokens(llm)
+          # Use a percentage of available tokens for results
+          max_prompt_tokens = llm.max_prompt_tokens
+
+          if max_prompt_tokens > 30_000
+            max_prompt_tokens * 0.7
+          elsif max_prompt_tokens > 10_000
+            max_prompt_tokens * 0.6
+          else
+            max_prompt_tokens * 0.5
+          end.to_i
+        end
+      end
+    end
+  end
+end

--- a/lib/utils/research/llm_formatter.rb
+++ b/lib/utils/research/llm_formatter.rb
@@ -11,29 +11,71 @@ module DiscourseAi
           @to_process = filter_to_hash
         end
 
-        def next_batch
-          # return text that is easily consumed by the LLM containing:
-          # - topic title, tags, category and creation date
-          # - info about previous posts in the topic that are omitted (mostly count eg: 7 posts omitted)
-          # - raw post content
-          # - author name
-          # - date
-          # - info about future posts in the topic that are omitted
-          #
-          # always attempt to return entire topics (or multiple) if possible
-          # return nil if we are done
-          #
-          # example_return:
-          # { post_count: 12, topic_count: 3, text: "..." }
+        def each_chunk
+          return nil if @to_process.empty?
+
+          result = { post_count: 0, topic_count: 0, text: +"" }
+          estimated_tokens = 0
+
+          @to_process.each do |topic_id, topic_data|
+            topic = Topic.find_by(id: topic_id)
+            next unless topic
+
+            topic_text, topic_tokens, post_count = format_topic(topic, topic_data[:posts])
+
+            # If this single topic exceeds our token limit and we haven't added anything yet,
+            # we need to include at least this one topic (partial content)
+            if estimated_tokens == 0 && topic_tokens > @max_tokens_per_batch
+              offset = 0
+              while offset < topic_text.length
+                chunk = +""
+                chunk_tokens = 0
+                lines = topic_text[offset..].lines
+                lines.each do |line|
+                  line_tokens = estimate_tokens(line)
+                  break if chunk_tokens + line_tokens > @max_tokens_per_batch
+                  chunk << line
+                  chunk_tokens += line_tokens
+                end
+                break if chunk.empty?
+                yield(
+                  {
+                    text: chunk,
+                    post_count: post_count, # This may overcount if split mid-topic, but preserves original logic
+                    topic_count: 1,
+                  }
+                )
+                offset += chunk.length
+              end
+
+              next
+            end
+
+            # If adding this topic would exceed our token limit and we already have content, skip it
+            if estimated_tokens > 0 && estimated_tokens + topic_tokens > @max_tokens_per_batch
+              yield result if result[:text].present?
+              estimated_tokens = 0
+              result = { post_count: 0, topic_count: 0, text: +"" }
+            else
+              # Add this topic to the result
+              result[:text] << topic_text
+              result[:post_count] += post_count
+              result[:topic_count] += 1
+              estimated_tokens += topic_tokens
+            end
+          end
+          yield result if result[:text].present?
+
+          @to_process.clear
         end
 
         private
 
         def filter_to_hash
           hash = {}
-          filter
+          @filter
             .search
-            .pluck(:topic_id, :post_id, :post_number)
+            .pluck(:topic_id, :id, :post_number)
             .each do |topic_id, post_id, post_number|
               hash[topic_id] ||= { posts: [] }
               hash[topic_id][:posts] << [post_id, post_number]
@@ -41,6 +83,90 @@ module DiscourseAi
 
           hash.each_value { |topic| topic[:posts].sort_by! { |_, post_number| post_number } }
           hash
+        end
+
+        def format_topic(topic, posts_data)
+          text = ""
+          total_tokens = 0
+          post_count = 0
+
+          # Add topic header
+          text += format_topic_header(topic)
+          total_tokens += estimate_tokens(text)
+
+          # Get all post numbers in this topic
+          all_post_numbers = topic.posts.pluck(:post_number).sort
+
+          # Format posts with omitted information
+          first_post_number = posts_data.first[1]
+          last_post_number = posts_data.last[1]
+
+          # Handle posts before our selection
+          if first_post_number > 1
+            omitted_before = first_post_number - 1
+            text += format_omitted_posts(omitted_before, "before")
+            total_tokens += estimate_tokens(format_omitted_posts(omitted_before, "before"))
+          end
+
+          # Format each post
+          posts_data.each do |post_id, post_number|
+            post = Post.find_by(id: post_id)
+            next unless post
+
+            text += format_post(post)
+            total_tokens += estimate_tokens(format_post(post))
+            post_count += 1
+          end
+
+          # Handle posts after our selection
+          if last_post_number < all_post_numbers.last
+            omitted_after = all_post_numbers.last - last_post_number
+            text += format_omitted_posts(omitted_after, "after")
+            total_tokens += estimate_tokens(format_omitted_posts(omitted_after, "after"))
+          end
+
+          [text, total_tokens, post_count]
+        end
+
+        def format_topic_header(topic)
+          header = +"# #{topic.title}\n"
+
+          # Add category
+          header << "Category: #{topic.category.name}\n" if topic.category
+
+          # Add tags
+          header << "Tags: #{topic.tags.map(&:name).join(", ")}\n" if topic.tags.present?
+
+          # Add creation date
+          header << "Created: #{format_date(topic.created_at)}\n"
+          header << "Topic url: /t/#{topic.id}\n\n"
+
+          header
+        end
+
+        def format_post(post)
+          text = +"---\n"
+          text << "## Post by #{post.user.username} - #{format_date(post.created_at)}\n\n"
+          text << "#{post.raw}\n"
+          text << "Likes: #{post.like_count}\n" if post.like_count.to_i > 0
+          text << "Post url: /t/-/#{post.topic_id}/#{post.post_number}\n\n"
+          text
+        end
+
+        def format_omitted_posts(count, position)
+          if position == "before"
+            "#{count} earlier #{count == 1 ? "post" : "posts"} omitted\n\n"
+          else
+            "#{count} later #{count == 1 ? "post" : "posts"} omitted\n\n"
+          end
+        end
+
+        def format_date(date)
+          date.strftime("%Y-%m-%d %H:%M")
+        end
+
+        def estimate_tokens(text)
+          @tokenizer.tokenize(text).length
         end
       end
     end

--- a/spec/lib/completions/cancel_manager_spec.rb
+++ b/spec/lib/completions/cancel_manager_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+describe DiscourseAi::Completions::CancelManager do
+  fab!(:model) { Fabricate(:anthropic_model, name: "test-model") }
+
+  it "can stop monitoring for cancellation cleanly" do
+    cancel_manager = DiscourseAi::Completions::CancelManager.new
+    cancel_manager.start_monitor(delay: 100) { false }
+    expect(cancel_manager.monitor_thread).not_to be_nil
+    cancel_manager.stop_monitor
+    expect(cancel_manager.cancelled?).to eq(false)
+    expect(cancel_manager.monitor_thread).to be_nil
+  end
+
+  it "can monitor for cancellation" do
+    cancel_manager = DiscourseAi::Completions::CancelManager.new
+    results = [true, false, false]
+
+    cancel_manager.start_monitor(delay: 0) { results.pop }
+
+    wait_for { cancel_manager.cancelled? == true }
+    wait_for { cancel_manager.monitor_thread.nil? }
+
+    expect(cancel_manager.cancelled?).to eq(true)
+    expect(cancel_manager.monitor_thread).to be_nil
+  end
+
+  it "should do nothing when cancel manager is already cancelled" do
+    cancel_manager = DiscourseAi::Completions::CancelManager.new
+    cancel_manager.cancel!
+
+    llm = model.to_llm
+    prompt =
+      DiscourseAi::Completions::Prompt.new(
+        "You are a test bot",
+        messages: [{ type: :user, content: "hello" }],
+      )
+
+    result = llm.generate(prompt, user: Discourse.system_user, cancel_manager: cancel_manager)
+    expect(result).to be_nil
+  end
+
+  it "should be able to cancel a completion" do
+    # Start an HTTP server that hangs indefinitely
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+
+    begin
+      thread =
+        Thread.new do
+          loop do
+            begin
+              _client = server.accept
+              sleep(30) # Hold the connection longer than the test will run
+              break
+            rescue StandardError
+              # Server closed
+              break
+            end
+          end
+        end
+
+      # Create a model that points to our hanging server
+      model.update!(url: "http://127.0.0.1:#{port}")
+
+      cancel_manager = DiscourseAi::Completions::CancelManager.new
+
+      completion_thread =
+        Thread.new do
+          llm = model.to_llm
+          prompt =
+            DiscourseAi::Completions::Prompt.new(
+              "You are a test bot",
+              messages: [{ type: :user, content: "hello" }],
+            )
+
+          result = llm.generate(prompt, user: Discourse.system_user, cancel_manager: cancel_manager)
+          expect(result).to be_nil
+          expect(cancel_manager.cancelled).to eq(true)
+        end
+
+      wait_for { cancel_manager.callbacks.size == 1 }
+
+      cancel_manager.cancel!
+      completion_thread.join(2)
+
+      expect(completion_thread).not_to be_alive
+    ensure
+      begin
+        server.close
+      rescue StandardError
+        nil
+      end
+      begin
+        thread.kill
+      rescue StandardError
+        nil
+      end
+      begin
+        completion_thread&.kill
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -1159,8 +1159,8 @@ RSpec.describe DiscourseAi::AiBot::Playground do
 
       last_post = third_post.topic.posts.order(:id).last
 
-      # not Hello123, we cancelled at 1 which means we may get 2 and then be done
-      expect(last_post.raw).to eq("Hello12")
+      # not Hello123, we cancelled at 1
+      expect(last_post.raw).to eq("Hello1")
     end
   end
 

--- a/spec/lib/personas/persona_spec.rb
+++ b/spec/lib/personas/persona_spec.rb
@@ -223,6 +223,7 @@ RSpec.describe DiscourseAi::Personas::Persona do
           DiscourseAi::Personas::Artist,
           DiscourseAi::Personas::Creative,
           DiscourseAi::Personas::DiscourseHelper,
+          DiscourseAi::Personas::ForumResearcher,
           DiscourseAi::Personas::GithubHelper,
           DiscourseAi::Personas::Researcher,
           DiscourseAi::Personas::SettingsExplorer,
@@ -237,6 +238,7 @@ RSpec.describe DiscourseAi::Personas::Persona do
           DiscourseAi::Personas::Artist,
           DiscourseAi::Personas::Creative,
           DiscourseAi::Personas::DiscourseHelper,
+          DiscourseAi::Personas::ForumResearcher,
           DiscourseAi::Personas::GithubHelper,
           DiscourseAi::Personas::Researcher,
           DiscourseAi::Personas::SettingsExplorer,
@@ -256,6 +258,7 @@ RSpec.describe DiscourseAi::Personas::Persona do
         DiscourseAi::Personas::SettingsExplorer,
         DiscourseAi::Personas::Creative,
         DiscourseAi::Personas::DiscourseHelper,
+        DiscourseAi::Personas::ForumResearcher,
         DiscourseAi::Personas::GithubHelper,
       )
 
@@ -268,6 +271,7 @@ RSpec.describe DiscourseAi::Personas::Persona do
         DiscourseAi::Personas::SettingsExplorer,
         DiscourseAi::Personas::Creative,
         DiscourseAi::Personas::DiscourseHelper,
+        DiscourseAi::Personas::ForumResearcher,
         DiscourseAi::Personas::GithubHelper,
       )
     end

--- a/spec/lib/personas/persona_spec.rb
+++ b/spec/lib/personas/persona_spec.rb
@@ -217,32 +217,28 @@ RSpec.describe DiscourseAi::Personas::Persona do
       SiteSetting.ai_google_custom_search_cx = "abc123"
 
       # should be ordered by priority and then alpha
-      expect(DiscourseAi::Personas::Persona.all(user: user).map(&:superclass)).to eq(
-        [
-          DiscourseAi::Personas::General,
-          DiscourseAi::Personas::Artist,
-          DiscourseAi::Personas::Creative,
-          DiscourseAi::Personas::DiscourseHelper,
-          DiscourseAi::Personas::GithubHelper,
-          DiscourseAi::Personas::Researcher,
-          DiscourseAi::Personas::SettingsExplorer,
-          DiscourseAi::Personas::SqlHelper,
-        ],
+      expect(DiscourseAi::Personas::Persona.all(user: user).map(&:superclass)).to contain_exactly(
+        DiscourseAi::Personas::General,
+        DiscourseAi::Personas::Artist,
+        DiscourseAi::Personas::Creative,
+        DiscourseAi::Personas::DiscourseHelper,
+        DiscourseAi::Personas::GithubHelper,
+        DiscourseAi::Personas::Researcher,
+        DiscourseAi::Personas::SettingsExplorer,
+        DiscourseAi::Personas::SqlHelper,
       )
 
       # it should allow staff access to WebArtifactCreator
-      expect(DiscourseAi::Personas::Persona.all(user: admin).map(&:superclass)).to eq(
-        [
-          DiscourseAi::Personas::General,
-          DiscourseAi::Personas::Artist,
-          DiscourseAi::Personas::Creative,
-          DiscourseAi::Personas::DiscourseHelper,
-          DiscourseAi::Personas::GithubHelper,
-          DiscourseAi::Personas::Researcher,
-          DiscourseAi::Personas::SettingsExplorer,
-          DiscourseAi::Personas::SqlHelper,
-          DiscourseAi::Personas::WebArtifactCreator,
-        ],
+      expect(DiscourseAi::Personas::Persona.all(user: admin).map(&:superclass)).to contain_exactly(
+        DiscourseAi::Personas::General,
+        DiscourseAi::Personas::Artist,
+        DiscourseAi::Personas::Creative,
+        DiscourseAi::Personas::DiscourseHelper,
+        DiscourseAi::Personas::GithubHelper,
+        DiscourseAi::Personas::Researcher,
+        DiscourseAi::Personas::SettingsExplorer,
+        DiscourseAi::Personas::SqlHelper,
+        DiscourseAi::Personas::WebArtifactCreator,
       )
 
       # omits personas if key is missing

--- a/spec/lib/personas/persona_spec.rb
+++ b/spec/lib/personas/persona_spec.rb
@@ -223,7 +223,6 @@ RSpec.describe DiscourseAi::Personas::Persona do
           DiscourseAi::Personas::Artist,
           DiscourseAi::Personas::Creative,
           DiscourseAi::Personas::DiscourseHelper,
-          DiscourseAi::Personas::ForumResearcher,
           DiscourseAi::Personas::GithubHelper,
           DiscourseAi::Personas::Researcher,
           DiscourseAi::Personas::SettingsExplorer,
@@ -238,7 +237,6 @@ RSpec.describe DiscourseAi::Personas::Persona do
           DiscourseAi::Personas::Artist,
           DiscourseAi::Personas::Creative,
           DiscourseAi::Personas::DiscourseHelper,
-          DiscourseAi::Personas::ForumResearcher,
           DiscourseAi::Personas::GithubHelper,
           DiscourseAi::Personas::Researcher,
           DiscourseAi::Personas::SettingsExplorer,
@@ -258,7 +256,6 @@ RSpec.describe DiscourseAi::Personas::Persona do
         DiscourseAi::Personas::SettingsExplorer,
         DiscourseAi::Personas::Creative,
         DiscourseAi::Personas::DiscourseHelper,
-        DiscourseAi::Personas::ForumResearcher,
         DiscourseAi::Personas::GithubHelper,
       )
 
@@ -271,7 +268,6 @@ RSpec.describe DiscourseAi::Personas::Persona do
         DiscourseAi::Personas::SettingsExplorer,
         DiscourseAi::Personas::Creative,
         DiscourseAi::Personas::DiscourseHelper,
-        DiscourseAi::Personas::ForumResearcher,
         DiscourseAi::Personas::GithubHelper,
       )
     end

--- a/spec/lib/personas/tools/researcher_spec.rb
+++ b/spec/lib/personas/tools/researcher_spec.rb
@@ -89,10 +89,16 @@ RSpec.describe DiscourseAi::Personas::Tools::Researcher do
       responses = 10.times.map { |i| ["Found: Relevant content #{i + 1}"] }
       results = nil
 
+      last_progress = nil
+      progress_blk = Proc.new { |response| last_progress = response }
+
       DiscourseAi::Completions::Llm.with_prepared_responses(responses) do
         researcher.llm = llm_model.to_llm
         results = researcher.invoke(&progress_blk)
       end
+
+      expect(last_progress).to include("find relevant content")
+      expect(last_progress).to include("category:research-category")
 
       expect(results[:dry_run]).to eq(false)
       expect(results[:goals]).to eq("find relevant content")

--- a/spec/lib/personas/tools/researcher_spec.rb
+++ b/spec/lib/personas/tools/researcher_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe DiscourseAi::Personas::Tools::Researcher do
       expect(results[:goals]).to eq("analyze post patterns")
       expect(results[:dry_run]).to eq(true)
       expect(results[:number_of_results]).to be > 0
-      expect(researcher.last_filter).to eq("tag:research after:2023")
+      expect(researcher.filter).to eq("tag:research after:2023")
       expect(researcher.result_count).to be > 0
     end
 

--- a/spec/lib/personas/tools/researcher_spec.rb
+++ b/spec/lib/personas/tools/researcher_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::Personas::Tools::Researcher do
+  before { SearchIndexer.enable }
+  after { SearchIndexer.disable }
+
+  fab!(:llm_model)
+  let(:bot_user) { DiscourseAi::AiBot::EntryPoint.find_user_from_model(llm_model.name) }
+  let(:llm) { DiscourseAi::Completions::Llm.proxy("custom:#{llm_model.id}") }
+  let(:progress_blk) { Proc.new {} }
+
+  fab!(:admin)
+  fab!(:user)
+  fab!(:category) { Fabricate(:category, name: "research-category") }
+  fab!(:tag_research) { Fabricate(:tag, name: "research") }
+  fab!(:tag_data) { Fabricate(:tag, name: "data") }
+
+  fab!(:topic_with_tags) { Fabricate(:topic, category: category, tags: [tag_research, tag_data]) }
+  fab!(:post) { Fabricate(:post, topic: topic_with_tags) }
+
+  before { SiteSetting.ai_bot_enabled = true }
+
+  describe "#invoke" do
+    it "returns filter information and result count" do
+      researcher =
+        described_class.new(
+          { filter: "tag:research after:2023", goal: "analyze post patterns" },
+          bot_user: bot_user,
+          llm: llm,
+          context: DiscourseAi::Personas::BotContext.new(user: user),
+        )
+
+      results = researcher.invoke(&progress_blk)
+
+      expect(results[:filter]).to eq("tag:research after:2023")
+      expect(results[:goal]).to eq("analyze post patterns")
+      expect(results[:dry_run]).to eq(true)
+      expect(results[:number_of_results]).to be > 0
+      expect(researcher.last_filter).to eq("tag:research after:2023")
+      expect(researcher.result_count).to be > 0
+    end
+
+    it "handles empty filters" do
+      researcher =
+        described_class.new({ goal: "analyze all content" }, bot_user: bot_user, llm: llm)
+
+      results = researcher.invoke(&progress_blk)
+
+      expect(results[:filter]).to eq("")
+      expect(results[:goal]).to eq("analyze all content")
+      expect(researcher.last_filter).to eq("")
+    end
+
+    it "accepts max_results option" do
+      researcher =
+        described_class.new(
+          { filter: "category:research-category" },
+          persona_options: {
+            "max_results" => "50",
+          },
+          bot_user: bot_user,
+          llm: llm,
+        )
+
+      expect(researcher.options[:max_results]).to eq(50)
+    end
+  end
+end

--- a/spec/lib/personas/tools/researcher_spec.rb
+++ b/spec/lib/personas/tools/researcher_spec.rb
@@ -24,16 +24,16 @@ RSpec.describe DiscourseAi::Personas::Tools::Researcher do
     it "returns filter information and result count" do
       researcher =
         described_class.new(
-          { filter: "tag:research after:2023", goal: "analyze post patterns" },
+          { filter: "tag:research after:2023", goals: "analyze post patterns", dry_run: true },
           bot_user: bot_user,
           llm: llm,
-          context: DiscourseAi::Personas::BotContext.new(user: user),
+          context: DiscourseAi::Personas::BotContext.new(user: user, post: post),
         )
 
       results = researcher.invoke(&progress_blk)
 
       expect(results[:filter]).to eq("tag:research after:2023")
-      expect(results[:goal]).to eq("analyze post patterns")
+      expect(results[:goals]).to eq("analyze post patterns")
       expect(results[:dry_run]).to eq(true)
       expect(results[:number_of_results]).to be > 0
       expect(researcher.last_filter).to eq("tag:research after:2023")
@@ -42,13 +42,11 @@ RSpec.describe DiscourseAi::Personas::Tools::Researcher do
 
     it "handles empty filters" do
       researcher =
-        described_class.new({ goal: "analyze all content" }, bot_user: bot_user, llm: llm)
+        described_class.new({ goals: "analyze all content" }, bot_user: bot_user, llm: llm)
 
       results = researcher.invoke(&progress_blk)
 
-      expect(results[:filter]).to eq("")
-      expect(results[:goal]).to eq("analyze all content")
-      expect(researcher.last_filter).to eq("")
+      expect(results[:error]).to eq("No filter provided")
     end
 
     it "accepts max_results option" do
@@ -80,7 +78,7 @@ RSpec.describe DiscourseAi::Personas::Tools::Researcher do
         described_class.new(
           {
             filter: "category:research-category @#{user.username}",
-            goal: "find relevant content",
+            goals: "find relevant content",
             dry_run: false,
           },
           bot_user: bot_user,
@@ -97,7 +95,7 @@ RSpec.describe DiscourseAi::Personas::Tools::Researcher do
       end
 
       expect(results[:dry_run]).to eq(false)
-      expect(results[:goal]).to eq("find relevant content")
+      expect(results[:goals]).to eq("find relevant content")
       expect(results[:filter]).to eq("category:research-category @#{user.username}")
       expect(results[:results].first).to include("Found: Relevant content 1")
     end

--- a/spec/lib/utils/research/filter_spec.rb
+++ b/spec/lib/utils/research/filter_spec.rb
@@ -92,6 +92,11 @@ describe DiscourseAi::Utils::Research::Filter do
       end
     end
 
+    it "can limit number of results" do
+      filter = described_class.new("category:Feedback max_results:1", limit: 5)
+      expect(filter.search.pluck(:id).length).to eq(1)
+    end
+
     describe "full text keyword searching" do
       before_all { SearchIndexer.enable }
       fab!(:post_with_apples) do

--- a/spec/lib/utils/research/llm_formatter_spec.rb
+++ b/spec/lib/utils/research/llm_formatter_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+#
+describe DiscourseAi::Utils::Research::LlmFormatter do
+  fab!(:user) { Fabricate(:user, username: "test_user") }
+  fab!(:topic) { Fabricate(:topic, title: "This is a Test Topic", user: user) }
+  fab!(:post) { Fabricate(:post, topic: topic, user: user) }
+  let(:tokenizer) { DiscourseAi::Tokenizer::OpenAiTokenizer }
+  let(:filter) { DiscourseAi::Utils::Research::Filter.new("@#{user.username}") }
+
+  describe "#truncate_if_needed" do
+    it "returns original content when under token limit" do
+      formatter =
+        described_class.new(
+          filter,
+          max_tokens_per_batch: 1000,
+          tokenizer: tokenizer,
+          max_tokens_per_post: 100,
+        )
+
+      short_text = "This is a short post"
+      expect(formatter.send(:truncate_if_needed, short_text)).to eq(short_text)
+    end
+
+    it "truncates content when over token limit" do
+      # Create a post with content that will exceed our token limit
+      long_text = ("word " * 200).strip
+
+      formatter =
+        described_class.new(
+          filter,
+          max_tokens_per_batch: 1000,
+          tokenizer: tokenizer,
+          max_tokens_per_post: 50,
+        )
+
+      truncated = formatter.send(:truncate_if_needed, long_text)
+
+      expect(truncated).to include("... elided 150 tokens ...")
+      expect(truncated).to_not eq(long_text)
+
+      # Should have roughly 25 words before and 25 after (half of max_tokens_per_post)
+      first_chunk = truncated.split("\n\n")[0]
+      expect(first_chunk.split(" ").length).to be_within(5).of(25)
+
+      last_chunk = truncated.split("\n\n")[2]
+      expect(last_chunk.split(" ").length).to be_within(5).of(25)
+    end
+  end
+
+  describe "#format_post" do
+    it "formats posts with truncation for long content" do
+      # Set up a post with long content
+      long_content = ("word " * 200).strip
+      long_post = Fabricate(:post, raw: long_content, topic: topic, user: user)
+
+      formatter =
+        described_class.new(
+          filter,
+          max_tokens_per_batch: 1000,
+          tokenizer: tokenizer,
+          max_tokens_per_post: 50,
+        )
+
+      formatted = formatter.send(:format_post, long_post)
+
+      # Should have standard formatting elements
+      expect(formatted).to include("## Post by #{user.username}")
+      expect(formatted).to include("Post url: /t/-/#{long_post.topic_id}/#{long_post.post_number}")
+
+      # Should include truncation marker
+      expect(formatted).to include("... elided 150 tokens ...")
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces a new Forum Researcher persona specialized in deep forum content analysis along with comprehensive improvements to our AI infrastructure.

Key additions:
- New Forum Researcher persona with advanced filtering and analysis capabilities
- Robust filtering system supporting tags, categories, dates, users, and keywords
- LLM formatter to efficiently process and chunk research results

Infrastructure improvements:
- Implemented CancelManager class to centrally manage AI completion cancellations
- Replaced callback-based cancellation with a more robust pattern
- Added systematic cancellation monitoring with callbacks

Other improvements:
- Added configurable `default_enabled` flag to control which personas are enabled by default
- Updated translation strings for the new researcher functionality
- Added comprehensive specs for the new components

This change makes our AI platform more stable while adding powerful research capabilities that can analyze forum trends and surface relevant content.

