### PR TITLE
DEV: Improve AI bot conversation submit upload handling

### DIFF
--- a/assets/javascripts/discourse/components/ai-bot-conversations.gjs
+++ b/assets/javascripts/discourse/components/ai-bot-conversations.gjs
@@ -260,10 +260,11 @@ export default class AiBotConversations extends Component {
 
   @action
   async prepareAndSubmitToBot() {
-    // Pass uploads to the service before submitting
-    this.aiBotConversationsHiddenSubmit.uploads = this.uploads;
     try {
-      await this.aiBotConversationsHiddenSubmit.submitToBot();
+      await this.aiBotConversationsHiddenSubmit.submitToBot({
+        uploads: this.uploads,
+        inProgressUploadsCount: this.inProgressUploads.length,
+      });
       this.uploads = new TrackedArray();
     } catch (error) {
       popupAjaxError(error);

--- a/assets/javascripts/discourse/services/ai-bot-conversations-hidden-submit.js
+++ b/assets/javascripts/discourse/services/ai-bot-conversations-hidden-submit.js
@@ -18,7 +18,6 @@ export default class AiBotConversationsHiddenSubmit extends Service {
 
   personaId;
   targetUsername;
-  uploads = [];
 
   inputValue = "";
 
@@ -32,7 +31,7 @@ export default class AiBotConversationsHiddenSubmit extends Service {
   }
 
   @action
-  async submitToBot() {
+  async submitToBot(uploadData) {
     if (
       this.inputValue.length <
       this.siteSettings.min_personal_message_post_length
@@ -48,7 +47,7 @@ export default class AiBotConversationsHiddenSubmit extends Service {
     }
 
     // Don't submit if there are still uploads in progress
-    if (document.querySelector(".ai-bot-upload--in-progress")) {
+    if (uploadData.inProgressUploadsCount > 0) {
       return this.dialog.alert({
         message: i18n("discourse_ai.ai_bot.conversations.uploads_in_progress"),
       });
@@ -61,10 +60,10 @@ export default class AiBotConversationsHiddenSubmit extends Service {
     let rawContent = this.inputValue;
 
     // Append upload markdown if we have uploads
-    if (this.uploads && this.uploads.length > 0) {
+    if (uploadData.uploads && uploadData.uploads.length > 0) {
       rawContent += "\n\n";
 
-      this.uploads.forEach((upload) => {
+      uploadData.uploads.forEach((upload) => {
         const uploadMarkdown = getUploadMarkdown(upload);
         rawContent += uploadMarkdown + "\n";
       });
@@ -83,7 +82,6 @@ export default class AiBotConversationsHiddenSubmit extends Service {
       });
 
       // Reset uploads after successful submission
-      this.uploads = [];
       this.inputValue = "";
 
       this.appEvents.trigger("discourse-ai:bot-pm-created", {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -872,6 +872,7 @@ en:
           last_7_days: "Last 7 days"
           last_30_days: "Last 30 days"
           upload_files: "Upload files"
+          uploads_in_progress: "Cannot submit while uploads are in progress"
       sentiments:
         dashboard:
           title: "Sentiment"


### PR DESCRIPTION
Try fix a flaky spec in /ai_bot/homepage_spec.rb by using ember
data rather than inspecting the DOM directly to see if there
are any in-progress uploads.

Also add missing translation for in progress uploads warning,
and spec for this behaviour.
