### PR TITLE
UX: Fix typo in bot.description text

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -204,7 +204,7 @@ en:
         bot:
           bot: "Chatbot"
           name: "Bot"
-          description: "A chat bot that can answer questions and assist users in private messagges, forum and in chat"
+          description: "A chat bot that can answer questions and assist users in personal messages, forum and in chat"
         nav:
           configured: "Configured"
           unconfigured: "Unconfigured"


### PR DESCRIPTION
Introducing a typo isn't the right way to bypass the check that blocks the term "private messages".

Nice try, though ;)

I changed it to "personal messages".