### PR TITLE
FIX: correctly translate automation name

### DIFF
--- a/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
+++ b/assets/javascripts/discourse/components/ai-llms-list-editor.gjs
@@ -112,17 +112,9 @@ export default class AiLlmsListEditor extends Component {
   }
 
   localizeUsage(usage) {
-    if (usage.type === "ai_persona") {
-      return i18n("discourse_ai.llms.usage.ai_persona", {
-        persona: usage.name,
-      });
-    } else if (usage.type === "automation") {
-      return i18n("discourse_ai.llms.usage.automation", {
-        name: usage.name,
-      });
-    } else {
-      return i18n("discourse_ai.llms.usage." + usage.type);
-    }
+    return i18n(`discourse_ai.llms.usage.${usage.type}`, {
+      persona: usage.name,
+    });
   }
 
   <template>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -568,7 +568,7 @@ en:
           ai_summarization: "Summarize"
           ai_embeddings_semantic_search: "AI search"
           ai_spam: "Spam"
-          automation: "Automation (%{name})"
+          automation: "Automation (%{persona})"
         in_use_warning:
           one: "This model is currently used by %{settings}. If misconfigured, the feature won't work as expected."
           other: "This model is currently used by the following: %{settings}. If misconfigured, features won't work as expected. "


### PR DESCRIPTION
The key is `persona`, not `name`.

Before:
![Screenshot 2025-07-04 at 01 11 37](https://github.com/user-attachments/assets/ece3c24c-5dba-4870-9377-bdb21800518f)

After the fix:
![Screenshot 2025-07-04 at 01 10 21](https://github.com/user-attachments/assets/894fc693-2c9d-46cf-a003-f05e63c52201)
