### PR TITLE
UX: add features to persona list and other style updates

### DIFF
--- a/app/controllers/discourse_ai/admin/ai_personas_controller.rb
+++ b/app/controllers/discourse_ai/admin/ai_personas_controller.rb
@@ -8,19 +8,11 @@ module DiscourseAi
       before_action :find_ai_persona, only: %i[edit update destroy create_user]
 
       def index
-        features_by_persona_id = DiscourseAi::Features.features.group_by { |f| f[:persona]&.id }
-
         ai_personas =
           AiPersona
             .ordered
             .includes(:user, :uploads)
-            .map do |persona|
-              LocalizedAiPersonaSerializer.new(
-                persona,
-                root: false,
-                features_by_persona_id: features_by_persona_id,
-              )
-            end
+            .map { |persona| LocalizedAiPersonaSerializer.new(persona, root: false) }
 
         tools =
           DiscourseAi::Personas::Persona.all_available_tools.map do |tool|

--- a/app/serializers/localized_ai_persona_serializer.rb
+++ b/app/serializers/localized_ai_persona_serializer.rb
@@ -56,6 +56,8 @@ class LocalizedAiPersonaSerializer < ApplicationSerializer
   end
 
   def features
-    object.features.map { |feature| { id: feature.module_id, name: feature.module_name } }
+    object.features.map do |feature|
+      { id: feature.module_id, module_name: feature.module_name, name: feature.name }
+    end
   end
 end

--- a/app/serializers/localized_ai_persona_serializer.rb
+++ b/app/serializers/localized_ai_persona_serializer.rb
@@ -3,6 +3,11 @@
 class LocalizedAiPersonaSerializer < ApplicationSerializer
   root "ai_persona"
 
+  def initialize(object, options = {})
+    @features_by_persona_id = options.delete(:features_by_persona_id)
+    super(object, options)
+  end
+
   attributes :id,
              :name,
              :description,
@@ -32,7 +37,8 @@ class LocalizedAiPersonaSerializer < ApplicationSerializer
              :allow_personal_messages,
              :force_default_llm,
              :response_format,
-             :examples
+             :examples,
+             :features
 
   has_one :user, serializer: BasicUserSerializer, embed: :object
   has_many :rag_uploads, serializer: UploadSerializer, embed: :object

--- a/app/serializers/localized_ai_persona_serializer.rb
+++ b/app/serializers/localized_ai_persona_serializer.rb
@@ -3,11 +3,6 @@
 class LocalizedAiPersonaSerializer < ApplicationSerializer
   root "ai_persona"
 
-  def initialize(object, options = {})
-    @features_by_persona_id = options.delete(:features_by_persona_id)
-    super(object, options)
-  end
-
   attributes :id,
              :name,
              :description,
@@ -58,5 +53,9 @@ class LocalizedAiPersonaSerializer < ApplicationSerializer
 
   def default_llm
     LlmModel.find_by(id: object.default_llm_id)
+  end
+
+  def features
+    object.features.map { |feature| { id: feature.module_id, name: feature.module_name } }
   end
 end

--- a/app/serializers/localized_ai_persona_serializer.rb
+++ b/app/serializers/localized_ai_persona_serializer.rb
@@ -56,8 +56,6 @@ class LocalizedAiPersonaSerializer < ApplicationSerializer
   end
 
   def features
-    object.features.map do |feature|
-      { id: feature.module_id, module_name: feature.module_name, name: feature.name }
-    end
+    object.features.map { |feature| { id: feature.module_id, name: feature.module_name } }
   end
 end

--- a/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
@@ -4,6 +4,7 @@ import { concat, fn, hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
+import { gt } from "truth-helpers";
 import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
 import DButton from "discourse/components/d-button";
 import DPageSubheader from "discourse/components/d-page-subheader";
@@ -76,7 +77,11 @@ export default class AiPersonaListEditor extends Component {
           feature.name?.toLowerCase().includes(term)
         );
 
-        return textMatches || featureMatches;
+        const llmMatches = persona.default_llm?.display_name
+          ?.toLowerCase()
+          .includes(term);
+
+        return textMatches || featureMatches || llmMatches;
       });
     }
 
