### PR TITLE
FIX: various bugs in AI interface

### DIFF
--- a/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
+++ b/assets/javascripts/discourse/components/ai-llm-editor-form.gjs
@@ -202,13 +202,15 @@ export default class AiLlmEditorForm extends Component {
 
       if (isNew) {
         this.args.llms.addObject(this.args.model);
-        this.router.transitionTo("adminPlugins.show.discourse-ai-llms.index");
-      } else {
-        this.toasts.success({
-          data: { message: i18n("discourse_ai.llms.saved") },
-          duration: 2000,
-        });
+        await this.router.replaceWith(
+          "adminPlugins.show.discourse-ai-llms.edit",
+          this.args.model.id
+        );
       }
+      this.toasts.success({
+        data: { message: i18n("discourse_ai.llms.saved") },
+        duration: 2000,
+      });
     } catch (e) {
       popupAjaxError(e);
     } finally {
@@ -340,7 +342,7 @@ export default class AiLlmEditorForm extends Component {
         @format="large"
         as |field|
       >
-        <field.Password />
+        <field.Password autocomplete="off" data-1p-ignore />
       </form.Field>
 
       <form.Object @name="provider_params" as |object providerParamsData|>

--- a/assets/javascripts/discourse/components/ai-persona-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-editor.gjs
@@ -122,16 +122,15 @@ export default class PersonaEditor extends Component {
 
       if (isNew && this.args.model.rag_uploads.length === 0) {
         this.args.personas.addObject(personaToSave);
-        this.router.transitionTo(
+        await this.router.replaceWith(
           "adminPlugins.show.discourse-ai-personas.edit",
           personaToSave
         );
-      } else {
-        this.toasts.success({
-          data: { message: i18n("discourse_ai.ai_persona.saved") },
-          duration: 2000,
-        });
       }
+      this.toasts.success({
+        data: { message: i18n("discourse_ai.ai_persona.saved") },
+        duration: 2000,
+      });
     } catch (e) {
       popupAjaxError(e);
     } finally {

--- a/assets/javascripts/discourse/components/ai-persona-tool-options.gjs
+++ b/assets/javascripts/discourse/components/ai-persona-tool-options.gjs
@@ -16,16 +16,16 @@ export default class AiPersonaToolOptions extends Component {
   }
 
   get toolsMetadata() {
-    const metatada = {};
+    const metadata = {};
 
     this.args.allTools.map((t) => {
-      metatada[t.id] = {
+      metadata[t.id] = {
         name: t.name,
         ...t?.options,
       };
     });
 
-    return metatada;
+    return metadata;
   }
 
   @action
@@ -76,7 +76,7 @@ export default class AiPersonaToolOptions extends Component {
                       >
                         {{#if (eq optionMeta.type "enum")}}
                           <field.Select @includeNone={{false}} as |select|>
-                            {{#each optionsObj.values as |v|}}
+                            {{#each optionMeta.values as |v|}}
                               <select.Option @value={{v}}>{{v}}</select.Option>
                             {{/each}}
                           </field.Select>

--- a/assets/javascripts/discourse/components/ai-tool-editor-form.gjs
+++ b/assets/javascripts/discourse/components/ai-tool-editor-form.gjs
@@ -91,7 +91,7 @@ export default class AiToolEditorForm extends Component {
         this.args.tools.pushObject(this.args.model);
       }
 
-      this.router.replaceWith(
+      await this.router.replaceWith(
         "adminPlugins.show.discourse-ai-tools.edit",
         this.args.model
       );

--- a/assets/javascripts/discourse/components/ai-tool-editor-form.gjs
+++ b/assets/javascripts/discourse/components/ai-tool-editor-form.gjs
@@ -91,7 +91,7 @@ export default class AiToolEditorForm extends Component {
         this.args.tools.pushObject(this.args.model);
       }
 
-      this.router.transitionTo(
+      this.router.replaceWith(
         "adminPlugins.show.discourse-ai-tools.edit",
         this.args.model
       );

--- a/db/fixtures/personas/603_ai_personas.rb
+++ b/db/fixtures/personas/603_ai_personas.rb
@@ -79,13 +79,8 @@ DiscourseAi::Personas::Persona.system_personas.each do |persona_class, id|
 
   persona.tools = tools.map { |name, value| [name, value] }
 
-  # Only set response_format if it's not defined as a method in the persona class
-  if !instance.class.instance_methods.include?(:response_format)
-    persona.response_format = instance.response_format
-  end
-
-  # Only set examples if it's not defined as a method in the persona class
-  persona.examples = instance.examples if !instance.class.instance_methods.include?(:examples)
+  persona.response_format = instance.response_format
+  persona.examples = instance.examples
 
   persona.system_prompt = instance.system_prompt
   persona.top_p = instance.top_p

--- a/spec/system/llms/ai_llm_spec.rb
+++ b/spec/system/llms/ai_llm_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Managing LLM configurations", type: :system, js: true do
     form.field("enabled_chat_bot").toggle
     form.submit
 
-    expect(page).to have_current_path("/admin/plugins/discourse-ai/ai-llms")
+    expect(page).to have_current_path(%r{/admin/plugins/discourse-ai/ai-llms/\d+/edit})
 
     llm = LlmModel.order(:id).last
 


### PR DESCRIPTION
1. Improves logic so when we save llm/person/tool we don't have /new routes in our state stack. Breaking expected behavior of back button
2. Fixes implementation of enum in llm tool options
3. Improves seeding logic to avoid having information hidden from end users in the UI (show examples and structured output)