### PR TITLE
DEV: Indicate backfill rate for translations is hourly

### DIFF
--- a/app/jobs/regular/localize_posts.rb
+++ b/app/jobs/regular/localize_posts.rb
@@ -5,16 +5,15 @@ module Jobs
     cluster_concurrency 1
     sidekiq_options retry: false
 
-    BATCH_SIZE = 50
-
     def execute(args)
+      limit = args[:limit]
+      raise Discourse::InvalidParameters.new(:limit) if limit.blank? || limit <= 0
+
       return if !SiteSetting.discourse_ai_enabled
       return if !SiteSetting.ai_translation_enabled
 
       locales = SiteSetting.content_localization_supported_locales.split("|")
       return if locales.blank?
-
-      limit = args[:limit] || BATCH_SIZE
 
       locales.each do |locale|
         posts =

--- a/app/jobs/regular/localize_topics.rb
+++ b/app/jobs/regular/localize_topics.rb
@@ -5,16 +5,15 @@ module Jobs
     cluster_concurrency 1
     sidekiq_options retry: false
 
-    BATCH_SIZE = 50
-
     def execute(args)
+      limit = args[:limit]
+      raise Discourse::InvalidParameters.new(:limit) if limit.blank? || limit <= 0
+
       return if !SiteSetting.discourse_ai_enabled
       return if !SiteSetting.ai_translation_enabled
 
       locales = SiteSetting.content_localization_supported_locales.split("|")
       return if locales.blank?
-
-      limit = args[:limit] || BATCH_SIZE
 
       locales.each do |locale|
         topics =

--- a/app/jobs/scheduled/categories_locale_detection_backfill.rb
+++ b/app/jobs/scheduled/categories_locale_detection_backfill.rb
@@ -9,7 +9,8 @@ module Jobs
     def execute(args)
       return if !SiteSetting.discourse_ai_enabled
       return if !SiteSetting.ai_translation_enabled
-      return if SiteSetting.ai_translation_backfill_rate == 0
+      limit = SiteSetting.ai_translation_backfill_hourly_rate
+      return if limit == 0
 
       categories = Category.where(locale: nil)
 
@@ -17,7 +18,7 @@ module Jobs
         categories = categories.where(read_restricted: false)
       end
 
-      categories = categories.limit(SiteSetting.ai_translation_backfill_rate)
+      categories = categories.limit(limit)
       return if categories.empty?
 
       categories.each do |category|

--- a/app/jobs/scheduled/category_localization_backfill.rb
+++ b/app/jobs/scheduled/category_localization_backfill.rb
@@ -2,15 +2,17 @@
 
 module Jobs
   class CategoryLocalizationBackfill < ::Jobs::Scheduled
-    every 12.hours
+    every 1.hour
     cluster_concurrency 1
 
     def execute(args)
       return if !SiteSetting.discourse_ai_enabled
       return if !SiteSetting.ai_translation_enabled
       return if SiteSetting.content_localization_supported_locales.blank?
+      limit = SiteSetting.ai_translation_backfill_hourly_rate
+      return if limit == 0
 
-      Jobs.enqueue(:localize_categories)
+      Jobs.enqueue(:localize_categories, limit:)
     end
   end
 end

--- a/app/jobs/scheduled/post_localization_backfill.rb
+++ b/app/jobs/scheduled/post_localization_backfill.rb
@@ -10,9 +10,10 @@ module Jobs
       return if !SiteSetting.ai_translation_enabled
 
       return if SiteSetting.content_localization_supported_locales.blank?
-      return if SiteSetting.ai_translation_backfill_rate == 0
+      limit = SiteSetting.ai_translation_backfill_hourly_rate / (60 / 5) # this job runs in 5-minute intervals
+      return if limit == 0
 
-      Jobs.enqueue(:localize_posts, limit: SiteSetting.ai_translation_backfill_rate)
+      Jobs.enqueue(:localize_posts, limit:)
     end
   end
 end

--- a/app/jobs/scheduled/posts_locale_detection_backfill.rb
+++ b/app/jobs/scheduled/posts_locale_detection_backfill.rb
@@ -9,7 +9,8 @@ module Jobs
     def execute(args)
       return if !SiteSetting.discourse_ai_enabled
       return if !SiteSetting.ai_translation_enabled
