### PR TITLE
DEV: replace sortBy with toSorted

### DIFF
--- a/assets/javascripts/discourse/components/ai-features-list.gjs
+++ b/assets/javascripts/discourse/components/ai-features-list.gjs
@@ -70,7 +70,9 @@ export default class AiFeaturesList extends Component {
       return [];
     }
 
-    return this.args.modules.toSorted((a, b) => a.module_name.localeCompare(b.module_name));
+    return this.args.modules.toSorted((a, b) =>
+      a.module_name.localeCompare(b.module_name)
+    );
   }
 
   @action

--- a/assets/javascripts/discourse/components/ai-features-list.gjs
+++ b/assets/javascripts/discourse/components/ai-features-list.gjs
@@ -70,7 +70,7 @@ export default class AiFeaturesList extends Component {
       return [];
     }
 
-    return this.args.modules.sortBy("module_name");
+    return this.args.modules.toSorted((a, b) => a.module_name.localeCompare(b.module_name));
   }
 
   @action


### PR DESCRIPTION
replacing the old deprecated `sortBy` with the newer vanilla JS `toSorted` — also learned that `localeCompare` is handy for comparisons like this 