### PR TITLE
FIX: Improve MessageBus efficiency and correctly stop streaming

### DIFF
--- a/app/controllers/discourse_ai/ai_helper/assistant_controller.rb
+++ b/app/controllers/discourse_ai/ai_helper/assistant_controller.rb
@@ -124,6 +124,10 @@ module DiscourseAi
           raise Discourse::InvalidParameters.new(:custom_prompt) if params[:custom_prompt].blank?
         end
 
+        # to stream we must have an appropriate client_id
+        # otherwise we may end up streaming the data to the wrong client
+        raise Discourse::InvalidParameters.new(:client_id) if params[:client_id].blank?
+
         if location == "composer"
           Jobs.enqueue(
             :stream_composer_helper,
@@ -132,6 +136,7 @@ module DiscourseAi
             prompt: prompt.name,
             custom_prompt: params[:custom_prompt],
             force_default_locale: params[:force_default_locale] || false,
+            client_id: params[:client_id],
           )
         else
           post_id = get_post_param!
@@ -146,6 +151,7 @@ module DiscourseAi
             text: text,
             prompt: prompt.name,
             custom_prompt: params[:custom_prompt],
+            client_id: params[:client_id],
           )
         end
 

--- a/app/jobs/regular/stream_composer_helper.rb
+++ b/app/jobs/regular/stream_composer_helper.rb
@@ -8,6 +8,7 @@ module Jobs
       return unless args[:prompt]
       return unless user = User.find_by(id: args[:user_id])
       return unless args[:text]
+      return unless args[:client_id]
 
       prompt = CompletionPrompt.enabled_by_name(args[:prompt])
 
@@ -21,6 +22,7 @@ module Jobs
         user,
         "/discourse-ai/ai-helper/stream_composer_suggestion",
         force_default_locale: args[:force_default_locale],
+        client_id: args[:client_id],
       )
     end
   end

--- a/assets/javascripts/discourse/components/ai-post-helper-menu.gjs
+++ b/assets/javascripts/discourse/components/ai-post-helper-menu.gjs
@@ -242,6 +242,7 @@ export default class AiPostHelperMenu extends Component {
         text: this.args.data.selectedText,
         post_id: this.args.data.quoteState.postId,
         custom_prompt: this.customPromptValue,
+        client_id: this.messageBus.clientId,
       },
     });
 

--- a/assets/javascripts/discourse/components/modal/diff-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/diff-modal.gjs
@@ -108,6 +108,7 @@ export default class ModalDiffModal extends Component {
           text: this.selectedText,
           custom_prompt: this.args.model.customPromptValue,
           force_default_locale: true,
+          client_id: this.messageBus.clientId,
         },
       });
     } catch (e) {

--- a/assets/javascripts/discourse/lib/diff-streamer.gjs
+++ b/assets/javascripts/discourse/lib/diff-streamer.gjs
@@ -1,5 +1,5 @@
 import { tracked } from "@glimmer/tracking";
-import { later } from "@ember/runloop";
+import { cancel, later } from "@ember/runloop";
 import loadJSDiff from "discourse/lib/load-js-diff";
 import { parseAsync } from "discourse/lib/text";
 
@@ -45,7 +45,7 @@ export default class DiffStreamer {
       this.words = [];
 
       if (this.typingTimer) {
-        clearTimeout(this.typingTimer);
+        cancel(this.typingTimer);
         this.typingTimer = null;
       }
 
@@ -100,7 +100,7 @@ export default class DiffStreamer {
     this.currentCharIndex = 0;
     this.isStreaming = false;
     if (this.typingTimer) {
-      clearTimeout(this.typingTimer);
+      cancel(this.typingTimer);
       this.typingTimer = null;
     }
   }
@@ -254,6 +254,8 @@ export default class DiffStreamer {
 
   #formatDiffWithTags(diffArray, highlightLastWord = true) {
     const wordsWithType = [];
+    const output = [];
+
     diffArray.forEach((part) => {
       const tokens = part.value.match(/\S+|\s+/g) || [];
       tokens.forEach((token) => {
@@ -276,8 +278,6 @@ export default class DiffStreamer {
         }
       }
     }
-
-    const output = [];
 
     for (let i = 0; i <= lastWordIndex; i++) {
       const { text, type } = wordsWithType[i];

--- a/spec/jobs/regular/stream_composer_helper_spec.rb
+++ b/spec/jobs/regular/stream_composer_helper_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Jobs::StreamComposerHelper do
               text: nil,
               prompt: prompt.name,
               force_default_locale: false,
+              client_id: "123",
             )
           end
 
@@ -58,6 +59,7 @@ RSpec.describe Jobs::StreamComposerHelper do
                 text: input,
                 prompt: prompt.name,
                 force_default_locale: true,
+                client_id: "123",
               )
             end
 


### PR DESCRIPTION
This commit enhances the message bus implementation for AI helper streaming by:

- Adding client_id targeting for message bus publications to ensure only the requesting client receives streaming updates
- Limiting MessageBus backlog size (2) and age (60 seconds) to prevent Redis bloat
- Replacing clearTimeout with Ember's cancel method for proper runloop management, we were leaking a stop
- Adding tests for client-specific message delivery

These changes improve memory usage and make streaming more reliable by ensuring messages are properly directed to the requesting client.

