### PR TITLE
DEV: Hide proofreading shortcut in toolbar title

### DIFF
--- a/assets/javascripts/initializers/ai-helper.js
+++ b/assets/javascripts/initializers/ai-helper.js
@@ -27,6 +27,7 @@ function initializeAiHelperTrigger(api) {
       icon: "discourse-sparkles",
       title: "discourse_ai.ai_helper.context_menu.trigger",
       preventFocus: true,
+      hideShortcutInTitle: true,
       shortcut: "ALT+P",
       shortcutAction: (toolbarEvent) => {
         if (toolbarEvent.getText().length === 0) {


### PR DESCRIPTION
## :mag: Overview

Showing the proofreading shortcut in the toolbar button title is misleading. The shortcut triggers proofreading, not the Ask AI menu. This update makes use of the new API here https://github.com/discourse/discourse/pull/32860 to hide the proofreading shortcut in the toolbar button title.

## 📷 Screenshots

### ←Before
<img width="314" alt="Screenshot 2025-05-22 at 09 02 53" src="https://github.com/user-attachments/assets/1f07d2ff-34f5-4301-b6bb-b8b523114784" />

### → After
<img width="335" alt="Screenshot 2025-05-22 at 09 02 34" src="https://github.com/user-attachments/assets/a664deb9-0a92-40c2-b9c9-3c0d2a6970f5" />

