### PR TITLE
FIX: Cleanup properties on closing `DiffModal`

### DIFF
--- a/assets/javascripts/discourse/components/modal/diff-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/diff-modal.gjs
@@ -159,7 +159,7 @@ export default class ModalDiffModal extends Component {
   }
 
   @action
-  closeAndCleanup() {
+  cleanupAndClose() {
     this.#resetState();
     this.loading = false;
     this.args.closeModal();
@@ -176,7 +176,7 @@ export default class ModalDiffModal extends Component {
     <DModal
       class="composer-ai-helper-modal"
       @title={{i18n "discourse_ai.ai_helper.context_menu.changes"}}
-      @closeModal={{this.closeAndCleanup}}
+      @closeModal={{this.cleanupAndClose}}
     >
       <:body>
         <div
@@ -231,7 +231,7 @@ export default class ModalDiffModal extends Component {
         </DButton>
         <DButton
           class="btn-flat discard"
-          @action={{this.closeAndCleanup}}
+          @action={{this.cleanupAndClose}}
           @label="discourse_ai.ai_helper.context_menu.discard"
         />
         <DButton


### PR DESCRIPTION
## :mag: Overview
This update ensures that we reset the tracked properties when closing the DiffModal so that the state doesn't leak when triggering the AI suggestions again. We also reset before suggesting new changes, thus if regeneration is called there shouldn't be any leaks either.

No tests in this PR as tests currently not working great due to streaming/animation issues. Will do a broader PR following up with various specs to improve test coverage here.

 