### PR TITLE
FIX: Full page search broken

### DIFF
--- a/assets/javascripts/discourse/connectors/full-page-search-below-search-header/ai-full-page-discobot-discoveries.gjs
+++ b/assets/javascripts/discourse/connectors/full-page-search-below-search-header/ai-full-page-discobot-discoveries.gjs
@@ -15,6 +15,7 @@ export default class AiFullPageDiscobotDiscoveries extends Component {
     );
   }
 
+  @service capabilities;
   @service discobotDiscoveries;
   @service site;
 


### PR DESCRIPTION
Follow-up to 59d6e2b467d1d1e558b59d9d32794231791ee241

Error encountered in prod.

```
ai-full-page-discobot-discoveries.js:21 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'viewport')
    at get previewLength (ai-full-page-discobot-discoveries.js:21:1)
    at eM (cache-BESCGvbE.js:1647:18)
    at index.js:95:32
    at index.js:75:37
    at Z (index.js:418:5)
    at T (index.js:74:16)
    at p.get (index.js:26:32)
    at k.<anonymous> (ai-search-discoveries.js:37:1)
    at getter (index.js:444:104)
    at k.o [as discoveryPreviewLength] (cache-BESCGvbE.js:1878:17)
    at get canShowExpandtoggle (ai-search-discoveries.js:114:1)
    at get renderPreviewOnly (ai-search-discoveries.js:117:1)
```

