### PR TITLE
FEATURE: bring back hidden settings

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -65,7 +65,7 @@ en:
     ai_helper_enabled: "Enable the AI helper."
     composer_ai_helper_allowed_groups: "Users on these groups will see the AI helper button in the composer."
     ai_helper_allowed_in_pm: "Enable the composer's AI helper in PMs."
-    ai_helper_model: "Model to use for the AI helper."
+    ai_helper_model: "Default model for the AI helper. (specific personas can override this setting using default llm)"
     ai_helper_custom_prompts_allowed_groups: "Users on these groups will see the custom prompt option in the AI helper."
     ai_helper_automatic_chat_thread_title_delay: "Delay in minutes before the AI helper automatically sets the chat thread title."
     ai_helper_automatic_chat_thread_title: "Automatically set the chat thread titles based on thread contents."
@@ -87,7 +87,7 @@ en:
     ai_embeddings_per_post_enabled: Generate embeddings for each post
 
     ai_summarization_enabled: "Enable the summarize feature"
-    ai_summarization_model: "Model to use for summarization"
+    ai_summarization_model: "Default model to use for summarization features. (can be overridden by personas)"
     ai_summarization_persona: "Persona to use for summarize feature"
     ai_custom_summarization_allowed_groups: "Groups allowed to use create new summaries."
     ai_pm_summarization_allowed_groups: "Groups allowed to create and view summaries in PMs."
@@ -577,6 +577,7 @@ en:
           neutral: "Neutral"
 
     llm:
+      not_configured: "(not configured)"
       configuration:
         create_llm: "You need to setup an LLM before enabling this feature"
         disable_module_first: "You have to disable %{setting} first."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -108,7 +108,7 @@ discourse_ai:
     allow_any: false
     type: enum
     enum: "DiscourseAi::Configuration::LlmEnumerator"
-    hidden: true
+    area: "ai-features/ai_helper"
   ai_helper_custom_prompts_allowed_groups: # Deprecated. TODO(roman): Remove 2025-09-01
     type: group_list
     list_type: compact
@@ -322,7 +322,7 @@ discourse_ai:
     type: enum
     enum: "DiscourseAi::Configuration::LlmEnumerator"
     validator: "DiscourseAi::Configuration::LlmValidator"
-    hidden: true
+    area: "ai-features/summarization"
   ai_summarization_persona:
     default: "-11"
     type: enum

--- a/lib/configuration/llm_enumerator.rb
+++ b/lib/configuration/llm_enumerator.rb
@@ -108,6 +108,7 @@ module DiscourseAi
         end
 
         values.each { |value_h| value_h[:value] = "custom:#{value_h[:value]}" }
+        values.unshift({ value: "", name: I18n.t("discourse_ai.llm.not_configured") })
         values
       end
     end


### PR DESCRIPTION
The hidden settings have general use and may be already set.

Helper one is particularly important cause it sets a default for a large
number of settings

Additionally hiding access means people can not remove LLMs without console
access

