### PR TITLE
FIX: persona triage should be logged to automation

### DIFF
--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -190,7 +190,8 @@ module DiscourseAi
         add_user_to_pm: false,
         stream_reply: false,
         auto_set_title: false,
-        silent_mode: false
+        silent_mode: false,
+        feature_name: nil
       )
         ai_persona = AiPersona.find_by(id: persona_id)
         raise Discourse::InvalidParameters.new(:persona_id) if !ai_persona
@@ -210,6 +211,7 @@ module DiscourseAi
           stream_reply: stream_reply,
           auto_set_title: auto_set_title,
           silent_mode: silent_mode,
+          feature_name: feature_name,
         )
       rescue => e
         if Rails.env.test?
@@ -380,6 +382,7 @@ module DiscourseAi
         stream_reply: nil,
         auto_set_title: true,
         silent_mode: false,
+        feature_name: nil,
         &blk
       )
         # this is a multithreading issue
@@ -414,6 +417,7 @@ module DiscourseAi
           DiscourseAi::Personas::BotContext.new(
             post: post,
             custom_instructions: custom_instructions,
+            feature_name: feature_name,
             messages:
               DiscourseAi::Completions::PromptMessagesBuilder.messages_from_post(
                 post,

--- a/lib/automation/llm_persona_triage.rb
+++ b/lib/automation/llm_persona_triage.rb
@@ -8,6 +8,7 @@ module DiscourseAi
           persona_id: persona_id,
           whisper: whisper,
           silent_mode: silent_mode,
+          feature_name: "automation - #{automation&.name}",
         )
       rescue => e
         Discourse.warn_exception(


### PR DESCRIPTION
We were logging persona triage as "bot" in logs, causing some
confusions around real world usage

This amends it so we log usage to "automation - AUTOMATION NAME"

