### PR TITLE
FEATURE: support configurable thinking tokens for Gemini

### DIFF
--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -63,6 +63,8 @@ class LlmModel < ActiveRecord::Base
       },
       google: {
         disable_native_tools: :checkbox,
+        enable_thinking: :checkbox,
+        thinking_tokens: :number,
       },
       azure: {
         disable_native_tools: :checkbox,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -533,6 +533,8 @@ en:
           disable_streaming: "Disable streaming completions (convert streaming to non streaming requests)"
           reasoning_effort: "Reasoning effort (only applicable to reasoning models)"
           enable_reasoning: "Enable reasoning (only applicable to Sonnet 3.7)"
+          enable_thinking: "Enable thinking (only on applicable models eg: flash 2.5)"
+          thinking_tokens: "Number of tokens used for thinking"
           reasoning_tokens: "Number of tokens used for reasoning"
           disable_temperature: "Disable temperature (some thinking models don't support temperature)"
           disable_top_p: "Disable top P (some thinking models don't support top P)"

--- a/lib/completions/endpoints/gemini.rb
+++ b/lib/completions/endpoints/gemini.rb
@@ -94,6 +94,12 @@ module DiscourseAi
             end
           end
 
+          if llm_model.lookup_custom_param("enable_thinking")
+            thinking_tokens = llm_model.lookup_custom_param("thinking_tokens").to_i
+            thinking_tokens = thinking_tokens.clamp(0, 24_576)
+            payload[:generationConfig][:thinkingConfig] = { thinkingBudget: thinking_tokens }
+          end
+
           payload
         end
 


### PR DESCRIPTION
Gemini 2.5 series models support configurable thinking tokens. 

This allows this to be configured. 

https://ai.google.dev/gemini-api/docs/thinking