### PR TITLE
DEV: Patch `Net::BufferedIO` to help debug spec flakes

### DIFF
--- a/spec/lib/completions/cancel_manager_spec.rb
+++ b/spec/lib/completions/cancel_manager_spec.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# Debugging https://github.com/ruby/net-protocol/issues/32
+# which seems to be happening inconsistently in CI
+Net::BufferedIO.prepend(
+  Module.new do
+    def initialize(*args, **kwargs)
+      puts "Initializing #{kwargs.inspect}"
+      if kwargs[:debug_output] && !kwargs[:debug_output].respond_to(:<<)
+        raise ArgumentError, "debug_output must support <<"
+      end
+      super
+    end
+
+    def debug_output=(debug_output)
+      puts "SETTING DEBUG OUTPUT: #{debug_output.inspect}"
+      if debug_output && !debug_output.respond_to?(:<<)
+        raise ArgumentError, "debug_output must support <<"
+      end
+      super
+    end
+  end,
+)
+
 describe DiscourseAi::Completions::CancelManager do
   fab!(:model) { Fabricate(:anthropic_model, name: "test-model") }
 


### PR DESCRIPTION
We are getting lots of 

```
Failure/Error: @debug_output << '<- ' if @debug_output

NoMethodError:
  undefined method `<<' for an instance of Hash

/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:303:in `writing'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:286:in `write'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http/generic_request.rb:410:in `write_header'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http/generic_request.rb:264:in `send_request_with_body'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http/generic_request.rb:200:in `exec'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http.rb:2413:in `block in transport_request'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http.rb:2411:in `catch'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http.rb:2411:in `transport_request'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http.rb:2384:in `request'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/fakeweb-1.3.0/lib/fake_web/ext/net_http.rb:50:in `request_with_fakeweb'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/http_lib_adapters/net_http.rb:108:in `block in request'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/http_lib_adapters/net_http.rb:113:in `request'
./plugins/discourse-ai/lib/completions/endpoints/base.rb:158:in `block in perform_completion!'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/http_lib_adapters/net_http.rb:130:in `start_without_connect'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/http_lib_adapters/net_http.rb:157:in `start'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http.rb:1070:in `start'
./plugins/discourse-ai/lib/completions/endpoints/base.rb:129:in `perform_completion!'
./plugins/discourse-ai/lib/completions/llm.rb:374:in `generate'
./plugins/discourse-ai/spec/lib/completions/cancel_manager_spec.rb:79:in `block (3 levels) in <main>'
```
Internal `/t/154170`