### PR TITLE
FEATURE: Add diff streaming animation

### DIFF
--- a/assets/javascripts/discourse/components/modal/diff-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/diff-modal.gjs
@@ -145,6 +145,7 @@ export default class ModalDiffModal extends Component {
                 "streamable-content"
                 (if this.isStreaming "streaming")
                 (if @model.showResultAsDiff "inline-diff")
+                (if this.diffStreamer.isThinking "thinking")
               }}
             >
               {{~#if @model.showResultAsDiff~}}

--- a/assets/javascripts/discourse/lib/diff-streamer.gjs
+++ b/assets/javascripts/discourse/lib/diff-streamer.gjs
@@ -37,6 +37,24 @@ export default class DiffStreamer {
     const newText = result[newTextKey];
     this.isDone = !!result?.done;
 
+    if (this.isDone) {
+      this.isStreaming = false;
+      this.suggestion = newText;
+      this.words = [];
+
+      if (this.typingTimer) {
+        clearTimeout(this.typingTimer);
+        this.typingTimer = null;
+      }
+
+      const originalDiff = this.jsDiff.diffWordsWithSpace(
+        this.selectedText,
+        this.suggestion
+      );
+      this.diff = this.#formatDiffWithTags(originalDiff, false);
+      return;
+    }
+
     if (newText.length < this.lastResultText.length) {
       this.isThinking = false;
       // reset if text got shorter (e.g., reset or new input)

--- a/assets/javascripts/discourse/lib/diff-streamer.gjs
+++ b/assets/javascripts/discourse/lib/diff-streamer.gjs
@@ -1,11 +1,10 @@
 import { tracked } from "@glimmer/tracking";
 import { later } from "@ember/runloop";
+import loadJSDiff from "discourse/lib/load-js-diff";
+import { IMAGE_MARKDOWN_REGEX } from "discourse/lib/uploads";
 
-const DEFAULT_WORD_TYPING_DELAY = 200;
+const DEFAULT_CHAR_TYPING_DELAY = 30;
 
-/**
- * DiffStreamer provides a word-by-word animation effect for streamed diff updates.
- */
 export default class DiffStreamer {
   @tracked isStreaming = false;
   @tracked words = [];
@@ -13,147 +12,236 @@ export default class DiffStreamer {
   @tracked diff = "";
   @tracked suggestion = "";
   @tracked isDone = false;
-  @tracked isThinking = false;
+
   typingTimer = null;
   currentWordIndex = 0;
+  currentCharIndex = 0;
+  jsDiff = null;
 
-  /**
-   * @param {string} selectedText - The original text to compare against.
-   * @param {number} [typingDelay] - Delay in milliseconds between each word (ommitting this will use default delay).
-   */
   constructor(selectedText, typingDelay) {
     this.selectedText = selectedText;
-    this.typingDelay = typingDelay || DEFAULT_WORD_TYPING_DELAY;
+    this.typingDelay = typingDelay || DEFAULT_CHAR_TYPING_DELAY;
+    this.loadJSDiff();
   }
 
-  /**
-   * Updates the result with a newly streamed text chunk, computes new words,
-   * and begins or continues streaming animation.
-   *
-   * @param {object} result - Object containing the updated text under the given key.
-   * @param {string} newTextKey - The key where the updated suggestion text is found (e.g. if the JSON is { text: "Hello", done: false }, newTextKey would be "text")
-   */
+  async loadJSDiff() {
+    this.jsDiff = await loadJSDiff();
+  }
+
   async updateResult(result, newTextKey) {
+    if (!this.jsDiff) {
+      await this.loadJSDiff();
+    }
+
     const newText = result[newTextKey];
-    const diffText = newText.slice(this.lastResultText.length).trim();
-    const newWords = diffText.split(/\s+/).filter(Boolean);
-    this.isDone = result?.done;
+    this.isDone = !!result?.done;
+
+    if (newText.length < this.lastResultText.length) {
+      // reset if text got shorter (e.g., reset or new input)
+      this.words = [];
+      this.suggestion = "";
+      this.currentWordIndex = 0;
+      this.currentCharIndex = 0;
+    }
+
+    const diffText = newText.slice(this.lastResultText.length);
+    if (!diffText.trim()) {
+      this.lastResultText = newText;
+      return;
+    }
+
+    const newWords = this.#tokenizeMarkdownAware(diffText);
 
     if (newWords.length > 0) {
       this.isStreaming = true;
       this.words.push(...newWords);
       if (!this.typingTimer) {
-        this.#streamNextWord();
+        this.#streamNextChar();
       }
     }
 
     this.lastResultText = newText;
   }
 
-  /**
-   * Resets the streamer to its initial state.
-   */
+  #tokenizeMarkdownAware(text) {
+    const tokens = [];
+    let lastIndex = 0;
+
+    let match;
+    while ((match = IMAGE_MARKDOWN_REGEX.exec(text)) !== null) {
+      const matchStart = match.index;
+
+      if (lastIndex < matchStart) {
+        const preceding = text.slice(lastIndex, matchStart);
+        tokens.push(...(preceding.match(/\S+\s*|\s+/g) || []));
+      }
+
+      tokens.push(match[0]);
+
+      lastIndex = IMAGE_MARKDOWN_REGEX.lastIndex;
+    }
+
+    if (lastIndex < text.length) {
+      const trailing = text.slice(lastIndex);
+      tokens.push(...(trailing.match(/\S+\s*|\s+/g) || []));
+    }
+
+    return tokens;
+  }
+
   reset() {
-    this.diff = null;
+    this.diff = "";
     this.suggestion = "";
     this.lastResultText = "";
     this.words = [];
     this.currentWordIndex = 0;
-  }
-
-  /**
-   * Internal method to animate the next word in the queue and update the diff.
-   *
-   * Highlights the current word if streaming is ongoing.
-   */
-  #streamNextWord() {
-    if (this.currentWordIndex === this.words.length && !this.isDone) {
-      this.isThinking = true;
-    }
-
-    if (this.currentWordIndex === this.words.length && this.isDone) {
-      this.isThinking = false;
-      this.diff = this.#compareText(this.selectedText, this.suggestion, {
-        markLastWord: false,
-      });
-      this.isStreaming = false;
-    }
-
-    if (this.currentWordIndex < this.words.length) {
-      this.isThinking = false;
-      this.suggestion += this.words[this.currentWordIndex] + " ";
-      this.diff = this.#compareText(this.selectedText, this.suggestion, {
-        markLastWord: true,
-      });
-
-      this.currentWordIndex++;
-      this.typingTimer = later(this, this.#streamNextWord, this.typingDelay);
-    } else {
+    this.currentCharIndex = 0;
+    this.isStreaming = false;
+    if (this.typingTimer) {
+      clearTimeout(this.typingTimer);
       this.typingTimer = null;
     }
   }
 
-  /**
-   * Computes a simple word-level diff between the original and new text.
-   * Inserts <ins> for inserted words, <del> for removed/replaced words,
-   * and <mark> for the currently streaming word.
-   *
-   * @param {string} [oldText=""] - Original text.
-   * @param {string} [newText=""] - Updated suggestion text.
-   * @param {object} opts - Options for diff display.
-   * @param {boolean} opts.markLastWord - Whether to highlight the last word.
-   * @returns {string} - HTML string with diff markup.
-   */
-  #compareText(oldText = "", newText = "", opts = {}) {
-    const oldWords = oldText.trim().split(/\s+/);
-    const newWords = newText.trim().split(/\s+/);
+  async #streamNextChar() {
+    if (this.currentWordIndex < this.words.length) {
+      const currentToken = this.words[this.currentWordIndex];
 
-    // Track where the line breaks are in the original oldText
-    const lineBreakMap = (() => {
-      const lines = oldText.trim().split("\n");
-      const map = new Set();
-      let wordIndex = 0;
+      const isMarkdownToken =
+        currentToken.startsWith("![") || currentToken.startsWith("[");
 
-      for (const line of lines) {
-        const wordsInLine = line.trim().split(/\s+/);
-        wordIndex += wordsInLine.length;
-        map.add(wordIndex - 1); // Mark the last word in each line
+      if (isMarkdownToken) {
+        this.suggestion += currentToken;
+
+        this.currentWordIndex++;
+        this.currentCharIndex = 0;
+
+        const originalDiff = this.jsDiff.diffWordsWithSpace(
+          this.selectedText,
+          this.suggestion
+        );
+
+        this.diff = this.#formatDiffWithTags(originalDiff);
+
+        if (this.currentWordIndex === 1) {
+          this.diff = this.diff.replace(/^\s+/, "");
+        }
+
+        this.typingTimer = later(this, this.#streamNextChar, this.typingDelay);
+      } else {
+        const nextChar = currentToken.charAt(this.currentCharIndex);
+        this.suggestion += nextChar;
+        this.currentCharIndex++;
+
+        if (this.currentCharIndex >= currentToken.length) {
+          this.currentWordIndex++;
+          this.currentCharIndex = 0;
+
+          const originalDiff = this.jsDiff.diffWordsWithSpace(
+            this.selectedText,
+            this.suggestion
+          );
+
+          this.diff = this.#formatDiffWithTags(originalDiff);
+
+          if (this.currentWordIndex === 1) {
+            this.diff = this.diff.replace(/^\s+/, "");
+          }
+        }
+
+        this.typingTimer = later(this, this.#streamNextChar, this.typingDelay);
+      }
+    } else {
+      if (!this.suggestion || !this.selectedText || !this.jsDiff) {
+        return;
       }
 
-      return map;
-    })();
+      const originalDiff = this.jsDiff.diffWordsWithSpace(
+        this.selectedText,
+        this.suggestion
+      );
 
-    const diff = [];
-    let i = 0;
+      this.typingTimer = null;
+      this.diff = this.#formatDiffWithTags(originalDiff, false);
+      this.isStreaming = false;
+    }
+  }
 
-    while (i < oldWords.length || i < newWords.length) {
-      const oldWord = oldWords[i];
-      const newWord = newWords[i];
-
-      let wordHTML = "";
-
-      if (newWord === undefined) {
-        wordHTML = `<span class="ghost">${oldWord}</span>`;
-      } else if (oldWord === newWord) {
-        wordHTML = `<span class="same-word">${newWord}</span>`;
-      } else if (oldWord !== newWord) {
-        wordHTML = `<del>${oldWord ?? ""}</del> <ins>${newWord ?? ""}</ins>`;
+  #wrapChunk(text, type) {
+    if (type === "added") {
+      return `<ins>${text}</ins>`;
+    }
+    if (type === "removed") {
+      if (/^\s+$/.test(text)) {
+        return "";
       }
+      return `<del>${text}</del>`;
+    }
+    return `<span>${text}</span>`;
+  }
 
-      if (i === newWords.length - 1 && opts.markLastWord) {
-        wordHTML = `<mark class="highlight">${wordHTML}</mark>`;
+  #formatDiffWithTags(diffArray, highlightLastWord = true) {
+    const wordsWithType = [];
+    diffArray.forEach((part) => {
+      const tokens = part.value.match(/\S+|\s+/g) || [];
+      tokens.forEach((token) => {
+        wordsWithType.push({
+          text: token,
+          type: part.added ? "added" : part.removed ? "removed" : "unchanged",
+        });
+      });
+    });
+
+    let lastWordIndex = -1;
+    if (highlightLastWord) {
+      for (let i = wordsWithType.length - 1; i >= 0; i--) {
+        if (
+          wordsWithType[i].type !== "removed" &&
+          /\S/.test(wordsWithType[i].text)
+        ) {
+          lastWordIndex = i;
+          break;
+        }
       }
-
-      diff.push(wordHTML);
-
-      // Add a line break after this word if it ended a line in the original text
-      if (lineBreakMap.has(i)) {
-        diff.push("<br>");
-      }
-
-      i++;
     }
 
-    return diff.join(" ");
+    const output = [];
+
+    for (let i = 0; i <= lastWordIndex; i++) {
+      const { text, type } = wordsWithType[i];
+
+      if (/^\s+$/.test(text)) {
+        output.push(text);
+        continue;
+      }
+
+      let content = this.#wrapChunk(text, type);
+
+      if (highlightLastWord && i === lastWordIndex) {
+        content = `<mark class="highlight">${content}</mark>`;
+      }
+
+      output.push(content);
+    }
+
+    if (lastWordIndex < wordsWithType.length - 1) {
+      let i = lastWordIndex + 1;
+      while (i < wordsWithType.length) {
+        let chunkType = wordsWithType[i].type;
+        let chunkText = "";
+
+        while (
+          i < wordsWithType.length &&
+          wordsWithType[i].type === chunkType
+        ) {
+          chunkText += wordsWithType[i].text;
+          i++;
+        }
+
+        output.push(this.#wrapChunk(chunkText, chunkType));
+      }
+    }
+
+    return output.join("");
   }
 }

--- a/assets/stylesheets/common/streaming.scss
+++ b/assets/stylesheets/common/streaming.scss
@@ -83,19 +83,34 @@ article.streaming .cooked {
 @keyframes mark-blink {
   0%,
   100% {
-    border-color: var(--highlight-high);
+    border-color: transparent;
   }
 
   50% {
-    border-color: transparent;
+    border-color: var(--highlight-high);
   }
+}
+
+@keyframes fade-in-highlight {
+  from {
+    opacity: 0.5;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+mark.highlight {
+  background-color: var(--highlight-high);
+  animation: fade-in-highlight 0.5s ease-in-out forwards;
 }
 
 .composer-ai-helper-modal__suggestion.thinking mark.highlight {
   animation: mark-blink 1s step-start 0s infinite;
+  animation-name: mark-blink;
 }
 
-// TODO: cleanup and move around to proper files
 .composer-ai-helper-modal__loading {
   white-space: pre-wrap;
 }
@@ -111,19 +126,5 @@ article.streaming .cooked {
 
   .diff-inner {
     display: inline;
-  }
-}
-
-mark.highlight {
-  background-color: var(--highlight-high);
-  animation: fadeInHighlight 0.5s ease-in-out forwards;
-}
-
-@keyframes fadeInHighlight {
-  from {
-    opacity: 0.5;
-  }
-  to {
-    opacity: 1;
   }
 }

--- a/assets/stylesheets/common/streaming.scss
+++ b/assets/stylesheets/common/streaming.scss
@@ -94,3 +94,36 @@ article.streaming .cooked {
 .composer-ai-helper-modal__suggestion.thinking mark.highlight {
   animation: mark-blink 1s step-start 0s infinite;
 }
+
+// TODO: cleanup and move around to proper files
+.composer-ai-helper-modal__loading {
+  white-space: pre-wrap;
+}
+
+.composer-ai-helper-modal__suggestion.inline-diff {
+  white-space: pre-wrap;
+
+  del:last-child {
+    text-decoration: none;
+    background-color: transparent;
+    color: var(--primary-low-mid);
+  }
+
+  .diff-inner {
+    display: inline;
+  }
+}
+
+mark.highlight {
+  background-color: var(--highlight-high);
+  animation: fadeInHighlight 0.5s ease-in-out forwards;
+}
+
+@keyframes fadeInHighlight {
+  from {
+    opacity: 0.5;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
### :mag: Overview
Previously we attempted to add a diff streaming animation to the AI composer helper: https://github.com/discourse/discourse-ai/pull/1332, but it resulted in issues despite attempted fixes (https://github.com/discourse/discourse-ai/pull/1338) so we temporarily suppressed the diff animation (https://github.com/discourse/discourse-ai/pull/1341).

This update makes a second attempt at implementing the diff streaming animation. Instead of creating a custom diff algorithm, we make use of a third-party library [`jsDiff`](https://github.com/kpdecker/jsdiff) (which we added to core here: https://github.com/discourse/discourse/pull/32833). While streaming, the diff animation often struggles with markdown links and images, so we make use of `markdown-it` parser to detect those cases and prevent breaking the animation.

### 📹 Preview

https://github.com/user-attachments/assets/99df4ede-1ad0-4fa3-9bcd-f7ad2e7e3956