### PR TITLE
UX: AI composer helper refinements

### DIFF
--- a/assets/stylesheets/common/streaming.scss
+++ b/assets/stylesheets/common/streaming.scss
@@ -111,7 +111,7 @@ mark.highlight {
   animation-name: mark-blink;
 }
 
-.composer-ai-helper-modal__loading {
+.composer-ai-helper-modal__loading.inline-diff {
   white-space: pre-wrap;
 }
 

--- a/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -1,11 +1,13 @@
 @use "lib/viewport";
 
 .composer-ai-helper-modal {
-  .text-preview,
   .inline-diff {
     font-family: var(--d-font-family--monospace);
     font-variant-ligatures: none;
+  }
 
+  .text-preview,
+  .inline-diff {
     ins {
       background-color: var(--success-low);
       text-decoration: none;
@@ -55,13 +57,16 @@
   }
 
   &__old-value {
-    background-color: var(--danger-low);
+    white-space: pre-wrap;
+    border-left: 2px solid var(--danger);
+    padding-left: 1rem;
     color: var(--danger);
     margin-bottom: 1rem;
   }
 
   &__new-value {
-    background-color: var(--success-low);
+    border-left: 2px solid var(--success);
+    padding-left: 1rem;
     color: var(--success);
   }
 
@@ -77,7 +82,6 @@
 }
 
 .ai-composer-helper-menu {
-  padding: 0.25rem;
   max-width: 25rem;
   list-style: none;
 
@@ -701,7 +705,7 @@
     width: 100%;
     border-radius: 0;
     margin: 0;
-    padding: 0.5em 1rem;
+    padding: 0.7rem 1rem;
 
     &:focus,
     &:hover {


### PR DESCRIPTION
## 🔍 Overview
This update includes a variety of small refinements to the AI composer helper:

- prevent height jump when going from loading text placeholder → proofreading text streaming
- update padding on AI helper options list to be more suitable with typical Discourse menu design
- for composer helper results that are not `showResultAsDiff` (i.e. translation):
   - update before/after diff design to be more subtle
   - results should be in normal font (as the text is cooked and not raw markdown)
- fix: smooth streaming animation stuck showing dot icon even after smooth streaming is done

## 📷 Screenshots

| Before | After|
|-----|-----|
![Screenshot 2025-05-30 at 10 06 10](https://github.com/user-attachments/assets/3284be69-6c6d-4e56-a68d-45247fe2ec43)|![Screenshot 2025-05-30 at 10 03 30](https://github.com/user-attachments/assets/97594ce3-bce1-42da-ab4b-65b7bae4b151)|
|![Screenshot 2025-05-30 at 10 05 50](https://github.com/user-attachments/assets/d3c4eb2e-c264-497e-888e-737acea32319)|![Screenshot 2025-05-30 at 10 10 30](https://github.com/user-attachments/assets/ba40bfe0-cecc-4b7b-915f-11d2785ce1c5)|

