### PR TITLE
FIX: cross talk when in ai helper

### DIFF
--- a/app/jobs/regular/stream_composer_helper.rb
+++ b/app/jobs/regular/stream_composer_helper.rb
@@ -9,6 +9,7 @@ module Jobs
       return unless user = User.find_by(id: args[:user_id])
       return unless args[:text]
       return unless args[:client_id]
+      return unless args[:progress_channel]
 
       helper_mode = args[:prompt]
 
@@ -16,7 +17,7 @@ module Jobs
         helper_mode,
         args[:text],
         user,
-        "/discourse-ai/ai-helper/stream_composer_suggestion",
+        args[:progress_channel],
         force_default_locale: args[:force_default_locale],
         client_id: args[:client_id],
         custom_prompt: args[:custom_prompt],

--- a/app/jobs/regular/stream_post_helper.rb
+++ b/app/jobs/regular/stream_post_helper.rb
@@ -8,6 +8,8 @@ module Jobs
       return unless post = Post.includes(:topic).find_by(id: args[:post_id])
       return unless user = User.find_by(id: args[:user_id])
       return unless args[:text]
+      return unless args[:progress_channel]
+      return unless args[:client_id]
 
       topic = post.topic
       reply_to = post.reply_to_post
@@ -31,8 +33,9 @@ module Jobs
         helper_mode,
         input,
         user,
-        "/discourse-ai/ai-helper/stream_suggestion/#{post.id}",
+        args[:progress_channel],
         custom_prompt: args[:custom_prompt],
+        client_id: args[:client_id],
       )
     end
   end

--- a/assets/javascripts/discourse/components/ai-post-helper-menu.gjs
+++ b/assets/javascripts/discourse/components/ai-post-helper-menu.gjs
@@ -155,7 +155,7 @@ export default class AiPostHelperMenu extends Component {
   }
 
   subscribe() {
-    this.messageBus.subscribe(this._progressChannel, this._updateResult);
+    this.messageBus.subscribe(this._progressChannel, this._updateResult, 0);
   }
 
   @bind

--- a/lib/ai_helper/entry_point.rb
+++ b/lib/ai_helper/entry_point.rb
@@ -73,18 +73,6 @@ module DiscourseAi
               scope.user.in_any_groups?(SiteSetting.ai_auto_image_caption_allowed_groups_map)
           end,
         ) { object.auto_image_caption }
-
-        plugin.add_to_serializer(
-          :post,
-          :discourse_ai_helper_stream_suggestion_last_message_bus_id,
-          include_condition: -> { SiteSetting.ai_helper_enabled && scope.authenticated? },
-        ) { MessageBus.last_id("/discourse-ai/ai-helper/stream_suggestion/#{object.id}") }
-
-        plugin.add_to_serializer(
-          :current_user,
-          :discourse_ai_helper_stream_composer_suggestion_last_message_bus_id,
-          include_condition: -> { SiteSetting.ai_helper_enabled && scope.authenticated? },
-        ) { MessageBus.last_id("/discourse-ai/ai-helper/stream_composer_suggestion") }
       end
     end
   end

--- a/spec/jobs/regular/stream_composer_helper_spec.rb
+++ b/spec/jobs/regular/stream_composer_helper_spec.rb
@@ -18,23 +18,33 @@ RSpec.describe Jobs::StreamComposerHelper do
       let(:mode) { DiscourseAi::AiHelper::Assistant::PROOFREAD }
 
       it "does nothing if there is no user" do
+        channel = "/some/channel"
         messages =
-          MessageBus.track_publish("/discourse-ai/ai-helper/stream_suggestion") do
-            job.execute(user_id: nil, text: input, prompt: mode, force_default_locale: false)
+          MessageBus.track_publish(channel) do
+            job.execute(
+              user_id: nil,
+              text: input,
+              prompt: mode,
+              force_default_locale: false,
+              client_id: "123",
+              progress_channel: channel,
+            )
           end
 
         expect(messages).to be_empty
       end
 
       it "does nothing if there is no text" do
