### PR TITLE
DEV: adds pointerup event to our select text helper

### DIFF
--- a/test/javascripts/acceptance/post-helper-menu-test.js
+++ b/test/javascripts/acceptance/post-helper-menu-test.js
@@ -78,6 +78,8 @@ acceptance("AI Helper - Post Helper Menu", function (needs) {
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(range);
+    const event = new PointerEvent("pointerup");
+    document.dispatchEvent(event);
     await settled();
   }
 


### PR DESCRIPTION
This is needed for https://github.com/discourse/discourse/pull/33143

Ideally we should move all these helpers to core, or improve the ones in core.