### PR TITLE
FIX: unable to scroll on mobile AI post helper results

### DIFF
--- a/assets/stylesheets/modules/ai-helper/mobile/ai-helper.scss
+++ b/assets/stylesheets/modules/ai-helper/mobile/ai-helper.scss
@@ -12,7 +12,6 @@
       display: flex;
       flex-direction: column;
       max-height: 100%;
-      overflow: hidden;
     }
 
     .ai-helper-options {


### PR DESCRIPTION
## :mag: Overview

As reported on [Meta](https://meta.discourse.org/t/when-selecting-text-and-giving-ai-a-custom-prompt-based-on-the-text-the-popup-cannot-be-scrolled/368687?u=keegan), you are currently unable to scroll on long AI post helper results when on mobile. This update fixes that by allowing scroll back. No test as it's tricky to test scroll behavior.

## 🔗 Relevant Links
https://meta.discourse.org/t/when-selecting-text-and-giving-ai-a-custom-prompt-based-on-the-text-the-popup-cannot-be-scrolled/368687

## 📹 Screen Recording

### ← Before
https://github.com/user-attachments/assets/9dc6f6a2-b9d4-46a8-91ee-ad1ed6f47de0


### → After
https://github.com/user-attachments/assets/ca93dba1-eefb-4d03-9b47-c4a8ba291117