+        channel = "/some/channel"
         messages =
-          MessageBus.track_publish("/discourse-ai/ai-helper/stream_suggestion") do
+          MessageBus.track_publish(channel) do
             job.execute(
               user_id: user.id,
               text: nil,
               prompt: mode,
               force_default_locale: false,
               client_id: "123",
+              progress_channel: channel,
             )
           end
 
@@ -47,16 +57,18 @@ RSpec.describe Jobs::StreamComposerHelper do
 
       it "publishes updates with a partial result" do
         proofread_result = "I like to eat pie for breakfast because it is delicious."
+        channel = "/channel/123"
 
         DiscourseAi::Completions::Llm.with_prepared_responses([proofread_result]) do
           messages =
-            MessageBus.track_publish("/discourse-ai/ai-helper/stream_composer_suggestion") do
+            MessageBus.track_publish(channel) do
               job.execute(
                 user_id: user.id,
                 text: input,
                 prompt: mode,
                 force_default_locale: true,
                 client_id: "123",
+                progress_channel: channel,
               )
             end
 
@@ -68,16 +80,18 @@ RSpec.describe Jobs::StreamComposerHelper do
 
       it "publishes a final update to signal we're done" do
         proofread_result = "I like to eat pie for breakfast because it is delicious."
+        channel = "/channel/123"
 
         DiscourseAi::Completions::Llm.with_prepared_responses([proofread_result]) do
           messages =
-            MessageBus.track_publish("/discourse-ai/ai-helper/stream_composer_suggestion") do
+            MessageBus.track_publish(channel) do
               job.execute(
                 user_id: user.id,
                 text: input,
                 prompt: mode,
                 force_default_locale: true,
                 client_id: "123",
+                progress_channel: channel,
               )
             end
 

--- a/spec/jobs/regular/stream_post_helper_spec.rb
+++ b/spec/jobs/regular/stream_post_helper_spec.rb
@@ -60,10 +60,18 @@ RSpec.describe Jobs::StreamPostHelper do
         explanation =
           "In this context, \"pie\" refers to a baked dessert typically consisting of a pastry crust and filling."
 
+        channel = "/my/channel"
         DiscourseAi::Completions::Llm.with_prepared_responses([explanation]) do
           messages =
-            MessageBus.track_publish("/discourse-ai/ai-helper/stream_suggestion/#{post.id}") do
-              job.execute(post_id: post.id, user_id: user.id, text: "pie", prompt: mode)
+            MessageBus.track_publish(channel) do
+              job.execute(
+                post_id: post.id,
+                user_id: user.id,
+                text: "pie",
+                prompt: mode,
+                progress_channel: channel,
+                client_id: "test_client_id",
+              )
             end
 
           partial_result_update = messages.first.data
@@ -76,10 +84,19 @@ RSpec.describe Jobs::StreamPostHelper do
         explanation =
           "In this context, \"pie\" refers to a baked dessert typically consisting of a pastry crust and filling."
 
+        channel = "/my/channel"
+
         DiscourseAi::Completions::Llm.with_prepared_responses([explanation]) do
           messages =
-            MessageBus.track_publish("/discourse-ai/ai-helper/stream_suggestion/#{post.id}") do
-              job.execute(post_id: post.id, user_id: user.id, text: "pie", prompt: mode)
+            MessageBus.track_publish(channel) do
+              job.execute(
+                post_id: post.id,
+                user_id: user.id,
+                text: "pie",
+                prompt: mode,
+                client_id: "test_client_id",
+                progress_channel: channel,
+              )
             end
 
           final_update = messages.last.data
@@ -96,10 +113,18 @@ RSpec.describe Jobs::StreamPostHelper do
         sentence = "I like to eat pie."
         translation = "Me gusta comer pastel."
 
+        channel = "/my/channel"
         DiscourseAi::Completions::Llm.with_prepared_responses([translation]) do
           messages =
