### PR TITLE
DEV: Add multiple appEvents trigger on AI Chatbot

### DIFF
--- a/assets/javascripts/discourse/components/ai-bot-header-icon.gjs
+++ b/assets/javascripts/discourse/components/ai-bot-header-icon.gjs
@@ -10,6 +10,7 @@ import { composeAiBotMessage } from "../lib/ai-bot-helper";
 import { AI_CONVERSATIONS_PANEL } from "../services/ai-conversations-sidebar-manager";
 
 export default class AiBotHeaderIcon extends Component {
+  @service appEvents;
   @service composer;
   @service currentUser;
   @service navigationMenu;
@@ -51,6 +52,7 @@ export default class AiBotHeaderIcon extends Component {
     }
 
     if (this.siteSettings.ai_bot_enable_dedicated_ux) {
+      this.appEvents.trigger("ai-bot:click-header-icon");
       return this.router.transitionTo("discourse-ai-bot-conversations");
     }
 

--- a/assets/javascripts/discourse/components/ai-bot-header-icon.gjs
+++ b/assets/javascripts/discourse/components/ai-bot-header-icon.gjs
@@ -52,7 +52,7 @@ export default class AiBotHeaderIcon extends Component {
     }
 
     if (this.siteSettings.ai_bot_enable_dedicated_ux) {
-      this.appEvents.trigger("ai-bot:click-header-icon");
+      this.appEvents.trigger("discourse-ai:bot-header-icon-clicked");
       return this.router.transitionTo("discourse-ai-bot-conversations");
     }
 

--- a/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
+++ b/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
@@ -27,6 +27,7 @@ export default class AiConversationsSidebarManager extends Service {
 
     this.sidebarState.isForcingSidebar = true;
     document.body.classList.add("has-ai-conversations-sidebar");
+    this.appEvents.trigger("discourse-ai:force-custom-sidebar");
     return true;
   }
 

--- a/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
+++ b/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
@@ -5,6 +5,7 @@ import { ADMIN_PANEL, MAIN_PANEL } from "discourse/lib/sidebar/panels";
 export const AI_CONVERSATIONS_PANEL = "ai-conversations";
 
 export default class AiConversationsSidebarManager extends Service {
+  @service appEvents;
   @service sidebarState;
 
   @tracked newTopicForceSidebar = false;
@@ -41,5 +42,7 @@ export default class AiConversationsSidebarManager extends Service {
       this.sidebarState.setPanel(MAIN_PANEL); // Return to main sidebar panel
       this.sidebarState.isForcingSidebar = false;
     }
+
+    this.appEvents.trigger("discourse-ai:stop-forcing-custom-sidebar");
   }
 }

--- a/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
+++ b/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
@@ -27,7 +27,7 @@ export default class AiConversationsSidebarManager extends Service {
 
     this.sidebarState.isForcingSidebar = true;
     document.body.classList.add("has-ai-conversations-sidebar");
-    this.appEvents.trigger("discourse-ai:force-custom-sidebar");
+    this.appEvents.trigger("discourse-ai:force-conversations-sidebar");
     return true;
   }
 

--- a/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
+++ b/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
@@ -44,6 +44,6 @@ export default class AiConversationsSidebarManager extends Service {
       this.sidebarState.isForcingSidebar = false;
     }
 
-    this.appEvents.trigger("discourse-ai:stop-forcing-custom-sidebar");
+    this.appEvents.trigger("discourse-ai:stop-forcing-conversations-sidebar");
   }
 }


### PR DESCRIPTION
## Changes

This PR adds appEvents triggers for 'discourse-ai:bot-header-icon-clicked', 'discourse-ai:force-custom-sidebar', and 'discourse-ai:stop-forcing-custom-sidebar'.