### PR TITLE
FIX: ensures stream update object is scoped to its initial topic

### DIFF
--- a/assets/javascripts/discourse/lib/ai-streamer/updaters/post-updater.js
+++ b/assets/javascripts/discourse/lib/ai-streamer/updaters/post-updater.js
@@ -18,7 +18,7 @@ export default class PostUpdater extends StreamUpdater {
     this.post = postStream.findLoadedPost(postId);
     const topicId = postStream.topic.id;
 
-    if (this.post && topicId) {
+    if (this.post) {
       this.postElement = document.querySelector(
         `.topic-area[data-topic-id="${topicId}"] #post_${this.post.post_number}`
       );

--- a/assets/javascripts/discourse/lib/ai-streamer/updaters/post-updater.js
+++ b/assets/javascripts/discourse/lib/ai-streamer/updaters/post-updater.js
@@ -12,13 +12,15 @@ export default class PostUpdater extends StreamUpdater {
 
   constructor(postStream, postId) {
     super();
+
     this.postStream = postStream;
     this.postId = postId;
     this.post = postStream.findLoadedPost(postId);
+    const topicId = postStream.topic.id;
 
-    if (this.post) {
+    if (this.post && topicId) {
       this.postElement = document.querySelector(
-        `#post_${this.post.post_number}`
+        `.topic-area[data-topic-id="${topicId}"] #post_${this.post.post_number}`
       );
     }
   }
@@ -57,6 +59,10 @@ export default class PostUpdater extends StreamUpdater {
   }
 
   async setCooked(value) {
+    if (!this.postElement) {
+      return;
+    }
+
     this.post.set("cooked", value);
 
     (await loadMorphlex()).morphInner(


### PR DESCRIPTION
Before this commit you could end up in this situation where a `post-updater` is constructed for a specific topic, but the user changes topic mid steam and it ends up updating the same post number but in a  different topic as we were only checking for `post_number` and not the combination of `topic_id` + `post_number`.

No test as there's only a unit test at the moment which wouldn't confirm the topic logic.