### PR TITLE
FIX: unable to scroll AI bot persona selector

### DIFF
--- a/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -125,6 +125,13 @@ body.has-ai-conversations-sidebar {
       gap: 0.5em;
       justify-content: flex-start;
 
+      .select-kit-body {
+        .select-kit-collection {
+          max-height: 50vh;
+          overflow-y: auto;
+        }
+      }
+
       &__selection-wrapper {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
## :mag: Overview
This update fixes a UX issue on the AI bot conversations page where the persona selector dropdown doesn't scroll when there are many items and the viewport is small.

No tests as it's tricky to test scrolling.

## :camera_flash: Screenshots



### ← Before
![before](https://github.com/user-attachments/assets/f3941b86-ea9e-4677-b9f1-1848bd2f0dd8)

### → After
![after](https://github.com/user-attachments/assets/e7e76e84-1190-4d51-9e14-1f38293040dc)