### PR TITLE
FIX: Bump persona's examples length

### DIFF
--- a/assets/javascripts/discourse/components/ai-persona-example.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-example.gjs
@@ -45,7 +45,7 @@ export default class AiPersonaCollapsableExample extends Component {
               (if (eq pairIdx 0) "user" "model")
             )
           }}
-          @validation="required|length:1,100"
+          @validation="required|length:1,5000"
           @disabled={{@system}}
           as |field|
         >

--- a/lib/personas/summarizer.rb
+++ b/lib/personas/summarizer.rb
@@ -41,7 +41,10 @@ module DiscourseAi
         [
           [
             "Here are the posts inside <input></input> XML tags:\n\n<input>1) user1 said: I love Mondays 2) user2 said: I hate Mondays</input>\n\nGenerate a concise, coherent summary of the text above maintaining the original language.",
-            "Two users are sharing their feelings toward Mondays. [user1]({resource_url}/1) hates them, while [user2]({resource_url}/2) loves them.",
+            {
+              summary:
+                "Two users are sharing their feelings toward Mondays. [user1]({resource_url}/1) hates them, while [user2]({resource_url}/2) loves them.",
+            }.to_json,
           ],
         ]
       end


### PR DESCRIPTION
We are also updating the summary example to reflect the response must be a JSON.