### PR TITLE
UX: add missing translation for uploads

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -237,7 +237,6 @@ en:
           topic_title_translator: "Topic title translator"
           short_text_translator: "Short text translator"
 
-
       modals:
         select_option: "Select an option..."
 
@@ -844,6 +843,7 @@ en:
           today: "Today"
           last_7_days: "Last 7 days"
           last_30_days: "Last 30 days"
+          upload_files: "Upload files"
       sentiments:
         dashboard:
           title: "Sentiment"


### PR DESCRIPTION
We were missing a translation for the upload button here:

![image](https://github.com/user-attachments/assets/5b41df9f-9f48-402c-869d-e69c91858a6a)

reported here: https://meta.discourse.org/t/ai-search-upload-button-tooltip-translation-missing/367371