### PR TITLE
UX: stop rendering back to forum link

### DIFF
--- a/assets/javascripts/initializers/ai-conversations-sidebar.js
+++ b/assets/javascripts/initializers/ai-conversations-sidebar.js
@@ -37,7 +37,7 @@ export default {
           class AiConversationsSidebarPanel extends BaseCustomSidebarPanel {
             key = AI_CONVERSATIONS_PANEL;
             hidden = true;
-            displayHeader = !navigationMenu.isHeaderDropdownMode;
+            displayHeader = false; // this would add a misplaced back to forum button
             expandActiveSection = true;
           }
       );

--- a/spec/system/ai_bot/homepage_spec.rb
+++ b/spec/system/ai_bot/homepage_spec.rb
@@ -320,9 +320,9 @@ RSpec.describe "AI Bot - Homepage", type: :system do
           expect(ai_pm_homepage.llm_selector).to have_selected_name(claude_2_dup.display_name)
         end
 
-        it "renders back to forum link" do
+        it "does not render back to forum link" do
           ai_pm_homepage.visit
-          expect(ai_pm_homepage).to have_sidebar_back_link
+          expect(ai_pm_homepage).to have_no_sidebar_back_link
         end
 
         context "with hamburger menu" do


### PR DESCRIPTION
Button is misplaced and confusing, header returns to forum