### PR TITLE
DEV: Temporarily suppress diff animation as we fix issues

### DIFF
--- a/assets/javascripts/discourse/components/modal/diff-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/diff-modal.gjs
@@ -23,6 +23,7 @@ export default class ModalDiffModal extends Component {
 
   @tracked loading = false;
   @tracked finalResult = "";
+  @tracked showcasedDiff = "";
   @tracked diffStreamer = new DiffStreamer(this.args.model.selectedText);
   @tracked suggestion = "";
   @tracked
@@ -30,14 +31,11 @@ export default class ModalDiffModal extends Component {
     () => this.suggestion,
     (newValue) => (this.suggestion = newValue)
   );
+  @tracked isStreaming = false;
 
   constructor() {
     super(...arguments);
     this.suggestChanges();
-  }
-
-  get isStreaming() {
-    return this.diffStreamer.isStreaming || this.smoothStreamer.isStreaming;
   }
 
   get primaryBtnLabel() {
@@ -64,10 +62,23 @@ export default class ModalDiffModal extends Component {
 
   @action
   async updateResult(result) {
+    // TODO(@keegan)
+    // Temporarily we are removing the animation using the diff streamer
+    // and simply showing the diff streamed without a proper animation
+    // while we figure things out
+    // so that things are not too janky in the meantime.
     this.loading = false;
+    this.isStreaming = true;
 
     if (result.done) {
       this.finalResult = result.result;
+    }
+
+    this.showcasedDiff = result.diff;
+
+    if (result.done) {
+      this.loading = false;
+      this.isStreaming = false;
     }
 
     if (this.args.model.showResultAsDiff) {
@@ -140,12 +151,11 @@ export default class ModalDiffModal extends Component {
                 "composer-ai-helper-modal__suggestion"
                 "streamable-content"
                 (if this.isStreaming "streaming")
-                (if this.diffStreamer.isThinking "thinking")
                 (if @model.showResultAsDiff "inline-diff")
               }}
             >
               {{#if @model.showResultAsDiff}}
-                {{htmlSafe this.diffStreamer.diff}}
+                {{htmlSafe this.showcasedDiff}}
               {{else}}
                 {{#if this.smoothStreamer.isStreaming}}
                   <CookText

--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -185,11 +185,9 @@ module DiscourseAi
           if (streamed_result.length > 10 && (Time.now - start > 0.3)) || Rails.env.test?
             sanitized = sanitize_result(streamed_result)
 
-            if DiscourseAi::Utils::DiffUtils::SafetyChecker.safe_to_stream?(sanitized)
-              payload = { result: sanitized, diff: streamed_diff, done: false }
-              publish_update(channel, payload, user)
-              start = Time.now
-            end
+            payload = { result: sanitized, diff: streamed_diff, done: false }
+            publish_update(channel, payload, user)
+            start = Time.now
           end
         end
 


### PR DESCRIPTION
## :mag: Overview

The diff animation introduced in https://github.com/discourse/discourse-ai/pull/1332 and with attempts to improve it in https://github.com/discourse/discourse-ai/pull/1338 still has various issues. As we work on a fix, we want to revert the animation to simply stream the diff without animation so users are not left with a janky unusable experience.

## 📹 Screen Recordings

### ← Before

https://github.com/user-attachments/assets/8385f20d-b38a-4a87-8823-d9f12d7c5d88



### → After

https://github.com/user-attachments/assets/bf51a727-bf5e-4fec-9133-5833c186a8f3

