### PR TITLE
FIX: Don't error when navigating from AI Bot topic to regular

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-map-participants-after/ai-conversation-invite.gjs
+++ b/assets/javascripts/discourse/connectors/topic-map-participants-after/ai-conversation-invite.gjs
@@ -18,8 +18,8 @@ export default class AiConversationInvite extends Component {
 
   get participants() {
     const participants = [
-      ...this.header.topicInfo.details.allowed_users,
-      ...this.header.topicInfo.details.allowed_groups,
+      ...(this.header.topicInfo.details?.allowed_users ?? []),
+      ...(this.header.topicInfo.details?.allowed_groups ?? []),
     ];
     return participants;
   }


### PR DESCRIPTION
We were getting an error in this logic causing Ember to fail to render the non-bot-topic that we navigate to.

I believe this is because the getter of `participants` is re-calculating **before the args to this connector changes**. Adding some safe navigation here fixes the issue.