### PR TITLE
FIX: improve admin api for artifact key values

### DIFF
--- a/app/controllers/discourse_ai/ai_bot/artifact_key_values_controller.rb
+++ b/app/controllers/discourse_ai/ai_bot/artifact_key_values_controller.rb
@@ -102,8 +102,12 @@ module DiscourseAi
 
         query = query.where("key = ?", index_params[:key]) if index_params[:key].present?
 
-        if !index_params[:all_users].to_s == "true" && current_user
-          query = query.where(user_id: current_user.id)
+        if index_params[:all_users].to_s != "true"
+          if current_user
+            query = query.where(user_id: current_user.id)
+          else
+            query = query.where("1 = 0")
+          end
         end
 
         query


### PR DESCRIPTION
Previously we had a logic error and were showing admins keys
that are not theirs when querying for all keys

This makes the API cleaner, to get all results you need to be explicit always

