### PR TITLE
FIX: Return no topics when embeddings is disabled

### DIFF
--- a/lib/embeddings/semantic_related.rb
+++ b/lib/embeddings/semantic_related.rb
@@ -10,7 +10,7 @@ module DiscourseAi
 
       def related_topic_ids_for(topic)
         return [] if SiteSetting.ai_embeddings_semantic_related_topics < 1
-        return [] if SiteSetting.ai_embeddings_selected_model.blank? # fail-safe in case something end up in a broken state.
+        return [] if !DiscourseAi::Embeddings.enabled? # fail-safe in case something end up in a broken state.
 
         cache_for = results_ttl(topic)
 

--- a/spec/lib/modules/embeddings/semantic_related_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_related_spec.rb
@@ -22,6 +22,20 @@ describe DiscourseAi::Embeddings::SemanticRelated do
   end
 
   describe "#related_topic_ids_for" do
+    it "returns empty array if AI embeddings are disabled" do
+      SiteSetting.ai_embeddings_enabled = false
+      SiteSetting.ai_embeddings_selected_model = 1234
+
+      expect(semantic_related.related_topic_ids_for(normal_topic_1)).to eq([])
+    end
+
+    it "returns empty array if AI embeddings model is invalid" do
+      SiteSetting.ai_embeddings_enabled = true
+      SiteSetting.ai_embeddings_selected_model = 1234
+
+      expect(semantic_related.related_topic_ids_for(normal_topic_1)).to eq([])
+    end
+
     context "when embeddings do not exist" do
       let(:topic) do
         post = Fabricate(:post)

--- a/spec/lib/modules/embeddings/semantic_topic_query_spec.rb
+++ b/spec/lib/modules/embeddings/semantic_topic_query_spec.rb
@@ -11,7 +11,10 @@ describe DiscourseAi::Embeddings::EntryPoint do
 
       fab!(:vector_def) { Fabricate(:cloudflare_embedding_def) }
 
-      before { SiteSetting.ai_embeddings_selected_model = vector_def.id }
+      before do
+        SiteSetting.ai_embeddings_enabled = true
+        SiteSetting.ai_embeddings_selected_model = vector_def.id
+      end
 
       # The Distance gap to target increases for each element of topics.
       def seed_embeddings(topics)


### PR DESCRIPTION
When an invalid model is set for embeddings, topics do not load even if embeddings is disabled.

Error:
> ## RuntimeError in TopicsController#show
> 
> Invalid embeddings selected model


This PR checks for valid settings before attempting to load related topics.