### PR TITLE
UX: Apply bot conversation sidebar styles to mobile sidebar

### DIFF
--- a/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -14,7 +14,8 @@ body.has-ai-conversations-sidebar {
     display: none;
   }
 
-  .sidebar-wrapper {
+  .sidebar-wrapper,
+  .hamburger-dropdown-wrapper {
     .ai-conversations-panel {
       padding-top: 1em;
     }


### PR DESCRIPTION
# Before
<img width="326" alt="Screenshot 2025-05-08 at 2 04 09 PM" src="https://github.com/user-attachments/assets/5d2ec63c-0852-4297-a4dc-e82ed4ca802a" />

# After
<img width="328" alt="Screenshot 2025-05-08 at 2 03 50 PM" src="https://github.com/user-attachments/assets/13ee4826-290f-4f65-a77d-62dd80cf0eb2" />