-      return if SiteSetting.ai_translation_backfill_rate == 0
+      limit = SiteSetting.ai_translation_backfill_hourly_rate / (60 / 5) # this job runs in 5-minute intervals
+      return if limit == 0
 
       posts =
         Post
@@ -35,7 +36,7 @@ module Jobs
           )
       end
 
-      posts = posts.order(updated_at: :desc).limit(SiteSetting.ai_translation_backfill_rate)
+      posts = posts.order(updated_at: :desc).limit(limit)
       return if posts.empty?
 
       posts.each do |post|

--- a/app/jobs/scheduled/topic_localization_backfill.rb
+++ b/app/jobs/scheduled/topic_localization_backfill.rb
@@ -10,9 +10,10 @@ module Jobs
       return if !SiteSetting.ai_translation_enabled
 
       return if SiteSetting.content_localization_supported_locales.blank?
-      return if SiteSetting.ai_translation_backfill_rate == 0
+      limit = SiteSetting.ai_translation_backfill_hourly_rate / (60 / 5) # this job runs in 5-minute intervals
+      return if limit == 0
 
-      Jobs.enqueue(:localize_topics, limit: SiteSetting.ai_translation_backfill_rate)
+      Jobs.enqueue(:localize_topics, limit:)
     end
   end
 end

--- a/app/jobs/scheduled/topics_locale_detection_backfill.rb
+++ b/app/jobs/scheduled/topics_locale_detection_backfill.rb
@@ -9,8 +9,7 @@ module Jobs
     def execute(args)
       return if !SiteSetting.discourse_ai_enabled
       return if !SiteSetting.ai_translation_enabled
-      limit = SiteSetting.ai_translation_backfill_rate
-
+      limit = SiteSetting.ai_translation_backfill_hourly_rate / (60 / 5) # this job runs in 5-minute intervals
       return if limit == 0
 
       topics = Topic.where(locale: nil, deleted_at: nil).where("topics.user_id > 0")

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -480,7 +480,7 @@ discourse_ai:
     type: enum
     enum: "DiscourseAi::Configuration::PersonaEnumerator"
     area: "ai-features/translation"
-  ai_translation_backfill_rate:
+  ai_translation_backfill_hourly_rate:
     default: 0
     min: 0
     max: 1000

--- a/db/migrate/20250620073222_specify_rate_frequency_in_backfill_setting.rb
+++ b/db/migrate/20250620073222_specify_rate_frequency_in_backfill_setting.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SpecifyRateFrequencyInBackfillSetting < ActiveRecord::Migration[7.2]
+  def up
+    execute "UPDATE site_settings SET name = 'ai_translation_backfill_hourly_rate' WHERE name = 'ai_translation_backfill_rate'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/jobs/regular/localize_posts_spec.rb
+++ b/spec/jobs/regular/localize_posts_spec.rb
@@ -19,28 +19,28 @@ describe Jobs::LocalizePosts do
     SiteSetting.discourse_ai_enabled = false
     DiscourseAi::Translation::PostLocalizer.expects(:localize).never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "does nothing when ai_translation_enabled is disabled" do
     SiteSetting.ai_translation_enabled = false
     DiscourseAi::Translation::PostLocalizer.expects(:localize).never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "does nothing when no target languages are configured" do
     SiteSetting.content_localization_supported_locales = ""
     DiscourseAi::Translation::PostLocalizer.expects(:localize).never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "does nothing when there are no posts to translate" do
     Post.destroy_all
     DiscourseAi::Translation::PostLocalizer.expects(:localize).never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "skips posts that already have localizations" do
@@ -50,7 +50,7 @@ describe Jobs::LocalizePosts do
     end
     DiscourseAi::Translation::PostLocalizer.expects(:localize).never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "skips bot posts" do
@@ -58,7 +58,7 @@ describe Jobs::LocalizePosts do
     DiscourseAi::Translation::PostLocalizer.expects(:localize).with(post, "en").never
     DiscourseAi::Translation::PostLocalizer.expects(:localize).with(post, "ja").never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "handles translation errors gracefully" do
