### PR TITLE
FEATURE: support upload.getUrl in custom tools

### DIFF
--- a/app/models/ai_tool.rb
+++ b/app/models/ai_tool.rb
@@ -142,6 +142,7 @@ class AiTool < ActiveRecord::Base
      *      base_64_content (string): Base64 encoded content of the file.
      *    Returns: { id: number, url: string, short_url: string } - Details of the created upload record.
      *
+     *    upload.getUrl(shortUrl): Given a short URL, eg upload://12345, returns the full CDN friendly URL of the upload.
      * 5. chain
      *    Controls the execution flow.
      *


### PR DESCRIPTION
Some tools need to share images with an API. A common pattern
is for APIs to expect a URL.

This allows converting upload://123123 to a proper CDN friendly
URL from within a custom tool

