### PR TITLE
UX: don't show AI suggestions in composer when inputs are disabled

### DIFF
--- a/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
+++ b/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
@@ -16,6 +16,7 @@ import { MIN_CHARACTER_COUNT } from "../../lib/ai-helper-suggestions";
 export default class AiTagSuggester extends Component {
   @service siteSettings;
   @service toasts;
+  @service composer;
 
   @tracked loading = false;
   @tracked suggestions = null;
@@ -24,6 +25,10 @@ export default class AiTagSuggester extends Component {
   @tracked content = null;
 
   get showSuggestionButton() {
+    if (this.composer.disableTagsChooser) {
+      return false;
+    }
+
     const composerFields = document.querySelector(".composer-fields");
     this.content = this.args.composer?.reply;
     const showTrigger =

--- a/assets/javascripts/discourse/connectors/after-composer-category-input/ai-category-suggestion.gjs
+++ b/assets/javascripts/discourse/connectors/after-composer-category-input/ai-category-suggestion.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import AiCategorySuggester from "../../components/suggestion-menus/ai-category-suggester";
 import { showComposerAiHelper } from "../../lib/show-ai-helper";
 
@@ -12,7 +13,14 @@ export default class AiCategorySuggestion extends Component {
     );
   }
 
+  @service composer;
+
   <template>
-    <AiCategorySuggester @composer={{@outletArgs.composer}} @topicState="new" />
+    {{#unless this.composer.disableCategoryChooser}}
+      <AiCategorySuggester
+        @composer={{@outletArgs.composer}}
+        @topicState="new"
+      />
+    {{/unless}}
   </template>
 }

--- a/assets/javascripts/discourse/connectors/after-composer-title-input/ai-title-suggestion.gjs
+++ b/assets/javascripts/discourse/connectors/after-composer-title-input/ai-title-suggestion.gjs
@@ -13,6 +13,8 @@ export default class AiTitleSuggestion extends Component {
   }
 
   <template>
-    <AiTitleSuggester @composer={{@outletArgs.composer}} @topicState="new" />
+    {{#unless @outletArgs.composer.disableTitleInput}}
+      <AiTitleSuggester @composer={{@outletArgs.composer}} @topicState="new" />
+    {{/unless}}
   </template>
 }

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -229,13 +229,13 @@
     padding-right: 2em;
   }
 
-  .category-chooser {
+  .category-chooser:not(.is-disabled) {
     .select-kit-header-wrapper {
       padding-right: 1.5em;
     }
   }
 
-  .mini-tag-chooser {
+  .mini-tag-chooser:not(.is-disabled) {
     .multi-select-header {
       padding-right: 2em;
     }
@@ -314,7 +314,7 @@
   }
 
   .showing-ai-suggestions {
-    #reply-title {
+    #reply-title:not([disabled]) {
       padding-right: 2em;
     }
   }

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -229,13 +229,13 @@
     padding-right: 2em;
   }
 
-  .category-chooser:not(.is-disabled) {
+  .category-chooser {
     .select-kit-header-wrapper {
       padding-right: 1.5em;
     }
   }
 
-  .mini-tag-chooser:not(.is-disabled) {
+  .mini-tag-chooser {
     .multi-select-header {
       padding-right: 2em;
     }
@@ -314,7 +314,7 @@
   }
 
   .showing-ai-suggestions {
-    #reply-title:not([disabled]) {
+    #reply-title {
       padding-right: 2em;
     }
   }


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/disable-ai-title-generator-when-pm-title-cannot-be-edited/307595

This hides the composer AI suggestion buttons when the user can't edit the title/category/tags



