### PR TITLE
FIX: Bring back empty state message when appropriate

### DIFF
--- a/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
+++ b/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
@@ -84,6 +84,13 @@ export default class AiConversationsSidebarManager extends Service {
     );
   }
 
+  addEmptyStateClass() {
+    document.body.classList.toggle(
+      "has-empty-ai-conversations-sidebar",
+      !this.topics.length
+    );
+  }
+
   forceCustomSidebar() {
     document.body.classList.add("has-ai-conversations-sidebar");
     if (!this.sidebarState.isForcingSidebar) {
@@ -100,6 +107,7 @@ export default class AiConversationsSidebarManager extends Service {
 
     // don't render sidebar multiple times
     if (this._didInit) {
+      this.addEmptyStateClass();
       return true;
     }
 
@@ -107,6 +115,7 @@ export default class AiConversationsSidebarManager extends Service {
 
     this.fetchMessages().then(() => {
       this.sidebarState.setPanel(AI_CONVERSATIONS_PANEL);
+      this.addEmptyStateClass();
     });
 
     return true;
@@ -140,6 +149,7 @@ export default class AiConversationsSidebarManager extends Service {
 
   stopForcingCustomSidebar() {
     document.body.classList.remove("has-ai-conversations-sidebar");
+    document.body.classList.remove("has-empty-ai-conversations-sidebar");
 
     const isAdmin = this.sidebarState.currentPanel?.key === ADMIN_PANEL;
     if (this.sidebarState.isForcingSidebar && !isAdmin) {

--- a/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -23,18 +23,20 @@ body.has-ai-conversations-sidebar {
     }
   }
 
-  // we always have the "today" section rendered at the top of the sidebar.
-  // Hide the "today" header when the section is empty
+  // When the sidebar is empty, we want to hide the "Today" header
+  // and only show the empty state component
+  &.has-empty-ai-conversations-sidebar
+    .sidebar-section[data-section-name="today"]
+    .sidebar-section-header-wrapper {
+    display: none;
+  }
+
+  // When the sidebar isn't empty, BUT "today" is empty, hide
+  // the entire section
   &:not(.has-empty-ai-conversations-sidebar)
     .sidebar-section[data-section-name="today"]:has(
       .ai-bot-sidebar-empty-state
     ) {
-    display: none;
-  }
-
-  &.has-empty-ai-conversations-sidebar
-    .sidebar-section[data-section-name="today"]
-    .sidebar-section-header-wrapper {
     display: none;
   }
 

--- a/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -23,8 +23,18 @@ body.has-ai-conversations-sidebar {
     }
   }
 
-  // we always have the "today" section rendered at the top of the sidebar but hide it when empty
-  .sidebar-section[data-section-name="today"]:has(.ai-bot-sidebar-empty-state) {
+  // we always have the "today" section rendered at the top of the sidebar.
+  // Hide the "today" header when the section is empty
+  &:not(.has-empty-ai-conversations-sidebar)
+    .sidebar-section[data-section-name="today"]:has(
+      .ai-bot-sidebar-empty-state
+    ) {
+    display: none;
+  }
+
+  &.has-empty-ai-conversations-sidebar
+    .sidebar-section[data-section-name="today"]
+    .sidebar-section-header-wrapper {
     display: none;
   }
 

--- a/spec/system/ai_bot/homepage_spec.rb
+++ b/spec/system/ai_bot/homepage_spec.rb
@@ -226,6 +226,22 @@ RSpec.describe "AI Bot - Homepage", type: :system do
           expect(sidebar).to have_section_link(pm.title)
         end
 
+        it "shows empty state when no PMs exist" do
+          pm.destroy!
+
+          visit "/"
+          header.click_bot_button
+
+          expect(page).to have_css(".sidebar-section .ai-bot-sidebar-empty-state", visible: true)
+        end
+
+        it "doesn't show empty state when a PM exists" do
+          visit "/"
+          header.click_bot_button
+
+          expect(page).to have_no_css(".sidebar-section .ai-bot-sidebar-empty-state")
+        end
+
         it "displays last_7_days label in the sidebar" do
           pm.update!(last_posted_at: Time.zone.now - 5.days)
           visit "/"


### PR DESCRIPTION
In [this commit](https://github.com/discourse/discourse-ai/commit/4f980d5514f571683596bb9042968d210feb0cef) the today section was added always, but a side-effect was that we hid the empty state component. This commit brings back the empty state, when appropriate:

Same as now when today is empty, BUT the sidebar has other sections:
![Screenshot 2025-06-18 at 3 06 05 PM](https://github.com/user-attachments/assets/80463cad-81a7-4764-aff3-b3cf22906cd3)

Today still works:
![Screenshot 2025-06-18 at 3 04 45 PM](https://github.com/user-attachments/assets/b2046852-cf44-4c85-bb91-e29d22b9f685)

When there are no messages we show the empty component, and hide the "today" header
![Screenshot 2025-06-18 at 3 04 28 PM](https://github.com/user-attachments/assets/e092e9f0-8220-4307-9e5f-84f1fa6394fe)
