### PR TITLE
Fix: convert array content to string before LLM prompt to avoid TypeE…

### DIFF
--- a/lib/ai_helper/assistant.rb
+++ b/lib/ai_helper/assistant.rb
@@ -125,6 +125,11 @@ module DiscourseAi
             custom_instructions: custom_locale_instructions(user, force_default_locale),
           )
         context = attach_user_context(context, user, force_default_locale: force_default_locale)
+        context.messages.each do |msg|
+           if msg[:content].is_a?(Array)
+             msg[:content] = msg[:content].map(&:to_s).join("\n")
+           end
+        end
 
         helper_response = +""
 


### PR DESCRIPTION
### Context
When using the AI helper with Gemini (or other LLMs) to analyze posts containing images, the `content` payload is an array combining text and image metadata. This causes the following error:

### Root Cause
The `generate_prompt` method constructs `context.messages` assuming `content` is always a string. When it's an array, string operations like `.gsub` or concatenation fail.

### Fix
This PR adds a simple guard clause to normalize any array content to a string by joining its elements before passing the prompt to the LLM.

### Reproduction
- Create a post with text and an image attachment
- Run the AI helper with the default "creative" model
- Observe the TypeError
- After this patch, the prompt is processed correctly.
