### PR TITLE
FEATURE: Triage can hide posts after adding them to the review queue

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,6 +3,7 @@ en:
     ai:
       flag_types:
         review: "Add post to review queue"
+        review_hide: "Add post to review queue and hide post"
         spam: "Flag as spam and hide post"
         spam_silence: "Flag as spam, hide post and silence user"
     scriptables:

--- a/lib/automation.rb
+++ b/lib/automation.rb
@@ -5,6 +5,10 @@ module DiscourseAi
     def self.flag_types
       [
         { id: "review", translated_name: I18n.t("discourse_automation.ai.flag_types.review") },
+        {
+          id: "review_hide",
+          translated_name: I18n.t("discourse_automation.ai.flag_types.review_hide"),
+        },
         { id: "spam", translated_name: I18n.t("discourse_automation.ai.flag_types.spam") },
         {
           id: "spam_silence",

--- a/lib/automation/llm_triage.rb
+++ b/lib/automation/llm_triage.rb
@@ -148,6 +148,11 @@ module DiscourseAi
                 reason: score_reason,
                 force_review: true,
               )
+
+              # We cannot do this through the PostActionCreator because hiding a post is reserved for auto action flags.
+              # Those flags are off_topic, inappropiate, and spam. We want a more generic type for triage, so none of those
+              # fit here.
+              post.hide!(PostActionType.types[:notify_moderators]) if flag_type == :review_hide
             end
           end
         end


### PR DESCRIPTION
Previously, this was only possible when flagging as spam.