### PR TITLE
FIX: When allowing private content translation, only translate group PMs and not personal PMs

### DIFF
--- a/app/jobs/regular/detect_translate_topic.rb
+++ b/app/jobs/regular/detect_translate_topic.rb
@@ -15,7 +15,12 @@ module Jobs
       end
 
       if SiteSetting.ai_translation_backfill_limit_to_public_content
-        return if topic.category&.read_restricted?
+        return if topic.category&.read_restricted? || topic.archetype == Archetype.private_message
+      else
+        if topic.archetype == Archetype.private_message &&
+             !TopicAllowedGroup.exists?(topic_id: topic.id)
+          return
+        end
       end
 
       if (detected_locale = topic.locale).blank?

--- a/spec/jobs/regular/detect_translate_post_spec.rb
+++ b/spec/jobs/regular/detect_translate_post_spec.rb
@@ -88,16 +88,78 @@ describe Jobs::DetectTranslatePost do
     expect { job.execute({ post_id: post.id }) }.not_to raise_error
   end
 
-  it "skips public content when `ai_translation_backfill_limit_to_public_content ` site setting is enabled" do
-    SiteSetting.ai_translation_backfill_limit_to_public_content = true
-    post.topic.category.update!(read_restricted: true)
+  describe "with public content and PM limitations" do
+    fab!(:private_category) { Fabricate(:private_category, group: Group[:staff]) }
+    fab!(:private_topic) { Fabricate(:topic, category: private_category) }
+    fab!(:private_post) { Fabricate(:post, topic: private_topic) }
 
-    DiscourseAi::Translation::PostLocaleDetector.expects(:detect_locale).with(post).never
-    DiscourseAi::Translation::PostLocalizer.expects(:localize).never
+    fab!(:personal_pm_topic) { Fabricate(:private_message_topic) }
+    fab!(:personal_pm_post) { Fabricate(:post, topic: personal_pm_topic) }
 
-    job.execute({ post_id: post.id })
+    fab!(:group_pm_topic) do
+      Fabricate(:group_private_message_topic, recipient_group: Fabricate(:group))
+    end
+    fab!(:group_pm_post) { Fabricate(:post, topic: group_pm_topic) }
 
-    pm_post = Fabricate(:post, topic: Fabricate(:private_message_topic))
-    job.execute({ post_id: pm_post.id })
+    context "when ai_translation_backfill_limit_to_public_content is true" do
+      before { SiteSetting.ai_translation_backfill_limit_to_public_content = true }
+
+      it "skips posts from restricted categories and PMs" do
+        DiscourseAi::Translation::PostLocaleDetector
+          .expects(:detect_locale)
+          .with(private_post)
+          .never
+        DiscourseAi::Translation::PostLocalizer
+          .expects(:localize)
+          .with(private_post, any_parameters)
+          .never
+        job.execute({ post_id: private_post.id })
+
+        DiscourseAi::Translation::PostLocaleDetector
+          .expects(:detect_locale)
+          .with(personal_pm_post)
+          .never
+        DiscourseAi::Translation::PostLocalizer
+          .expects(:localize)
+          .with(personal_pm_post, any_parameters)
+          .never
+        job.execute({ post_id: personal_pm_post.id })
+
+        DiscourseAi::Translation::PostLocaleDetector
+          .expects(:detect_locale)
+          .with(group_pm_post)
+          .never
+        DiscourseAi::Translation::PostLocalizer
+          .expects(:localize)
+          .with(group_pm_post, any_parameters)
+          .never
+        job.execute({ post_id: group_pm_post.id })
+      end
+    end
+
+    context "when ai_translation_backfill_limit_to_public_content is false" do
+      before { SiteSetting.ai_translation_backfill_limit_to_public_content = false }
+
+      it "processes posts from private categories and group PMs but skips personal PMs" do
+        DiscourseAi::Translation::PostLocaleDetector.expects(:detect_locale).with(private_post).once
+        job.execute({ post_id: private_post.id })
+
+        DiscourseAi::Translation::PostLocaleDetector
+          .expects(:detect_locale)
+          .with(group_pm_post)
+          .once
+        job.execute({ post_id: group_pm_post.id })
+
+        DiscourseAi::Translation::PostLocaleDetector
+          .expects(:detect_locale)
+          .with(personal_pm_post)
+          .never
+        DiscourseAi::Translation::PostLocalizer
+          .expects(:localize)
+          .with(personal_pm_post, any_parameters)
+          .never
+        job.execute({ post_id: personal_pm_post.id })
+      end
+    end
   end
 end


### PR DESCRIPTION
We want to avoid translating PMs that are not group PMs. This condition is applied when `SiteSetting.ai_translation_backfill_limit_to_public_content = false` 

/t/156330