### PR TITLE
FIX: custom tools incorrectly setting all fields to blank enum

### DIFF
--- a/assets/javascripts/discourse/components/ai-tool-editor-form.gjs
+++ b/assets/javascripts/discourse/components/ai-tool-editor-form.gjs
@@ -30,11 +30,16 @@ export default class AiToolEditorForm extends Component {
 
   get formData() {
     const parameters = (this.args.editingModel.parameters ?? []).map(
-      (parameter) => ({
-        ...parameter,
-        isEnum: !!parameter.enum?.length,
-        enum: (parameter.enum ??= []),
-      })
+      (parameter) => {
+        const mappedParameter = {
+          ...parameter,
+        };
+        parameter.isEnum = parameter.enum && parameter.enum.length > 0;
+        if (!parameter.isEnum) {
+          delete mappedParameter.enum;
+        }
+        return mappedParameter;
+      }
     );
 
     return {

--- a/spec/requests/admin/ai_tools_controller_spec.rb
+++ b/spec/requests/admin/ai_tools_controller_spec.rb
@@ -92,6 +92,40 @@ RSpec.describe DiscourseAi::Admin::AiToolsController do
         )
       end
     end
+
+    context "when enum validation fails" do
+      it "fails to create tool with empty enum" do
+        attrs = valid_attributes
+        attrs[:parameters] = [attrs[:parameters].first.merge(enum: [])]
+
+        expect {
+          post "/admin/plugins/discourse-ai/ai-tools.json",
+               params: { ai_tool: attrs }.to_json,
+               headers: {
+                 "CONTENT_TYPE" => "application/json",
+               }
+        }.not_to change(AiTool, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to include(match(/enum cannot be empty/))
+      end
+
+      it "fails to create tool with duplicate enum values" do
+        attrs = valid_attributes
+        attrs[:parameters] = [attrs[:parameters].first.merge(enum: %w[c f c])]
+
+        expect {
+          post "/admin/plugins/discourse-ai/ai-tools.json",
+               params: { ai_tool: attrs }.to_json,
+               headers: {
+                 "CONTENT_TYPE" => "application/json",
+               }
+        }.not_to change(AiTool, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to include(match(/enum values must be unique/))
+      end
+    end
   end
 
   describe "PUT #update" do


### PR DESCRIPTION
Previous to this change, enum was set to [] which broke all non
enum tools

