### PR TITLE
FIX: Return structured output on non-streaming mode

### DIFF
--- a/lib/completions/endpoints/base.rb
+++ b/lib/completions/endpoints/base.rb
@@ -114,8 +114,7 @@ module DiscourseAi
               model_params[:response_format].dig(:json_schema, :schema, :properties)
 
             if schema_properties.present?
-              structured_output =
-                DiscourseAi::Completions::StructuredOutput.new(schema_properties)
+              structured_output = DiscourseAi::Completions::StructuredOutput.new(schema_properties)
             end
           end
 
@@ -430,23 +429,9 @@ module DiscourseAi
           response_data.reject!(&:blank?)
 
           if structured_output.present?
-            has_string_response = false
+            response_data.each { |data| structured_output << data if data.is_a?(String) }
 
-            response_data =
-              response_data.reduce([]) do |memo, data|
-                if data.is_a?(String)
-                  structured_output << data
-                  has_string_response = true
-                  next(memo)
-                else
-                  memo << data
-                end
-
-                memo
-              end
-
-            # We only include the structured output if there was actually a structured response
-            response_data << structured_output if has_string_response
+            return structured_output
           end
 
           # this is to keep stuff backwards compatible

--- a/lib/completions/endpoints/canned_response.rb
+++ b/lib/completions/endpoints/canned_response.rb
@@ -68,6 +68,7 @@ module DiscourseAi
           end
 
           response = response.first if response.is_a?(Array) && response.length == 1
+
           response
         end
 


### PR DESCRIPTION
Non-streaming mode should always return a `StructureOutput` when a response format is given. Multi-turn responses aren't supported so `response_data` is always a string.