### PR TITLE
FIX: always render "today" on top of conversation sidebar

### DIFF
--- a/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
+++ b/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
@@ -216,6 +216,13 @@ export default class AiConversationsSidebarManager extends Service {
     const now = Date.now();
     const fresh = [];
 
+    const todaySection = {
+      name: "today",
+      title: i18n("discourse_ai.ai_bot.conversations.today"),
+      links: new TrackedArray(),
+    };
+    fresh.push(todaySection);
+
     this.topics.forEach((t) => {
       const postedAtMs = new Date(t.last_posted_at || now).valueOf();
       const diffDays = Math.floor((now - postedAtMs) / 86400000);
@@ -233,13 +240,16 @@ export default class AiConversationsSidebarManager extends Service {
         dateGroup = key;
       }
 
-      let sec = fresh.find((s) => s.name === dateGroup);
+      let sec;
+      if (dateGroup === "today") {
+        sec = todaySection;
+      } else {
+        sec = fresh.find((s) => s.name === dateGroup);
+      }
+
       if (!sec) {
         let title;
         switch (dateGroup) {
-          case "today":
-            title = i18n("discourse_ai.ai_bot.conversations.today");
-            break;
           case "last-7-days":
             title = i18n("discourse_ai.ai_bot.conversations.last_7_days");
             break;

--- a/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -23,6 +23,11 @@ body.has-ai-conversations-sidebar {
     }
   }
 
+  // we always have the "today" section rendered at the top of the sidebar but hide it when empty
+  .sidebar-section[data-section-name="today"]:has(.ai-bot-sidebar-empty-state) {
+    display: none;
+  }
+
   .sidebar-toggle-all-sections {
     display: none;
   }


### PR DESCRIPTION
follow-up to https://github.com/discourse/discourse-ai/commit/fa51e9d94846cc738bba8d3eaee1fd2562722885

Because sidebar sections are only registered once, a new "today" section wouldn’t appear until the sidebar re-rendered — which doesn’t happen immediately when posting a new bot PM.

This change always registers a "today" section up front, and uses CSS to hide it until it's populated with a message. 

Before (if you don't have a "today" section yet, you don't get one until refresh)

![image](https://github.com/user-attachments/assets/d91b9fbe-f762-4302-8795-d9d5c7edf5f9)


After ("today" section appears with new messages) 

![image](https://github.com/user-attachments/assets/208388b1-1d5a-4154-96e9-ced0fe8c89c0)