-            MessageBus.track_publish("/discourse-ai/ai-helper/stream_suggestion/#{post.id}") do
-              job.execute(post_id: post.id, user_id: user.id, text: sentence, prompt: mode)
+            MessageBus.track_publish(channel) do
+              job.execute(
+                post_id: post.id,
+                user_id: user.id,
+                text: sentence,
+                prompt: mode,
+                progress_channel: channel,
+                client_id: "test_client_id",
+              )
             end
 
           partial_result_update = messages.first.data
@@ -111,11 +136,19 @@ RSpec.describe Jobs::StreamPostHelper do
       it "publishes a final update to signal we're done" do
         sentence = "I like to eat pie."
         translation = "Me gusta comer pastel."
+        channel = "/my/channel"
 
         DiscourseAi::Completions::Llm.with_prepared_responses([translation]) do
           messages =
-            MessageBus.track_publish("/discourse-ai/ai-helper/stream_suggestion/#{post.id}") do
-              job.execute(post_id: post.id, user_id: user.id, text: sentence, prompt: mode)
+            MessageBus.track_publish(channel) do
+              job.execute(
+                post_id: post.id,
+                user_id: user.id,
+                text: sentence,
+                prompt: mode,
+                progress_channel: channel,
+                client_id: "test_client_id",
+              )
             end
 
           final_update = messages.last.data

--- a/test/javascripts/acceptance/post-helper-menu-test.js
+++ b/test/javascripts/acceptance/post-helper-menu-test.js
@@ -48,6 +48,7 @@ acceptance("AI Helper - Post Helper Menu", function (needs) {
       return helper.response({
         result: "This is a suggestio",
         done: false,
+        progress_channel: "/some/progress/channel",
       });
     });
 
@@ -61,13 +62,10 @@ acceptance("AI Helper - Post Helper Menu", function (needs) {
     await selectText(textNode, 9);
     await click(".ai-post-helper__trigger");
     await click(".ai-helper-options__button[data-name='explain']");
-    await publishToMessageBus(
-      `/discourse-ai/ai-helper/stream_suggestion/118591`,
-      {
-        done: true,
-        result: suggestion,
-      }
-    );
+    await publishToMessageBus(`/some/progress/channel`, {
+      done: true,
+      result: suggestion,
+    });
     assert.dom(".ai-post-helper__suggestion__text").hasText(suggestion);
   });
 
@@ -91,13 +89,10 @@ acceptance("AI Helper - Post Helper Menu", function (needs) {
     await selectSpecificText(textNode, 72, 77);
     await click(".ai-post-helper__trigger");
     await click(".ai-helper-options__button[data-name='explain']");
-    await publishToMessageBus(
-      `/discourse-ai/ai-helper/stream_suggestion/118591`,
-      {
-        done: true,
-        result: suggestion,
-      }
-    );
+    await publishToMessageBus(`/some/progress/channel`, {
+      done: true,
+      result: suggestion,
+    });
 
     assert.dom(".ai-post-helper__suggestion__insert-footnote").isDisabled();
   });
@@ -108,13 +103,10 @@ acceptance("AI Helper - Post Helper Menu", function (needs) {
     await selectText(query("#post_1 .cooked p"));
     await click(".ai-post-helper__trigger");
     await click(".ai-helper-options__button[data-name='translate']");
-    await publishToMessageBus(
-      `/discourse-ai/ai-helper/stream_suggestion/118591`,
-      {
-        done: true,
-        result: translated,
-      }
-    );
+    await publishToMessageBus(`/some/progress/channel`, {
+      done: true,
+      result: translated,
+    });
     assert.dom(".ai-post-helper__suggestion__text").hasText(translated);
   });
 });


### PR DESCRIPTION
Previous to this change we reused channels for proofreading progress and
ai helper progress

The new changeset ensures each POST to stream progress gets a dedicated
message bus channel

This fixes a class of issues where the wrong information could be displayed
to end users on subsequent proofreading or helper calls

