### PR TITLE
DEV: Re-introduce validator for AI Spam

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -374,6 +374,7 @@ discourse_ai:
 
   ai_spam_detection_enabled:
     default: false
+    validator: "DiscourseAi::Configuration::SpamDetectionValidator"
   ai_spam_detection_user_id:
     default: ""
     hidden: true

--- a/lib/configuration/spam_detection_validator.rb
+++ b/lib/configuration/spam_detection_validator.rb
@@ -10,6 +10,8 @@ module DiscourseAi
       def valid_value?(val)
         return true if Rails.env.test?
         return true if AiModerationSetting.spam
+        # only validate when enabling setting
+        return true if val == "f"
 
         false
       end


### PR DESCRIPTION
## :mag: Overview
This update re-introduces the validator used on the `ai_spam_detection_enabled` setting. It was initially added here: https://github.com/discourse/discourse-ai/pull/1374 to prevent Spam from being enabled without creating an `AiModerationSetting` value in the database. However, due to issues with backups/migrations we temporarily removed it here: https://github.com/discourse/discourse-ai/pull/1393. Now with some internal fixes, we can re-introduce it. We also update the validator so that it only validates when trying to turn on rather than when turning off too.