### PR TITLE
FIX: Localize description excerpts as they have limits

### DIFF
--- a/lib/translation/category_localizer.rb
+++ b/lib/translation/category_localizer.rb
@@ -10,8 +10,8 @@ module DiscourseAi
 
         translated_name = ShortTextTranslator.new(text: category.name, target_locale:).translate
         translated_description =
-          if category.description.present?
-            PostRawTranslator.new(text: category.description, target_locale:).translate
+          if category.description_excerpt.present?
+            PostRawTranslator.new(text: category.description_excerpt, target_locale:).translate
           else
             ""
           end

--- a/spec/lib/translation/category_localizer_spec.rb
+++ b/spec/lib/translation/category_localizer_spec.rb
@@ -28,7 +28,7 @@ describe DiscourseAi::Translation::CategoryLocalizer do
   end
 
   fab!(:category) do
-    Fabricate(:category, name: "Test Category", description: "This is a test category")
+    Fabricate(:category, name: "Test Category", description: "This is a test category. " * 50)
   end
 
   describe ".localize" do
@@ -42,7 +42,7 @@ describe DiscourseAi::Translation::CategoryLocalizer do
       )
       post_raw_translator_stub(
         {
-          text: category.description,
+          text: category.description_excerpt,
           target_locale: target_locale,
           translated: translated_cat_desc,
         },
@@ -61,7 +61,7 @@ describe DiscourseAi::Translation::CategoryLocalizer do
         { text: category.name, target_locale:, translated: translated_cat_name },
       )
       post_raw_translator_stub(
-        { text: category.description, target_locale:, translated: translated_cat_desc },
+        { text: category.description_excerpt, target_locale:, translated: translated_cat_desc },
       )
 
       res = localizer.localize(category, target_locale)
@@ -86,7 +86,11 @@ describe DiscourseAi::Translation::CategoryLocalizer do
         { text: category.name, target_locale: "es", translated: translated_cat_name },
       )
       post_raw_translator_stub(
-        { text: category.description, target_locale: "es", translated: translated_cat_desc },
+        {
+          text: category.description_excerpt,
+          target_locale: "es",
+          translated: translated_cat_desc,
+        },
       )
 
       res = localizer.localize(category)


### PR DESCRIPTION
Category descriptions [don't have limits](https://github.com/discourse/discourse/blob/5200bff76574fd52c01216a746d071dfe7246945/app/models/category.rb#L1346), but [their excerpts do](https://github.com/discourse/discourse/blob/5200bff76574fd52c01216a746d071dfe7246945/app/models/category.rb#L657). Localize them instead as they're the ones shown in category boxes

<img width="1085" alt="Screenshot 2025-07-07 at 5 59 34 PM" src="https://github.com/user-attachments/assets/93b53a41-203c-4cf6-9699-620d4ba10c94" />