### PR TITLE
FIX: prevent crash in "all" filter on features page

### DIFF
--- a/assets/javascripts/discourse/components/ai-features-list.gjs
+++ b/assets/javascripts/discourse/components/ai-features-list.gjs
@@ -66,9 +66,9 @@ class ExpandableList extends Component {
 
 export default class AiFeaturesList extends Component {
   get sortedModules() {
-    const modules = this.args.modules?.toArray?.() || this.args.modules;
+    const modules = this.args.modules?.toArray() || this.args.modules;
     return [...(modules || [])].toSorted((a, b) =>
-      (a?.module_name || "").localeCompare(b?.module_name || "")
+      (a.module_name || "").localeCompare(b.module_name || "")
     );
   }
 

--- a/assets/javascripts/discourse/components/ai-features-list.gjs
+++ b/assets/javascripts/discourse/components/ai-features-list.gjs
@@ -66,12 +66,9 @@ class ExpandableList extends Component {
 
 export default class AiFeaturesList extends Component {
   get sortedModules() {
-    if (!this.args.modules || !this.args.modules.length) {
-      return [];
-    }
-
-    return this.args.modules.toSorted((a, b) =>
-      a.module_name.localeCompare(b.module_name)
+    const modules = this.args.modules?.toArray?.() || this.args.modules;
+    return [...(modules || [])].toSorted((a, b) =>
+      (a?.module_name || "").localeCompare(b?.module_name || "")
     );
   }
 


### PR DESCRIPTION
Need to make sure modules is always an array to use toSorted, the "all" filter was throwing an error otherwise 

<img width="1512" height="344" alt="image" src="https://github.com/user-attachments/assets/0ffbba2c-af62-4b49-b2fb-741591b61317" />