@@ -70,7 +70,7 @@ describe Jobs::LocalizePosts do
     DiscourseAi::Translation::PostLocalizer.expects(:localize).with(post, "ja").once
     DiscourseAi::Translation::PostLocalizer.expects(:localize).with(post, "de").once
 
-    expect { job.execute({}) }.not_to raise_error
+    expect { job.execute({ limit: 10 }) }.not_to raise_error
   end
 
   it "logs a summary after translation" do
@@ -80,14 +80,14 @@ describe Jobs::LocalizePosts do
     DiscourseAi::Translation::VerboseLogger.expects(:log).with(includes("Translated 1 posts to ja"))
     DiscourseAi::Translation::VerboseLogger.expects(:log).with(includes("Translated 1 posts to de"))
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   context "for translation scenarios" do
     it "scenario 1: skips post when locale is not set" do
       DiscourseAi::Translation::PostLocalizer.expects(:localize).never
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
 
     it "scenario 2: returns post with locale 'es' if localizations for en/ja/de do not exist" do
@@ -97,7 +97,7 @@ describe Jobs::LocalizePosts do
       DiscourseAi::Translation::PostLocalizer.expects(:localize).with(post, "ja").once
       DiscourseAi::Translation::PostLocalizer.expects(:localize).with(post, "de").once
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
 
     it "scenario 3: returns post with locale 'en' if ja/de localization does not exist" do
@@ -107,7 +107,7 @@ describe Jobs::LocalizePosts do
       DiscourseAi::Translation::PostLocalizer.expects(:localize).with(post, "de").once
       DiscourseAi::Translation::PostLocalizer.expects(:localize).with(post, "en").never
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
 
     it "scenario 4: skips post with locale 'en' if 'ja' localization already exists" do
@@ -118,7 +118,7 @@ describe Jobs::LocalizePosts do
       DiscourseAi::Translation::PostLocalizer.expects(:localize).with(post, "ja").never
       DiscourseAi::Translation::PostLocalizer.expects(:localize).with(post, "de").once
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
   end
 
@@ -158,7 +158,7 @@ describe Jobs::LocalizePosts do
           .with(group_pm_post, any_parameters)
           .never
 
-        job.execute({})
+        job.execute({ limit: 10 })
       end
     end
 
@@ -176,7 +176,7 @@ describe Jobs::LocalizePosts do
           .with(personal_pm_post, any_parameters)
           .never
 
-        job.execute({})
+        job.execute({ limit: 10 })
       end
     end
   end
@@ -198,7 +198,7 @@ describe Jobs::LocalizePosts do
         .with(old_post, any_parameters)
         .never
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
 
     it "processes all posts when setting is disabled" do
@@ -208,7 +208,7 @@ describe Jobs::LocalizePosts do
 
       DiscourseAi::Translation::PostLocalizer.expects(:localize).with(old_post, "ja").once
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
   end
 end

--- a/spec/jobs/regular/localize_topics_spec.rb
+++ b/spec/jobs/regular/localize_topics_spec.rb
@@ -19,28 +19,28 @@ describe Jobs::LocalizeTopics do
     SiteSetting.discourse_ai_enabled = false
     DiscourseAi::Translation::TopicLocalizer.expects(:localize).never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "does nothing when ai_translation_enabled is disabled" do
     SiteSetting.ai_translation_enabled = false
     DiscourseAi::Translation::TopicLocalizer.expects(:localize).never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "does nothing when no target languages are configured" do
     SiteSetting.content_localization_supported_locales = ""
     DiscourseAi::Translation::TopicLocalizer.expects(:localize).never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "does nothing when there are no topics to translate" do
     Topic.destroy_all
     DiscourseAi::Translation::TopicLocalizer.expects(:localize).never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "skips topics that already have localizations" do
@@ -50,7 +50,7 @@ describe Jobs::LocalizeTopics do
     end
     DiscourseAi::Translation::TopicLocalizer.expects(:localize).never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "skips bot topics" do
