### PR TITLE
Revert "DEV: Patch `Net::BufferedIO` to help debug spec flakes (#1375)"

### DIFF
--- a/spec/lib/completions/cancel_manager_spec.rb
+++ b/spec/lib/completions/cancel_manager_spec.rb
@@ -1,25 +1,5 @@
 # frozen_string_literal: true
 
-# Debugging https://github.com/ruby/net-protocol/issues/32
-# which seems to be happening inconsistently in CI
-Net::BufferedIO.prepend(
-  Module.new do
-    def initialize(*args, **kwargs)
-      if kwargs[:debug_output] && !kwargs[:debug_output].respond_to(:<<)
-        raise ArgumentError, "debug_output must support <<"
-      end
-      super
-    end
-
-    def debug_output=(debug_output)
-      if debug_output && !debug_output.respond_to?(:<<)
-        raise ArgumentError, "debug_output must support <<"
-      end
-      super
-    end
-  end,
-)
-
 describe DiscourseAi::Completions::CancelManager do
   fab!(:model) { Fabricate(:anthropic_model, name: "test-model") }
 


### PR DESCRIPTION
This reverts commit ca78b1a1c588bd8708418bc42855837aafc6ab15.

Problem resolved by https://github.com/discourse/discourse-perspective-api/pull/110