### PR TITLE
UX: make topic list gists link to the topic

### DIFF
--- a/assets/javascripts/discourse/components/ai-topic-gist.gjs
+++ b/assets/javascripts/discourse/components/ai-topic-gist.gjs
@@ -24,16 +24,16 @@ export default class AiTopicGist extends Component {
   <template>
     {{#if this.shouldShow}}
       {{#if this.hasGist}}
-        <div class="excerpt">
+        <a href={{@topic.lastUnreadUrl}} class="excerpt">
           <div class="excerpt__contents">{{this.gist}}</div>
-        </div>
+        </a>
       {{else}}
         {{#if this.escapedExcerpt}}
-          <div class="excerpt">
+          <a href={{@topic.lastUnreadUrl}} class="excerpt">
             <div class="excerpt__contents">
               {{htmlSafe this.escapedExcerpt}}
             </div>
-          </div>
+          </a>
         {{/if}}
       {{/if}}
     {{/if}}

--- a/assets/stylesheets/modules/summarization/common/ai-gists.scss
+++ b/assets/stylesheets/modules/summarization/common/ai-gists.scss
@@ -41,6 +41,7 @@
       line-height: var(--line-height-large);
       margin-top: 0.15em;
       margin-bottom: 0.15em;
+      color: currentcolor;
 
       &__contents {
         max-width: 70ch;


### PR DESCRIPTION
This allows the gist to click through to the topic, similar to our default excerpts here: https://github.com/discourse/discourse/blob/32665cf9dd26a00b4f95cb43164aa7ccb17f2fa4/app/assets/javascripts/discourse/app/components/topic-list/topic-excerpt.gjs#L6