### PR TITLE
DEV: Set a min and max for translations backfill

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -527,6 +527,8 @@ discourse_ai:
     area: "ai-features/translation"
   ai_translation_backfill_max_age_days:
     default: 5
+    min: 0
+    max: 20000
     client: false
     area: "ai-features/translation"
   ai_translation_verbose_logs:

--- a/db/migrate/20250717075002_set_translation_backfill_max_age.rb
+++ b/db/migrate/20250717075002_set_translation_backfill_max_age.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class SetTranslationBackfillMaxAge < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      UPDATE site_settings
+      SET value = '20000'
+      WHERE name = 'ai_translation_backfill_max_age_days'
+      AND value::integer > 20000;
+    SQL
+
+    execute <<~SQL
+      UPDATE site_settings
+      SET value = '0'
+      WHERE name = 'ai_translation_backfill_max_age_days'
+      AND value::integer < 0;
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Since we use the value for `days.ago` and are seeing `PG::DatetimeFieldOverflow: ERROR:  timestamp out of range: "5473790-07-13 08:43:28.497823 BC`, set limits to the site setting.