### PR TITLE
FIX: AI share page assets via CDN on login-required sites

### DIFF
--- a/app/controllers/discourse_ai/ai_bot/shared_ai_conversations_controller.rb
+++ b/app/controllers/discourse_ai/ai_bot/shared_ai_conversations_controller.rb
@@ -8,7 +8,7 @@ module DiscourseAi
       before_action :require_site_settings!
 
       skip_before_action :preload_json, :check_xhr, only: %i[show asset]
-      skip_before_action :verify_authenticity_token, only: ["asset"]
+      skip_before_action :redirect_to_login_if_required, :verify_authenticity_token, only: %i[asset]
 
       def create
         ensure_allowed_create!


### PR DESCRIPTION
AI share page assets are loaded via the app CDN, which means the requests have no authentication and will never appear to the app as "logged in". Therefore we should skip the `redirect_to_login_if_required` before_action.