### PR TITLE
DEV: Prevent multiple translation per post

### DIFF
--- a/app/jobs/regular/detect_translate_post.rb
+++ b/app/jobs/regular/detect_translate_post.rb
@@ -2,6 +2,7 @@
 
 module Jobs
   class DetectTranslatePost < ::Jobs::Base
+    cluster_concurrency 1
     sidekiq_options retry: false
 
     def execute(args)

--- a/app/jobs/regular/detect_translate_topic.rb
+++ b/app/jobs/regular/detect_translate_topic.rb
@@ -2,6 +2,7 @@
 
 module Jobs
   class DetectTranslateTopic < ::Jobs::Base
+    cluster_concurrency 1
     sidekiq_options retry: false
 
     def execute(args)

--- a/lib/translation/entry_point.rb
+++ b/lib/translation/entry_point.rb
@@ -4,7 +4,7 @@ module DiscourseAi
   module Translation
     class EntryPoint
       def inject_into(plugin)
-        plugin.on(:post_process_cooked) do |_, post|
+        plugin.on(:post_created) do |post|
           if SiteSetting.discourse_ai_enabled && SiteSetting.ai_translation_enabled
             Jobs.enqueue(:detect_translate_post, post_id: post.id)
           end

--- a/spec/lib/translation/entry_point_spec.rb
+++ b/spec/lib/translation/entry_point_spec.rb
@@ -11,9 +11,8 @@ describe DiscourseAi::Translation::EntryPoint do
 
   describe "upon post process cooked" do
     it "enqueues detect post locale and translate post job" do
-      post = Fabricate(:post)
-      CookedPostProcessor.new(post).post_process
-
+      post =
+        PostCreator.create!(Fabricate(:user), raw: "post", title: "topic", skip_validations: true)
       expect_job_enqueued(job: :detect_translate_post, args: { post_id: post.id })
     end
 


### PR DESCRIPTION
We're seeing an aggressive number of translations being enqueued for a single post and locale. Historically, we trigger translation on `cooked` not `raw`, but that has changed a while back.

```
# from AiApiAuditLog, the same post is getting translated to the same locale within a few secs of each other
zh_CN - 2025-06-17 13:02:31 UTC
zh_CN - 2025-06-17 13:02:34 UTC
zh_CN - 2025-06-17 13:02:35 UTC
zh_CN - 2025-06-17 13:02:36 UTC
zh_CN - 2025-06-17 13:02:38 UTC
zh_CN - 2025-06-17 13:02:39 UTC
zh_CN - 2025-06-17 13:02:40 UTC
zh_CN - 2025-06-17 13:02:40 UTC
zh_CN - 2025-06-17 13:02:43 UTC
zh_CN - 2025-06-17 13:02:44 UTC
```

This PR prevents this from happening.