### PR TITLE
DEV: Increase chunk size before splitting content for translation

### DIFF
--- a/lib/translation/content_splitter.rb
+++ b/lib/translation/content_splitter.rb
@@ -3,7 +3,7 @@
 module DiscourseAi
   module Translation
     class ContentSplitter
-      CHUNK_SIZE = 3000
+      CHUNK_SIZE = 10_000
 
       BBCODE_PATTERNS = [
         %r{\[table.*?\].*?\[/table\]}m,


### PR DESCRIPTION
The chunk size limit being too low causes more API calls (for a post raw length of `10_000`, it will be split into 4 calls), if it's too high it causes timeouts. For now, it looks like `10_000` is still reasonable.