### PR TITLE
DEV: Ensure enabling/disabling spam is set and logged

### DIFF
--- a/app/controllers/discourse_ai/admin/ai_spam_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_spam_controller.rb
@@ -50,7 +50,7 @@ module DiscourseAi
             )
           end
 
-          SiteSetting.set_and_log("ai_spam_detection_enabled", is_enabled)
+          SiteSetting.set_and_log("ai_spam_detection_enabled", is_enabled, current_user)
         end
 
         render json: AiSpamSerializer.new(spam_config, root: false)


### PR DESCRIPTION
### :mag: Overview

Since we enable/disable `ai_spam_detection_enabled` setting in a custom Spam tab UI in AI, we want to ensure we retain the setting and logging features. To preserve that, we want to update the controller to use `SiteSetting.set_and_log` instead of setting the value directly. 