### PR TITLE
PERF: Create index `ON ai_topics_embeddings(topic_id, model_id)`

### DIFF
--- a/db/migrate/20250722082515_add_index_to_ai_topics_embeddings.rb
+++ b/db/migrate/20250722082515_add_index_to_ai_topics_embeddings.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddIndexToAiTopicsEmbeddings < ActiveRecord::Migration[7.2]
+  def up
+    add_index :ai_topics_embeddings, %i[topic_id model_id]
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This index helps to speed up queries that joins the `topics` table
against the `ai_topics_embeddings` table on the `topic_id` column. There
are a number of queries which filters on `ai_topics_embeddings.model_id`
so we are including that in the index as well.
