### PR TITLE
UX: Show error and ability to try again when no suggestions

### DIFF
--- a/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
+++ b/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
@@ -11,7 +11,10 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
 import DMenu from "float-kit/components/d-menu";
-import { MIN_CHARACTER_COUNT } from "../../lib/ai-helper-suggestions";
+import {
+  MIN_CHARACTER_COUNT,
+  showSuggestionsError,
+} from "../../lib/ai-helper-suggestions";
 
 export default class AiTagSuggester extends Component {
   @service siteSettings;
@@ -79,6 +82,7 @@ export default class AiTagSuggester extends Component {
         method: "POST",
         data,
       });
+
       this.suggestions = assistant;
 
       const model = this.args.composer
@@ -92,15 +96,7 @@ export default class AiTagSuggester extends Component {
       }
 
       if (this.suggestions?.length <= 0) {
-        this.toasts.error({
-          class: "ai-suggestion-error",
-          duration: 3000,
-          data: {
-            message: i18n(
-              "discourse_ai.ai_helper.suggest_errors.no_suggestions"
-            ),
-          },
-        });
+        showSuggestionsError(this, this.loadSuggestions.bind(this));
         return;
       }
     } catch (error) {

--- a/assets/javascripts/discourse/lib/ai-helper-suggestions.js
+++ b/assets/javascripts/discourse/lib/ai-helper-suggestions.js
@@ -1,1 +1,34 @@
+import { getOwner } from "@ember/application";
+import { later } from "@ember/runloop";
+import { i18n } from "discourse-i18n";
+
 export const MIN_CHARACTER_COUNT = 40;
+
+export function showSuggestionsError(context, reloadFn) {
+  const toasts = getOwner(context).lookup("service:toasts");
+
+  toasts.error({
+    class: "ai-suggestion-error",
+    duration: "long",
+    showProgressBar: true,
+    data: {
+      message: i18n("discourse_ai.ai_helper.suggest_errors.no_suggestions"),
+      actions: [
+        {
+          label: i18n("discourse_ai.ai_helper.context_menu.regen"),
+          icon: "rotate",
+          class: "btn btn-small",
+          action: async (toast) => {
+            toast.close();
+
+            await reloadFn();
+
+            if (context.dMenu?.show && context.suggestions?.length > 0) {
+              later(() => context.dMenu.show(), 50);
+            }
+          },
+        },
+      ],
+    },
+  });
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -599,7 +599,7 @@ en:
           trigger: "Ask AI"
           loading: "AI is generating"
           cancel: "Cancel"
-          regen: "Try Again"
+          regen: "Try again"
           confirm: "Confirm"
           discard: "Discard"
           changes: "Suggested edits"


### PR DESCRIPTION
## 🔍  Overview
When the title suggestions return no suggestions, there is no indication in the UI. In the tag suggester we show a toast when there aren't any suggestions but the request was a success. In this update we make a similar UI indication with a toast for both category and title suggestions. Additionally, for all suggestions we add a "Try again" button to the toast so that suggestions can be generated again if the results yield nothing the first time.

## 📹 Preview
https://github.com/user-attachments/assets/f586694f-9c4a-4ad2-9ac4-7c2bb5a22659

