### PR TITLE
UX: focus conversation input on route transition and button click

### DIFF
--- a/assets/javascripts/discourse/components/ai-bot-conversations.gjs
+++ b/assets/javascripts/discourse/components/ai-bot-conversations.gjs
@@ -5,6 +5,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { scheduleOnce } from "@ember/runloop";
 import { service } from "@ember/service";
 import { TrackedArray } from "@ember-compat/tracked-built-ins";
 import $ from "jquery";
@@ -163,6 +164,12 @@ export default class AiBotConversations extends Component {
   setTextArea(element) {
     this.textarea = element;
     this.setupAutocomplete(element);
+    scheduleOnce("afterRender", this, this.focusTextarea);
+  }
+
+  @action
+  focusTextarea() {
+    this.textarea?.focus();
   }
 
   @action
@@ -198,7 +205,7 @@ export default class AiBotConversations extends Component {
       transformComplete: (obj) => obj.username || obj.name,
       afterComplete: (text) => {
         this.textarea.value = text;
-        this.textarea.focus();
+        this.focusTextarea();
         this.updateInputValue({ target: { value: text } });
       },
       onClose: destroyUserStatuses,
@@ -215,7 +222,7 @@ export default class AiBotConversations extends Component {
       treatAsTextarea: true,
       afterComplete: (text) => {
         this.textarea.value = text;
-        this.textarea.focus();
+        this.focusTextarea();
         this.updateInputValue({ target: { value: text } });
       },
     });

--- a/assets/javascripts/discourse/components/ai-bot-sidebar-new-conversation.gjs
+++ b/assets/javascripts/discourse/components/ai-bot-sidebar-new-conversation.gjs
@@ -14,12 +14,20 @@ export default class AiBotSidebarNewConversation extends Component {
   }
 
   @action
+  focusTextarea() {
+    document.getElementById("ai-bot-conversations-input")?.focus();
+  }
+
+  @action
   routeTo() {
     this.appEvents.trigger("discourse-ai:new-conversation-btn-clicked");
 
     if (this.router.currentRouteName !== "discourse-ai-bot-conversations") {
       this.router.transitionTo("/discourse-ai/ai-bot/conversations");
+    } else {
+      this.focusTextarea();
     }
+
     this.args.outletArgs?.toggleNavigationMenu?.();
   }
 

--- a/assets/javascripts/discourse/components/ai-bot-sidebar-new-conversation.gjs
+++ b/assets/javascripts/discourse/components/ai-bot-sidebar-new-conversation.gjs
@@ -4,6 +4,8 @@ import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import { AI_CONVERSATIONS_PANEL } from "../services/ai-conversations-sidebar-manager";
 
+const TEXTAREA_ID = "ai-bot-conversations-input";
+
 export default class AiBotSidebarNewConversation extends Component {
   @service appEvents;
   @service router;
@@ -15,7 +17,7 @@ export default class AiBotSidebarNewConversation extends Component {
 
   @action
   focusTextarea() {
-    document.getElementById("ai-bot-conversations-input")?.focus();
+    document.getElementById(TEXTAREA_ID)?.focus();
   }
 
   @action


### PR DESCRIPTION
This improves the focus behavior in two situations:

1. When clicking "new question" from the sidebar when you're on the conversations index and the input isn't focused — this now refocuses the input. Previously it did nothing. 

2. When navigating from a PM to the conversations index (most likely when clicking the new question button in the sidebar), the input will now focus. Previously it was not focused. 

![image](https://github.com/user-attachments/assets/24a82110-f993-4b52-8797-032d49517b54)
