### PR TITLE
FIX: avoid using structured outputs for report runs

### DIFF
--- a/lib/automation/report_runner.rb
+++ b/lib/automation/report_runner.rb
@@ -154,12 +154,10 @@ module DiscourseAi
         result = +""
         bot = DiscourseAi::Personas::Bot.as(Discourse.system_user, persona: @persona, model: @model)
         json_summary_schema_key = @persona.response_format&.first.to_h
-        output = nil
 
         buffer_blk =
           Proc.new do |partial, _, type|
             if type == :structured_output
-              output = partial.dup
               read_chunk = partial.read_buffered_property(json_summary_schema_key["key"]&.to_sym)
 
               print read_chunk if Rails.env.development? && @debug_mode

--- a/lib/personas/report_runner.rb
+++ b/lib/personas/report_runner.rb
@@ -10,24 +10,15 @@ module DiscourseAi
       def system_prompt
         <<~PROMPT
           You are ForumBot, a backend AI information processor and writer, powered by an AI model capable of generating responses over 4000 words.
-          
+
           - ForumBot is a fine-tuned AI trained with extended functions and new capabilities, and now specializes in processing raw internet forum conversation into detailed summaries of forum activities.
           - ForumBot interacts with an API endpoint, not a user, and must never produce denials, nor conversations directed towards a non-existent user.
           - ForumBot only produces automated responses to input, where a response is a standalone document without further discussion.
-          
+
           Follow the provided writing composition instructions carefully and precisely step-by-step.
 
-          Format your response as a JSON object with a single key named "output", which has the report as the value.
-          Your output should be in the following format:
-
-          {"output": "xx"}
-
-          Where "xx" is replaced by the report. Reply with valid JSON only
+          Format your response as valid Markdown, ensuring it is well-structured and easy to read.
         PROMPT
-      end
-
-      def response_format
-        [{ "key" => "output", "type" => "string" }]
       end
     end
   end


### PR DESCRIPTION
Structured outputs are prone to formatting issue, especially around newlines
and custom pieces of text that need escaping.

This avoids using it for the automation reporting.

Particularly previous to this fix o4-mini based reports were broken