@@ -248,6 +253,7 @@ export default class AiPersonaListEditor extends Component {
             <thead>
               <tr>
                 <th>{{i18n "discourse_ai.ai_persona.name"}}</th>
+                <th>{{i18n "discourse_ai.llms.short_title"}}</th>
                 <th>{{i18n "discourse_ai.features.short_title"}}</th>
               </tr>
             </thead>
@@ -274,17 +280,43 @@ export default class AiPersonaListEditor extends Component {
                       </div>
                     </div>
                   </td>
-                  <td class="d-admin-row__features">
-                    {{#each persona.features as |feature|}}
+                  <td class="d-admin-row__llms">
+                    {{#if persona.default_llm}}
+                      <span class="--card-label">
+                        {{i18n "discourse_ai.ai_persona.llms_list"}}
+                      </span>
                       <DButton
                         class="btn-flat btn-small ai-persona-list__row-item-feature"
-                        @translatedLabel={{i18n
-                          (concat "discourse_ai.features." feature.name ".name")
-                        }}
-                        @route="adminPlugins.show.discourse-ai-features.edit"
-                        @routeModels={{feature.id}}
+                        @translatedLabel={{persona.default_llm.display_name}}
+                        @route="adminPlugins.show.discourse-ai-llms.edit"
+                        @routeModels={{persona.default_llm.id}}
                       />
-                    {{/each}}
+                    {{/if}}
+                  </td>
+                  <td class="d-admin-row__features">
+                    {{#if persona.features.length}}
+                      <span class="--card-label">
+                        {{i18n
+                          "discourse_ai.ai_persona.features_list"
+                          count=persona.features.length
+                        }}
+                      </span>
+                      {{#each persona.features as |feature index|}}
+                        <span class="d-admin-row__row-feature-list">
+                          {{#if (gt index 0)}}, {{/if}}
+                          <DButton
+                            class="btn-flat btn-small ai-persona-list__row-item-feature"
+                            @translatedLabel={{i18n
+                              (concat
+                                "discourse_ai.features." feature.name ".name"
+                              )
+                            }}
+                            @route="adminPlugins.show.discourse-ai-features.edit"
+                            @routeModels={{feature.id}}
+                          />
+                        </span>
+                      {{/each}}
+                    {{/if}}
                   </td>
                   <td class="d-admin-row__controls">
                     <LinkTo

--- a/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
@@ -98,7 +98,10 @@ export default class AiPersonaListEditor extends Component {
         value: "all",
         label: i18n("discourse_ai.ai_persona.filters.all_features"),
       },
-      ...features.map((name) => ({ value: name, label: name })),
+      ...features.map((name) => ({
+        value: name,
+        label: i18n(`discourse_ai.features.${name}.name`),
+      })),
     ];
   }
 
@@ -275,7 +278,9 @@ export default class AiPersonaListEditor extends Component {
                     {{#each persona.features as |feature|}}
                       <DButton
                         class="btn-flat btn-small ai-persona-list__row-item-feature"
-                        @translatedLabel={{feature.name}}
+                        @translatedLabel={{i18n
+                          (concat "discourse_ai.features." feature.name ".name")
+                        }}
                         @route="adminPlugins.show.discourse-ai-features.edit"
                         @routeModels={{feature.id}}
                       />

--- a/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
@@ -1,13 +1,12 @@
 import Component from "@glimmer/component";
-import { fn } from "@ember/helper";
-import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DButton from "discourse/components/d-button";
 import DPageSubheader from "discourse/components/d-page-subheader";
-import DToggleSwitch from "discourse/components/d-toggle-switch";
 import concatClass from "discourse/helpers/concat-class";
+import icon from "discourse/helpers/d-icon";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
 import AdminConfigAreaEmptyList from "admin/components/admin-config-area-empty-list";
@@ -61,17 +60,18 @@ export default class AiPersonaListEditor extends Component {
             <thead>
               <tr>
                 <th>{{i18n "discourse_ai.ai_persona.name"}}</th>
-                <th>{{i18n "discourse_ai.ai_persona.list.enabled"}}</th>
-                <th></th>
+                <th>{{i18n "discourse_ai.features.short_title"}}</th>
               </tr>
             </thead>
             <tbody>
               {{#each @personas as |persona|}}
+                {{log persona}}
                 <tr
                   data-persona-id={{persona.id}}
                   class={{concatClass
                     "ai-persona-list__row d-admin-row__content"
-                    (if persona.priority "priority")
+                    (if persona.priority "--priority")
+                    (if persona.enabled "--enabled")
                   }}
                 >
                   <td class="d-admin-row__overview">
@@ -79,6 +79,7 @@ export default class AiPersonaListEditor extends Component {
                       <div class="ai-persona-list__name">
                         <strong>
                           {{persona.name}}
+                          {{#if persona.enabled}}{{icon "check"}}{{/if}}
                         </strong>
                       </div>
                       <div class="ai-persona-list__description">
@@ -86,12 +87,20 @@ export default class AiPersonaListEditor extends Component {
                       </div>
                     </div>
                   </td>
-                  <td class="d-admin-row__detail">
-                    <DToggleSwitch
-                      @state={{persona.enabled}}
-                      {{on "click" (fn this.toggleEnabled persona)}}
-                    />
+
+                  <td class="d-admin-row__features">
+                    {{#each persona.features as |feature|}}
+                      {{log persona}}
+                      <DButton
+                        class="btn-flat btn-small ai-persona-list__row-item-feature"
+                        @translatedLabel={{feature.name}}
+                        @route="adminPlugins.show.discourse-ai-features.edit"
+                        @routeModels={{feature.id}}
+                      />
+                    {{/each}}
+
                   </td>
+
                   <td class="d-admin-row__controls">
                     <LinkTo
                       @route="adminPlugins.show.discourse-ai-personas.edit"

--- a/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
@@ -65,7 +65,6 @@ export default class AiPersonaListEditor extends Component {
             </thead>
             <tbody>
               {{#each @personas as |persona|}}
-                {{log persona}}
                 <tr
                   data-persona-id={{persona.id}}
                   class={{concatClass
@@ -90,7 +89,6 @@ export default class AiPersonaListEditor extends Component {
 
                   <td class="d-admin-row__features">
                     {{#each persona.features as |feature|}}
-                      {{log persona}}
                       <DButton
                         class="btn-flat btn-small ai-persona-list__row-item-feature"
                         @translatedLabel={{feature.name}}

--- a/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-list-editor.gjs
@@ -60,7 +60,7 @@ export default class AiPersonaListEditor extends Component {
     if (this.featureFilter !== "all") {
       personas = personas.filter((persona) =>
         (persona.features || []).some(
-          (feature) => feature.name === this.featureFilter
+          (feature) => feature.module_name === this.featureFilter
         )
       );
     }
@@ -74,7 +74,7 @@ export default class AiPersonaListEditor extends Component {
           persona.description?.toLowerCase().includes(term);
 
         const featureMatches = (persona.features || []).some((feature) =>
-          feature.name?.toLowerCase().includes(term)
+          feature.module_name?.toLowerCase().includes(term)
         );
 
         const llmMatches = persona.default_llm?.display_name
@@ -92,8 +92,8 @@ export default class AiPersonaListEditor extends Component {
     let features = [];
     (this.args.personas || []).forEach((persona) => {
       (persona.features || []).forEach((feature) => {
-        if (feature?.name && !features.includes(feature.name)) {
-          features.push(feature.name);
+        if (feature?.module_name && !features.includes(feature.module_name)) {
+          features.push(feature.module_name);
         }
       });
     });
@@ -308,7 +308,9 @@ export default class AiPersonaListEditor extends Component {
                             class="btn-flat btn-small ai-persona-list__row-item-feature"
                             @translatedLabel={{i18n
                               (concat
-                                "discourse_ai.features." feature.name ".name"
+                                "discourse_ai.features."
+                                feature.module_name
+                                ".name"
                               )
                             }}
                             @route="adminPlugins.show.discourse-ai-features.edit"

--- a/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
@@ -5,24 +5,6 @@
 }
 
 .ai-persona-list-editor {
-  @include viewport.until(md) {
-    td {
-      border: none;
-      padding: 0;
-
-      &.d-admin-row__llms,
-      &.d-admin-row__features {
-        padding-block: 0;
-
-        .--card-label {
-          display: inline-block;
-          font-size: var(--font-down-1);
-          color: var(--primary-high);
-        }
-      }
-    }
-  }
-
   &__header {
     display: flex;
     justify-content: space-between;
@@ -75,12 +57,6 @@
     }
   }
 
-  &.--layout-table {
-    .--card-label {
-      display: none;
-    }
-  }
-
   &.--layout-card {
     tbody {
       display: grid;
@@ -95,7 +71,7 @@
 
     .d-admin-row__content {
       display: grid;
-      grid-template-rows: auto 1fr auto auto;
+      grid-template-rows: auto auto 1fr;
       grid-template-columns: 1fr auto;
       border: 1px solid var(--primary-low);
       padding: var(--space-2) var(--space-4) var(--space-4);
@@ -132,16 +108,6 @@
       }
 
       .d-admin-row__features {
-        grid-row: 4;
-        grid-column: 1 / span 2;
-        padding: 0;
-
-        .btn {
-          margin-top: var(--space-0);
-        }
-      }
-
-      .d-admin-row__llms {
         grid-row: 3;
         grid-column: 1 / span 2;
         padding: 0;
@@ -150,17 +116,13 @@
           margin-top: var(--space-2);
         }
       }
-
-      .--card-label {
-        color: var(--primary-high);
-        font-size: var(--font-down-1);
-      }
     }
   }
 
   .ai-persona-list {
     &__row-item-feature {
       padding: 0;
+      margin-right: 0.5em;
       text-align: left;
     }
 
@@ -193,10 +155,6 @@
         padding-left: var(--space-2);
       }
     }
-  }
-
-  .d-admin-row__row-feature-list {
-    color: var(--primary-medium);
   }
 }
 

--- a/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
@@ -21,6 +21,31 @@
   li.disabled {
     opacity: 0.5;
   }
+
+  .ai-persona-list {
+    &__row-item-feature {
+      padding: 0;
+      margin-right: 0.5em;
+      text-align: left;
+    }
+
+    &__name {
+      .d-icon {
+        color: var(--success);
+        font-size: var(--font-down-1);
+      }
+    }
+
+    &__row {
+      &:hover {
+        background: transparent;
+      }
+
+      &__overview {
+        padding-left: var(--space-2);
+      }
+    }
+  }
 }
 
 .ai-persona-tool-option-editor {

--- a/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .admin-contents .ai-persona-list-editor {
   margin-top: 0;
 }
@@ -22,6 +24,101 @@
     opacity: 0.5;
   }
 
+  &__controls {
+    display: flex;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
+
+    .filter-input-container {
+      flex: 4 1 auto;
+    }
+
+    .d-select {
+      flex: 1 1 auto;
+      width: auto;
+      height: auto;
+    }
+  }
+
+  &__no-results {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+    justify-content: center;
+    padding: var(--space-6);
+    gap: var(--space-2);
+
+    h3 {
+      font-weight: normal;
+    }
+
+    .btn {
+      align-self: center;
+    }
+  }
+
+  &.--layout-card {
+    tbody {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(18em, 1fr));
+      gap: var(--space-4);
+      border: none;
+    }
+
+    thead {
+      display: none;
+    }
+
+    .d-admin-row__content {
+      display: grid;
+      grid-template-rows: auto auto 1fr;
+      grid-template-columns: 1fr auto;
+      border: 1px solid var(--primary-low);
+      padding: var(--space-2) var(--space-4) var(--space-4);
+      border-radius: var(--d-border-radius);
+
+      .d-admin-row__overview,
+      .ai-persona-list__name-with-description {
+        display: contents;
+      }
+
+      .ai-persona-list__name {
+        grid-row: 1;
+        grid-column: 1;
+        font-size: var(--font-up-1);
+        display: inline;
+        align-self: center;
+
+        .avatar {
+          height: 1.25em;
+          position: relative;
+          bottom: 0.15em;
+        }
+      }
+
+      .ai-persona-list__description {
+        grid-row: 2;
+        grid-column: 1;
+        margin: var(--space-2) 0;
+      }
+
+      .d-admin-row__controls {
+        grid-row: 1;
+        grid-column: 2;
+      }
+
+      .d-admin-row__features {
+        grid-row: 3;
+        grid-column: 1 / span 2;
+        padding: 0;
+
+        .btn {
+          margin-top: var(--space-2);
+        }
+      }
+    }
+  }
+
   .ai-persona-list {
     &__row-item-feature {
       padding: 0;
@@ -29,10 +126,23 @@
       text-align: left;
     }
 
+    &__description {
+      color: var(--primary-high);
+    }
+
     &__name {
-      .d-icon {
-        color: var(--success);
-        font-size: var(--font-down-1);
+      display: flex;
+      align-items: center;
+      gap: var(--space-1);
+      font-size: var(--font-up-0);
+      color: var(--primary);
+      margin: 0;
+      padding: 0;
+      line-height: var(--line-height-medium);
+
+      .avatar {
+        width: auto;
+        height: 1.25em;
       }
     }
 

--- a/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
+++ b/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
@@ -5,6 +5,24 @@
 }
 
 .ai-persona-list-editor {
+  @include viewport.until(md) {
+    td {
+      border: none;
+      padding: 0;
+
+      &.d-admin-row__llms,
+      &.d-admin-row__features {
+        padding-block: 0;
+
+        .--card-label {
+          display: inline-block;
+          font-size: var(--font-down-1);
+          color: var(--primary-high);
+        }
+      }
+    }
+  }
+
   &__header {
     display: flex;
     justify-content: space-between;
@@ -57,6 +75,12 @@
     }
   }
 
+  &.--layout-table {
+    .--card-label {
+      display: none;
+    }
+  }
+
   &.--layout-card {
     tbody {
       display: grid;
@@ -71,7 +95,7 @@
 
     .d-admin-row__content {
       display: grid;
-      grid-template-rows: auto auto 1fr;
+      grid-template-rows: auto 1fr auto auto;
       grid-template-columns: 1fr auto;
       border: 1px solid var(--primary-low);
       padding: var(--space-2) var(--space-4) var(--space-4);
@@ -108,6 +132,16 @@
       }
 
       .d-admin-row__features {
+        grid-row: 4;
+        grid-column: 1 / span 2;
+        padding: 0;
+
+        .btn {
+          margin-top: var(--space-0);
+        }
+      }
+
+      .d-admin-row__llms {
         grid-row: 3;
         grid-column: 1 / span 2;
         padding: 0;
@@ -116,13 +150,17 @@
           margin-top: var(--space-2);
         }
       }
+
+      .--card-label {
+        color: var(--primary-high);
+        font-size: var(--font-down-1);
+      }
     }
   }
 
   .ai-persona-list {
     &__row-item-feature {
       padding: 0;
-      margin-right: 0.5em;
       text-align: left;
     }
 
@@ -155,6 +193,10 @@
         padding-left: var(--space-2);
       }
     }
+  }
+
+  .d-admin-row__row-feature-list {
+    color: var(--primary-medium);
   }
 }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -215,6 +215,10 @@ en:
       modals:
         select_option: "Select an option..."
 
+      layout:
+        table: "Table"
+        card: "Card"
+
       spam:
         short_title: "Spam"
         title: "Configure spam handling"
@@ -378,6 +382,12 @@ en:
         ai_bot:
           title: "AI bot options"
           save_first: "More AI bot options will become available once you save the persona."
+
+        filters:
+          text: "Find a persona"
+          reset: "Reset"
+          no_results: "No personas found matching your filters."
+          all_features: "Any feature"
 
       rag:
         title: "RAG"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -211,6 +211,7 @@ en:
           custom_prompt: "Custom prompt"
           image_caption: "Caption images"
 
+
       modals:
         select_option: "Select an option..."
 
@@ -387,12 +388,6 @@ en:
           reset: "Reset"
           no_results: "No personas found matching your filters."
           all_features: "Any feature"
-
-        features_list:
-          one: "Feature:"
-          other: "Features:"
-
-        llms_list: "LLM:"
 
       rag:
         title: "RAG"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -211,7 +211,6 @@ en:
           custom_prompt: "Custom prompt"
           image_caption: "Caption images"
 
-
       modals:
         select_option: "Select an option..."
 
@@ -388,6 +387,12 @@ en:
           reset: "Reset"
           no_results: "No personas found matching your filters."
           all_features: "Any feature"
+
+        features_list:
+          one: "Feature:"
+          other: "Features:"
+
+        llms_list: "LLM:"
 
       rag:
         title: "RAG"


### PR DESCRIPTION
This updates the persona list layout to include:

* Features used
* Default LLM
* Filterable list (by name, description, LLM, or features)
* optional card view 


Before:
![image](https://github.com/user-attachments/assets/e0dff33e-85d1-4070-bb65-c31c15efc3d4)


After:
![image](https://github.com/user-attachments/assets/c50d364d-c150-4b14-b6e9-ab982a3c654b)

![image](https://github.com/user-attachments/assets/143ac63d-83c1-4ab2-8a89-2fce998fcb66)