@@ -58,7 +58,7 @@ describe Jobs::LocalizeTopics do
     DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(topic, "en").never
     DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(topic, "ja").never
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   it "handles translation errors gracefully" do
@@ -70,7 +70,7 @@ describe Jobs::LocalizeTopics do
     DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(topic, "ja").once
     DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(topic, "de").once
 
-    expect { job.execute({}) }.not_to raise_error
+    expect { job.execute({ limit: 10 }) }.not_to raise_error
   end
 
   it "logs a summary after translation" do
@@ -86,14 +86,14 @@ describe Jobs::LocalizeTopics do
       includes("Translated 1 topics to de"),
     )
 
-    job.execute({})
+    job.execute({ limit: 10 })
   end
 
   context "for translation scenarios" do
     it "scenario 1: skips topic when locale is not set" do
       DiscourseAi::Translation::TopicLocalizer.expects(:localize).never
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
 
     it "scenario 2: returns topic with locale 'es' if localizations for en/ja/de do not exist" do
@@ -103,7 +103,7 @@ describe Jobs::LocalizeTopics do
       DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(topic, "ja").once
       DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(topic, "de").once
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
 
     it "scenario 3: returns topic with locale 'en' if ja/de localization does not exist" do
@@ -113,7 +113,7 @@ describe Jobs::LocalizeTopics do
       DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(topic, "de").once
       DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(topic, "en").never
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
 
     it "scenario 4: skips topic with locale 'en' if 'ja' localization already exists" do
@@ -124,7 +124,7 @@ describe Jobs::LocalizeTopics do
       DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(topic, "ja").never
       DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(topic, "de").once
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
   end
 
@@ -162,7 +162,7 @@ describe Jobs::LocalizeTopics do
           .with(group_pm_topic, any_parameters)
           .never
 
-        job.execute({})
+        job.execute({ limit: 10 })
       end
     end
 
@@ -181,7 +181,7 @@ describe Jobs::LocalizeTopics do
           .with(personal_pm_topic, any_parameters)
           .never
 
-        job.execute({})
+        job.execute({ limit: 10 })
       end
     end
   end
@@ -202,7 +202,7 @@ describe Jobs::LocalizeTopics do
         .with(old_topic, any_parameters)
         .never
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
 
     it "processes all topics when setting is disabled" do
@@ -216,7 +216,7 @@ describe Jobs::LocalizeTopics do
       DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(old_topic, "ja").once
       DiscourseAi::Translation::TopicLocalizer.expects(:localize).with(old_topic, "de").once
 
-      job.execute({})
+      job.execute({ limit: 10 })
     end
   end
 end

--- a/spec/jobs/scheduled/posts_locale_detection_backfill_spec.rb
+++ b/spec/jobs/scheduled/posts_locale_detection_backfill_spec.rb
@@ -10,7 +10,7 @@ describe Jobs::PostsLocaleDetectionBackfill do
       SiteSetting.public_send("ai_translation_model=", "custom:#{fake_llm.id}")
     end
     SiteSetting.ai_translation_enabled = true
-    SiteSetting.ai_translation_backfill_rate = 100
+    SiteSetting.ai_translation_backfill_hourly_rate = 100
   end
 
   it "does nothing when translator is disabled" do
@@ -47,7 +47,7 @@ describe Jobs::PostsLocaleDetectionBackfill do
     post_2.update!(updated_at: 2.day.ago)
     post_3.update!(updated_at: 4.day.ago)
 
-    SiteSetting.ai_translation_backfill_rate = 1
+    SiteSetting.ai_translation_backfill_hourly_rate = 12
 
     DiscourseAi::Translation::PostLocaleDetector.expects(:detect_locale).with(post_2).once
     DiscourseAi::Translation::PostLocaleDetector.expects(:detect_locale).with(post).never


### PR DESCRIPTION
This PR improves the way we handle backfill translation jobs:

- The existing site setting `ai_translation_backfill_rate` is slightly ambiguous, renaming it to `ai_translation_backfill_hourly_rate`. This makes it similar to the original intention https://github.com/discourse/discourse-translator/commit/6c2c08cf5955c78dcd10d0b9654c8ee8c89e1a50.
- Updates category translations to also comply to this setting