### PR TITLE
FIX: when tool options are added they should be available

### DIFF
--- a/assets/javascripts/discourse/components/ai-persona-tool-options.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-tool-options.gjs
@@ -33,6 +33,19 @@ export default class AiPersonaToolOptions extends Component {
     return toolOptions ? Object.keys(toolOptions) : [];
   }
 
+  @action
+  toolOptionKeys(toolId) {
+    // this is important, some tools may not have all options defined (for example if a tool option is added)
+    const metadata = this.toolsMetadata[toolId];
+    if (!metadata) {
+      return [];
+    }
+
+    // a bit more verbose for clarity of our selection
+    const availableOptions = Object.keys(metadata).filter((k) => k !== "name");
+    return availableOptions;
+  }
+
   <template>
     {{#if this.showToolOptions}}
       <@form.Container
@@ -52,7 +65,7 @@ export default class AiPersonaToolOptions extends Component {
                   {{toolMeta.name}}
                 </div>
                 <toolObj.Object @name={{toolId}} as |optionsObj optionData|>
-                  {{#each (this.formObjectKeys optionData) as |optionName|}}
+                  {{#each (this.toolOptionKeys toolId) as |optionName|}}
                     {{#let (get toolMeta optionName) as |optionMeta|}}
                       <optionsObj.Field
                         @name={{optionName}}

--- a/spec/system/admin_ai_persona_spec.rb
+++ b/spec/system/admin_ai_persona_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe "Admin AI persona configuration", type: :system, js: true do
 
     expected_tools = [["Read", { "read_private" => nil }, true], ["ListCategories", {}, true]]
     expect(persona.tools).to contain_exactly(*expected_tools)
+
+    # lets also test upgrades here... particularly one options was deleted and another added
+    # this ensurse that we can still edit the tool correctly and all options are present
+    persona.update!(tools: [["Read", { "got_deleted" => true }]])
+
+    visit "/admin/plugins/discourse-ai/ai-personas/#{persona_id}/edit"
+
+    expect(page).to have_selector("input[name='toolOptions.Read.read_private']")
+    expect(page).not_to have_selector("input[name='toolOptions.Read.got_deleted']")
   end
 
   it "will not allow deletion or editing of system personas" do


### PR DESCRIPTION
Fixes a regression where tool option editor was not showing
all tools

